### PR TITLE
Whirlpool particles + bottom-right controls

### DIFF
--- a/components/audio/microphone-input.tsx
+++ b/components/audio/microphone-input.tsx
@@ -84,14 +84,14 @@ export function MicrophoneInput() {
         onClick={() => void (isMicActive ? stopMicrophone() : startMicrophone())}
         title={error ?? "toggle live microphone"}
         aria-label={isMicActive ? "stop live microphone" : "start live microphone"}
-        className={`absolute right-4 top-4 z-40 grid h-11 w-11 place-items-center rounded-full border backdrop-blur-md transition md:right-6 md:top-6 ${
+        className={`absolute bottom-20 right-16 z-40 grid h-8 w-8 place-items-center rounded-full border backdrop-blur-md transition md:bottom-20 md:right-20 ${
           isMicActive
             ? "border-[#7f0f1b] bg-[#2a0408]/90 shadow-[0_0_24px_rgba(90,0,10,0.45)]"
             : "border-amber-200/40 bg-[#24120c]/70 hover:border-amber-200/70"
         } ${error ? "border-amber-400/70" : ""}`}
       >
         <span
-          className={`h-3.5 w-3.5 rounded-full transition ${
+          className={`h-2.5 w-2.5 rounded-full transition ${
             isMicActive
               ? "bg-[#b10016] shadow-[0_0_12px_rgba(177,0,22,0.9)]"
               : "bg-amber-200/80"

--- a/components/hero/ascii-video-overlay.tsx
+++ b/components/hero/ascii-video-overlay.tsx
@@ -252,7 +252,7 @@ export function AsciiVideoOverlay() {
         onClick={() => void (isActive ? stopCapture() : startCapture())}
         title={isActive ? "stop video capture" : "grab video"}
         aria-label={isActive ? "stop video capture" : "grab video capture"}
-        className={`absolute right-20 top-4 z-40 grid h-11 w-11 place-items-center rounded-full border backdrop-blur-md transition md:right-24 md:top-6 ${
+        className={`absolute bottom-20 right-6 z-40 grid h-8 w-8 place-items-center rounded-full border backdrop-blur-md transition md:bottom-20 md:right-10 ${
           isActive
             ? "border-[#7f0f1b] bg-[#2a0408]/90 text-amber-100 shadow-[0_0_24px_rgba(90,0,10,0.45)]"
             : "border-amber-200/40 bg-[#24120c]/70 text-amber-100/90 hover:border-amber-200/70"
@@ -260,7 +260,7 @@ export function AsciiVideoOverlay() {
       >
         <svg
           viewBox="0 0 24 24"
-          className="h-5 w-5"
+          className="h-3.5 w-3.5"
           fill="none"
           stroke="currentColor"
           strokeWidth="1.8"
@@ -280,7 +280,7 @@ export function AsciiVideoOverlay() {
       </button>
 
       {error ? (
-        <div className="pointer-events-none absolute right-20 top-13 z-40 font-mono text-[10px] text-amber-300 md:right-24 md:top-15">
+        <div className="pointer-events-none absolute bottom-16 right-6 z-40 font-mono text-[10px] text-amber-300 md:right-10">
           {error}
         </div>
       ) : null}

--- a/components/hero/fractal-zoom-canvas.tsx
+++ b/components/hero/fractal-zoom-canvas.tsx
@@ -16,108 +16,22 @@ const VERTEX_SHADER = `
 
 const FRAGMENT_SHADER = `
   precision highp float;
-
-  uniform float uTime;
   uniform vec2 uResolution;
-  uniform float uAudio;
-  uniform float uBass;
-  uniform float uMid;
-  uniform float uHigh;
-  uniform float uOnset;
-
   varying vec2 vUv;
 
   void main() {
-    vec2 uv = (gl_FragCoord.xy - uResolution * 0.5) / min(uResolution.x, uResolution.y);
-
-    // continuous zoom into the Mandelbrot set
-    // target: a deep spiral near the boundary (Misiurewicz point)
-    vec2 target = vec2(-0.7435669, 0.1314023);
-
-    float zoomSpeed = 0.18 + uBass * 0.08;
-    float zoomPow = 2.0 + uTime * zoomSpeed;
-    float scale = pow(1.5, zoomPow);
-
-    // mid drives subtle rotation
-    float angle = uTime * 0.03 + uMid * 0.15;
-    float ca = cos(angle), sa = sin(angle);
-    uv = mat2(ca, -sa, sa, ca) * uv;
-
-    vec2 c = target + uv / scale;
-
-    // iterate
-    vec2 z = vec2(0.0);
-    float iter = 0.0;
-    const float MAX_ITER = 256.0;
-
-    for (float i = 0.0; i < MAX_ITER; i++) {
-      z = vec2(z.x * z.x - z.y * z.y, 2.0 * z.x * z.y) + c;
-      if (dot(z, z) > 4.0) break;
-      iter = i;
-    }
-
-    // smooth iteration count
-    float sl = iter - log2(log2(dot(z, z))) + 4.0;
-    float t = sl / MAX_ITER;
-
-    // inside the set = dark
-    if (dot(z, z) <= 4.0) {
-      // deep inside — dark with subtle audio glow
-      vec3 inner = vec3(0.04, 0.03, 0.02) + vec3(0.08, 0.04, 0.02) * uAudio;
-      inner += vec3(1.0, 0.9, 0.7) * uOnset * 0.15;
-      float vig = 1.0 - dot(vUv - 0.5, vUv - 0.5) * 1.2;
-      gl_FragColor = vec4(inner * vig, 1.0);
-      return;
-    }
-
-    // color palette — warm embers
-    vec3 warmA = vec3(0.54, 0.17, 0.06);
-    vec3 warmB = vec3(0.88, 0.40, 0.12);
-    vec3 warmC = vec3(1.0, 0.79, 0.36);
-    vec3 coolTip = vec3(0.7, 0.85, 1.0);
-    vec3 deep = vec3(0.12, 0.06, 0.03);
-
-    // base color from iteration count
-    float wave = 0.5 + 0.5 * sin(t * 12.0 + uTime * 0.3);
-    float wave2 = 0.5 + 0.5 * sin(t * 7.0 - uTime * 0.2 + 2.0);
-    vec3 color = mix(deep, warmA, smoothstep(0.0, 0.15, t));
-    color = mix(color, warmB, smoothstep(0.1, 0.4, t) * wave);
-    color = mix(color, warmC, smoothstep(0.3, 0.7, t) * wave2);
-
-    // audio influence
-    float audioMix = clamp(uAudio * 2.0, 0.0, 1.0);
-    color = mix(color, color * 1.4, audioMix * 0.3);
-
-    // highs add cool shimmer at edges
-    color = mix(color, coolTip, uHigh * smoothstep(0.5, 0.9, t) * 0.3);
-
-    // bass deepens contrast
-    color *= 1.0 - uBass * 0.15 * (1.0 - t);
-
-    // onset flash
-    color = mix(color, vec3(1.0, 0.95, 0.85), uOnset * 0.3 * smoothstep(0.1, 0.5, t));
-
-    // vignette
-    float vig = 1.0 - dot(vUv - 0.5, vUv - 0.5) * 1.2;
-    color *= vig;
-
-    gl_FragColor = vec4(color, 1.0);
+    gl_FragColor = vec4(vec3(0.0), 1.0);
   }
 `;
 
 export default function FractalZoomCanvas() {
   const mountRef = useRef<HTMLDivElement>(null);
-  const energyRef = useRef(0);
   const bandsRef = useRef<AudioBands>({ bass: 0, mid: 0, high: 0, onset: 0 });
-  const { energy, bands } = useAudioReactive();
+  const isPlayingRef = useRef(false);
+  const { bands, isPlaying } = useAudioReactive();
 
-  useEffect(() => {
-    energyRef.current = energy;
-  }, [energy]);
-
-  useEffect(() => {
-    bandsRef.current = bands;
-  }, [bands]);
+  useEffect(() => { bandsRef.current = bands; }, [bands]);
+  useEffect(() => { isPlayingRef.current = isPlaying; }, [isPlaying]);
 
   useEffect(() => {
     if (!mountRef.current) return;
@@ -128,12 +42,6 @@ export default function FractalZoomCanvas() {
 
     let rafId = 0;
     let active = true;
-    let smoothedAudio = 0;
-    let smoothedBass = 0;
-    let smoothedMid = 0;
-    let smoothedHigh = 0;
-    let smoothedOnset = 0;
-    const clock = new THREE.Clock();
 
     const renderer = new THREE.WebGLRenderer({
       antialias: false,
@@ -146,13 +54,7 @@ export default function FractalZoomCanvas() {
     container.appendChild(renderer.domElement);
 
     const uniforms = {
-      uTime: { value: 0 },
-      uResolution: { value: new THREE.Vector2(container.clientWidth, container.clientHeight) },
-      uAudio: { value: 0 },
-      uBass: { value: 0 },
-      uMid: { value: 0 },
-      uHigh: { value: 0 },
-      uOnset: { value: 0 },
+      uResolution: { value: new THREE.Vector2() },
     };
 
     const material = new THREE.ShaderMaterial({
@@ -166,35 +68,6 @@ export default function FractalZoomCanvas() {
 
     const render = () => {
       if (!active) return;
-
-      const t = clock.getElapsedTime();
-      const b = bandsRef.current;
-
-      const bandAttack = 0.3;
-      const bandRelease = 0.92;
-      smoothedAudio = energyRef.current > smoothedAudio
-        ? smoothedAudio * bandAttack + energyRef.current * (1 - bandAttack)
-        : smoothedAudio * bandRelease + energyRef.current * (1 - bandRelease);
-      smoothedBass = b.bass > smoothedBass
-        ? smoothedBass * bandAttack + b.bass * (1 - bandAttack)
-        : smoothedBass * bandRelease + b.bass * (1 - bandRelease);
-      smoothedMid = b.mid > smoothedMid
-        ? smoothedMid * bandAttack + b.mid * (1 - bandAttack)
-        : smoothedMid * bandRelease + b.mid * (1 - bandRelease);
-      smoothedHigh = b.high > smoothedHigh
-        ? smoothedHigh * bandAttack + b.high * (1 - bandAttack)
-        : smoothedHigh * bandRelease + b.high * (1 - bandRelease);
-      smoothedOnset = b.onset > smoothedOnset
-        ? b.onset
-        : smoothedOnset * 0.85;
-
-      uniforms.uTime.value = t;
-      uniforms.uAudio.value = Math.min(0.35, smoothedAudio);
-      uniforms.uBass.value = smoothedBass;
-      uniforms.uMid.value = smoothedMid;
-      uniforms.uHigh.value = smoothedHigh;
-      uniforms.uOnset.value = smoothedOnset;
-
       renderer.render(scene, camera);
       rafId = window.requestAnimationFrame(render);
     };
@@ -203,15 +76,14 @@ export default function FractalZoomCanvas() {
       if (!container) return;
       const w = container.clientWidth;
       const h = container.clientHeight;
-      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      const dpr = Math.min(window.devicePixelRatio, 2);
+      renderer.setPixelRatio(dpr);
       renderer.setSize(w, h);
-      uniforms.uResolution.value.set(w * Math.min(window.devicePixelRatio, 2), h * Math.min(window.devicePixelRatio, 2));
+      uniforms.uResolution.value.set(w * dpr, h * dpr);
     };
 
     window.addEventListener("resize", handleResize);
-    // set initial resolution accounting for pixel ratio
     handleResize();
-
     render();
 
     return () => {

--- a/components/hero/hero-canvas.tsx
+++ b/components/hero/hero-canvas.tsx
@@ -34,28 +34,35 @@ const VERTEX_SHADER = `
     vec3 p = position;
     float audioNorm = clamp(uAudio / 1.8, 0.0, 1.0);
 
-    // bass pushes particles outward radially
-    float bassExpand = 1.0 + uBass * 0.12;
+    // whirlpool: convert to polar, rotate based on distance from center
+    float radius = length(p.xy);
+    float angle = atan(p.y, p.x);
 
-    // kick/onset punches z-depth
+    // spiral rotation — inner particles spin faster than outer
+    float spinSpeed = 0.6 + uBass * 0.3;
+    float spiralTwist = spinSpeed / (radius + 0.3);
+    angle += uTime * spiralTwist;
+
+    // radial breathing — particles drift in/out
+    float drift = sin(uTime * 0.4 + aSeed * 6.2831 + radius * 2.0) * 0.15;
+    radius += drift;
+
+    // bass pulls particles inward (tightens the whirlpool)
+    radius *= 1.0 - uBass * 0.08;
+
+    // convert back to cartesian
+    p.x = cos(angle) * radius;
+    p.y = sin(angle) * radius;
+
+    // z-axis: wave motion + onset punch
+    float wave = sin(radius * 5.0 - uTime * 1.2 + aSeed * 6.2831) * 0.2;
     float onsetPunch = uOnset * sin(aSeed * 12.566) * 0.07;
-
-    // high frequencies add shimmer/jitter
     float highJitter = uHigh * (fract(sin(aSeed * 43758.5453 + uTime * 3.0) * 43758.5453) - 0.5) * 0.06;
-
-    float wave = sin((p.x * 1.8) + (p.y * 1.4) + uTime * 0.7 + aSeed * 6.2831) * 0.24;
-    float ring = sin(length(p.xy) * 5.0 - uTime * 1.2 + aSeed * 2.0) * 0.18;
-    p.z += wave + ring * (0.6 + (uAudio * 0.2)) + (uWasmMod * 0.45) + onsetPunch + highJitter;
-    p.xy *= mix(1.0, 1.2, audioNorm) * bassExpand;
-
-    // mid-range drives rotation offset per particle
-    float midSwirl = uMid * sin(length(p.xy) * 3.0 + uTime * 1.5) * 0.03;
-    p.x += midSwirl;
+    p.z += wave + onsetPunch + highJitter + (uWasmMod * 0.3);
 
     vec4 mvPosition = modelViewMatrix * vec4(p, 1.0);
     gl_Position = projectionMatrix * mvPosition;
 
-    // onset makes particles momentarily larger
     float onsetSize = 1.0 + uOnset * 0.25;
     gl_PointSize = (1.2 + (uAudio * 0.4)) * onsetSize * (150.0 / max(30.0, -mvPosition.z));
 
@@ -287,9 +294,8 @@ export default function HeroCanvas() {
         uniforms.uWasmMod.value = Math.max(-1, Math.min(1, wasmSample));
       }
 
-      // bass pulses rotation speed
-      points.rotation.z = t * (0.07 + smoothedBass * 0.08);
-      points.rotation.x = Math.sin(t * 0.22) * (0.14 + smoothedMid * 0.1);
+      // slight tilt for depth — whirlpool handles spin in shader
+      points.rotation.x = Math.sin(t * 0.15) * 0.1;
 
       const flowDetail: ParticleFlowDetail = {
         spread: Math.min(1, uniforms.uAudio.value / 1.8),

--- a/components/hero/hero-sketch-carousel.tsx
+++ b/components/hero/hero-sketch-carousel.tsx
@@ -2,22 +2,19 @@
 
 import dynamic from "next/dynamic";
 
-const FractalZoomSketch = dynamic(
-  () => import("@/components/hero/fractal-zoom-canvas"),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="absolute inset-0 flex items-center justify-center text-xs text-zinc-500">
-        loading sketch...
-      </div>
-    ),
-  },
-);
+const ParticleSketch = dynamic(() => import("@/components/hero/hero-canvas"), {
+  ssr: false,
+  loading: () => (
+    <div className="absolute inset-0 flex items-center justify-center text-xs text-zinc-500">
+      loading sketch...
+    </div>
+  ),
+});
 
 export function HeroSketchCarousel() {
   return (
     <div className="absolute inset-0">
-      <FractalZoomSketch />
+      <ParticleSketch />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Switch hero back to particle sketch with whirlpool spiral motion (inner spins faster than outer)
- Bass tightens the vortex, onset punches z-depth, highs add shimmer
- Move video and mic buttons to bottom-right, sized to match play button (h-8)
- Fractal zoom canvas gutted (black shell preserved)

## Test plan
- [ ] Verify whirlpool particle motion on homepage
- [ ] Play audio — confirm bass tightens spiral
- [ ] Check video/mic buttons in bottom-right corner
- [ ] Mobile responsiveness

🤖 Generated with [Claude Code](https://claude.com/claude-code)