### PR TITLE
Add VoiceJournal Obsidian plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# git worktrees
+.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ next-env.d.ts
 
 # git worktrees
 .worktrees/
+
+# Obsidian vault (private journal + config)
+content/journal/
+content/.obsidian/

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "wasm:build": "cargo build --manifest-path rust/garden_math/Cargo.toml --target wasm32-unknown-unknown --release && cp rust/garden_math/target/wasm32-unknown-unknown/release/garden_math.wasm public/wasm/garden_math.wasm",
-    "plugin:dev": "cd plugins/obsidian-voicejournal && npm run dev",
-    "plugin:build": "cd plugins/obsidian-voicejournal && npm run build"
+    "plugin:dev": "npm run dev --prefix plugins/obsidian-voicejournal",
+    "plugin:build": "npm run build --prefix plugins/obsidian-voicejournal"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "wasm:build": "cargo build --manifest-path rust/garden_math/Cargo.toml --target wasm32-unknown-unknown --release && cp rust/garden_math/target/wasm32-unknown-unknown/release/garden_math.wasm public/wasm/garden_math.wasm"
+    "wasm:build": "cargo build --manifest-path rust/garden_math/Cargo.toml --target wasm32-unknown-unknown --release && cp rust/garden_math/target/wasm32-unknown-unknown/release/garden_math.wasm public/wasm/garden_math.wasm",
+    "plugin:dev": "cd plugins/obsidian-voicejournal && npm run dev",
+    "plugin:build": "cd plugins/obsidian-voicejournal && npm run build"
   },
   "dependencies": {
     "next": "16.1.6",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "lint": "eslint",
     "wasm:build": "cargo build --manifest-path rust/garden_math/Cargo.toml --target wasm32-unknown-unknown --release && cp rust/garden_math/target/wasm32-unknown-unknown/release/garden_math.wasm public/wasm/garden_math.wasm",
+    "plugin:init": "bash plugins/obsidian-voicejournal/scripts/init.sh",
+    "plugin:run": "bash plugins/obsidian-voicejournal/scripts/run.sh",
     "plugin:dev": "npm run dev --prefix plugins/obsidian-voicejournal",
     "plugin:build": "npm run build --prefix plugins/obsidian-voicejournal"
   },

--- a/plugins/obsidian-voicejournal/.gitignore
+++ b/plugins/obsidian-voicejournal/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/plugins/obsidian-voicejournal/.gitignore
+++ b/plugins/obsidian-voicejournal/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.venv/

--- a/plugins/obsidian-voicejournal/esbuild.config.mjs
+++ b/plugins/obsidian-voicejournal/esbuild.config.mjs
@@ -1,0 +1,49 @@
+import esbuild from "esbuild";
+import process from "process";
+import builtins from "builtin-modules";
+import { mkdirSync, copyFileSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const outDir = join(__dirname, "../../content/.obsidian/plugins/voice-journal");
+
+// Ensure output directory exists and copy manifest
+mkdirSync(outDir, { recursive: true });
+copyFileSync(join(__dirname, "manifest.json"), join(outDir, "manifest.json"));
+
+const prod = process.argv[2] === "production";
+
+const context = await esbuild.context({
+  entryPoints: ["src/main.ts"],
+  bundle: true,
+  external: [
+    "obsidian",
+    "electron",
+    "@codemirror/autocomplete",
+    "@codemirror/collab",
+    "@codemirror/commands",
+    "@codemirror/language",
+    "@codemirror/lint",
+    "@codemirror/search",
+    "@codemirror/state",
+    "@codemirror/view",
+    "@lezer/common",
+    "@lezer/highlight",
+    "@lezer/lr",
+    ...builtins,
+  ],
+  format: "cjs",
+  target: "es2018",
+  logLevel: "info",
+  sourcemap: prod ? false : "inline",
+  treeShaking: true,
+  outfile: join(outDir, "main.js"),
+});
+
+if (prod) {
+  await context.rebuild();
+  process.exit(0);
+} else {
+  await context.watch();
+}

--- a/plugins/obsidian-voicejournal/esbuild.config.mjs
+++ b/plugins/obsidian-voicejournal/esbuild.config.mjs
@@ -1,12 +1,41 @@
 import esbuild from "esbuild";
 import process from "process";
 import builtins from "builtin-modules";
-import { mkdirSync, copyFileSync } from "fs";
-import { join, dirname } from "path";
+import { mkdirSync, copyFileSync, readFileSync, existsSync, statSync } from "fs";
+import { join, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const outDir = join(__dirname, "../../content/.obsidian/plugins/voice-journal");
+
+/**
+ * Find the actual git repo root using only Node.js fs — works in both the main
+ * checkout and a detached worktree (where .git is a file, not a directory).
+ */
+function findRepoRoot(startDir) {
+  let dir = startDir;
+  while (true) {
+    const gitPath = join(dir, ".git");
+    if (existsSync(gitPath)) {
+      if (statSync(gitPath).isDirectory()) {
+        return dir; // main checkout
+      }
+      // Worktree: .git is a file containing "gitdir: /main/.git/worktrees/name"
+      const content = readFileSync(gitPath, "utf8").trim();
+      const match = content.match(/^gitdir:\s*(.+)$/);
+      if (match) {
+        // Resolve relative gitdir path, then go up 3 levels: worktrees/name -> .git -> repo
+        return resolve(dir, match[1], "../../..");
+      }
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return startDir; // reached filesystem root
+    dir = parent;
+  }
+}
+
+const repoRoot = findRepoRoot(__dirname);
+const outDir = join(repoRoot, "content/.obsidian/plugins/voice-journal");
 
 // Ensure output directory exists and copy manifest
 mkdirSync(outDir, { recursive: true });

--- a/plugins/obsidian-voicejournal/esbuild.config.mjs
+++ b/plugins/obsidian-voicejournal/esbuild.config.mjs
@@ -43,6 +43,7 @@ const context = await esbuild.context({
 
 if (prod) {
   await context.rebuild();
+  await context.dispose();
   process.exit(0);
 } else {
   await context.watch();

--- a/plugins/obsidian-voicejournal/manifest.json
+++ b/plugins/obsidian-voicejournal/manifest.json
@@ -5,5 +5,5 @@
   "minAppVersion": "1.4.0",
   "description": "Voice journaling with Whisper transcription, Claude follow-up questions, and weekly digests.",
   "author": "Sam",
-  "isDesktopOnly": false
+  "isDesktopOnly": true
 }

--- a/plugins/obsidian-voicejournal/manifest.json
+++ b/plugins/obsidian-voicejournal/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id": "voice-journal",
+  "name": "VoiceJournal",
+  "version": "1.0.0",
+  "minAppVersion": "1.4.0",
+  "description": "Voice journaling with Whisper transcription, Claude follow-up questions, and weekly digests.",
+  "author": "Sam",
+  "isDesktopOnly": false
+}

--- a/plugins/obsidian-voicejournal/package-lock.json
+++ b/plugins/obsidian-voicejournal/package-lock.json
@@ -1,0 +1,610 @@
+{
+  "name": "obsidian-voice-journal",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obsidian-voice-journal",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "builtin-modules": "^3.3.0",
+        "esbuild": "^0.20.0",
+        "obsidian": "^1.4.0",
+        "tslib": "^2.6.0",
+        "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+      "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+      "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+      "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+      "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+      "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+      "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+      "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+      "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+      "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+      "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+      "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+      "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+      "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+      "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+      "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+      "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+      "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+      "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+      "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+      "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+      "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+      "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
+      "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
+      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/obsidian": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
+      "integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/plugins/obsidian-voicejournal/package.json
+++ b/plugins/obsidian-voicejournal/package.json
@@ -12,6 +12,7 @@
     "builtin-modules": "^3.3.0",
     "esbuild": "^0.20.0",
     "obsidian": "^1.4.0",
+    "tslib": "^2.6.0",
     "typescript": "^5.3.3"
   }
 }

--- a/plugins/obsidian-voicejournal/package.json
+++ b/plugins/obsidian-voicejournal/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "obsidian-voice-journal",
+  "version": "1.0.0",
+  "description": "Voice journaling plugin for Obsidian",
+  "main": "main.js",
+  "scripts": {
+    "dev": "node esbuild.config.mjs",
+    "build": "node esbuild.config.mjs production"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "builtin-modules": "^3.3.0",
+    "esbuild": "^0.20.0",
+    "obsidian": "^1.4.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/plugins/obsidian-voicejournal/scripts/init.sh
+++ b/plugins/obsidian-voicejournal/scripts/init.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# VoiceJournal one-time setup
+# Run once after cloning the repo: npm run plugin:init
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$PLUGIN_DIR/../.." && pwd)"
+VENV_DIR="$PLUGIN_DIR/.venv"
+
+# ── colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; CYAN='\033[0;36m'; RESET='\033[0m'
+ok()   { echo -e "${GREEN}✓${RESET} $*"; }
+info() { echo -e "${CYAN}→${RESET} $*"; }
+fail() { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+echo ""
+echo "=== VoiceJournal Setup ==="
+echo ""
+
+# ── 1. claude CLI ─────────────────────────────────────────────────────────────
+if ! command -v claude &>/dev/null; then
+  fail "'claude' not found. Install Claude Code: https://claude.ai/code"
+fi
+ok "claude ($(claude --version 2>&1 | head -1))"
+
+# ── 2. Python 3.10+ ───────────────────────────────────────────────────────────
+PYTHON=""
+for cmd in python3.12 python3.11 python3.10 python3 python; do
+  if command -v "$cmd" &>/dev/null \
+     && "$cmd" -c "import sys; exit(0 if sys.version_info >= (3,10) else 1)" 2>/dev/null; then
+    PYTHON="$cmd"
+    break
+  fi
+done
+[ -n "$PYTHON" ] || fail "Python 3.10+ required. Install from https://python.org"
+ok "$($PYTHON --version)"
+
+# ── 3. Python venv ────────────────────────────────────────────────────────────
+if [ ! -d "$VENV_DIR" ]; then
+  info "Creating Python venv at plugins/obsidian-voicejournal/.venv ..."
+  "$PYTHON" -m venv "$VENV_DIR"
+fi
+ok "venv ready"
+
+# ── 4. faster-whisper-server ──────────────────────────────────────────────────
+info "Installing faster-whisper-server (may take a minute on first run)..."
+"$VENV_DIR/bin/pip" install --quiet --upgrade pip
+"$VENV_DIR/bin/pip" install --quiet --upgrade faster-whisper-server
+ok "faster-whisper-server installed"
+
+# ── 5. npm deps ───────────────────────────────────────────────────────────────
+info "Installing npm dependencies..."
+npm install --prefix "$PLUGIN_DIR" --silent
+ok "npm deps installed"
+
+# ── 6. first build ────────────────────────────────────────────────────────────
+info "Building plugin..."
+npm run build --prefix "$PLUGIN_DIR"
+ok "Plugin built → content/.obsidian/plugins/voice-journal/main.js"
+
+# ── 7. vault skeleton ─────────────────────────────────────────────────────────
+mkdir -p "$REPO_ROOT/content/journal"
+ok "Vault journal folder ready"
+
+echo ""
+echo "=== Setup complete ==="
+echo ""
+echo "  Next steps:"
+echo "  1. Open Obsidian → 'Open folder as vault' → select content/"
+echo "  2. Settings → Community plugins → disable Safe mode → enable VoiceJournal"
+echo "  3. npm run plugin:run   (starts Whisper server + watch mode)"
+echo ""

--- a/plugins/obsidian-voicejournal/scripts/run.sh
+++ b/plugins/obsidian-voicejournal/scripts/run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# VoiceJournal dev runner
+# Starts the local Whisper server + plugin watch mode together.
+# Stop both with Ctrl+C.
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VENV_DIR="$PLUGIN_DIR/.venv"
+UVICORN="$VENV_DIR/bin/uvicorn"
+
+RED='\033[0;31m'; CYAN='\033[0;36m'; RESET='\033[0m'
+info() { echo -e "${CYAN}→${RESET} $*"; }
+fail() { echo -e "${RED}✗${RESET} $*" >&2; exit 1; }
+
+# ── preflight ─────────────────────────────────────────────────────────────────
+[ -f "$UVICORN" ] || fail "Whisper server not installed. Run: npm run plugin:init"
+command -v claude &>/dev/null || fail "'claude' not found. Run: npm run plugin:init"
+
+# ── start whisper server ──────────────────────────────────────────────────────
+info "Starting Whisper server on http://localhost:8000 ..."
+"$UVICORN" faster_whisper_server.app:app --port 8000 --log-level warning &
+WHISPER_PID=$!
+
+cleanup() {
+  echo ""
+  info "Stopping Whisper server (pid $WHISPER_PID)..."
+  kill "$WHISPER_PID" 2>/dev/null || true
+  wait "$WHISPER_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# brief pause so uvicorn is ready before esbuild watch starts printing
+sleep 1
+
+echo ""
+echo "  Whisper : http://localhost:8000"
+echo "  Claude  : local claude CLI"
+echo "  Plugin  : watch mode — rebuilds on save"
+echo "  Stop    : Ctrl+C"
+echo ""
+
+# ── start plugin watch ────────────────────────────────────────────────────────
+npm run dev --prefix "$PLUGIN_DIR"

--- a/plugins/obsidian-voicejournal/src/AudioCapture.ts
+++ b/plugins/obsidian-voicejournal/src/AudioCapture.ts
@@ -5,8 +5,11 @@ export class AudioCapture {
 
   private stream: MediaStream | null = null;
   private audioContext: AudioContext | null = null;
+  private analyserNode: AnalyserNode | null = null;
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
   private mediaRecorder: MediaRecorder | null = null;
   private intervalId: ReturnType<typeof setInterval> | null = null;
+  private isChunking = false; // prevent double-trigger while onstop is in flight
 
   constructor(settings: Pick<VoiceJournalSettings, 'silenceThreshold' | 'silenceDuration'>) {
     this.settings = settings;
@@ -16,6 +19,11 @@ export class AudioCapture {
     onSilence: (blob: Blob) => Promise<void>,
     onStatusChange: (status: 'recording' | 'listening') => void
   ): Promise<void> {
+    // Guard against calling start() while already running
+    if (this.stream !== null) {
+      throw new Error('AudioCapture is already running. Call stop() first.');
+    }
+
     // Request microphone — throws on permission denied / no device
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
     this.stream = stream;
@@ -23,11 +31,15 @@ export class AudioCapture {
     // Set up Web Audio analysis chain
     const audioContext = new AudioContext();
     this.audioContext = audioContext;
+    // Resume in case browser created context in suspended state (common in Chrome without user gesture)
+    await audioContext.resume();
 
     const analyser = audioContext.createAnalyser();
     analyser.fftSize = 2048;
+    this.analyserNode = analyser;
 
     const source = audioContext.createMediaStreamSource(stream);
+    this.sourceNode = source;
     source.connect(analyser);
 
     // Determine supported MIME type
@@ -74,7 +86,10 @@ export class AudioCapture {
       const sum = dataArray.reduce((acc, val) => acc + val, 0);
       const avg = sum / bufferLength;
 
-      // Avoid log10(0) which would be -Infinity
+      // NOTE: This is not absolute dB SPL. getByteFrequencyData returns FFT magnitude
+      // values already mapped to 0–255 on the browser's internal dB scale. Averaging
+      // and applying log10 gives a relative energy level. The silenceThreshold in
+      // DEFAULT_SETTINGS (-45) is calibrated to this scale, not to dB SPL references.
       const db = avg > 0 ? 20 * Math.log10(avg / 255) : -Infinity;
 
       const isSilent = db < this.settings.silenceThreshold;
@@ -93,8 +108,9 @@ export class AudioCapture {
       }
 
       // silenceCounter * 100ms >= silenceDuration
-      if (silenceCounter * 100 >= this.settings.silenceDuration) {
+      if (!this.isChunking && silenceCounter * 100 >= this.settings.silenceDuration) {
         silenceCounter = 0;
+        this.isChunking = true;
 
         // Capture snapshot references before async work
         const recorderToStop = recorder;
@@ -102,6 +118,7 @@ export class AudioCapture {
 
         // Stop the current recorder; wait for onstop, then process and restart
         recorderToStop.onstop = async () => {
+          this.isChunking = false;
           const blob = new Blob(chunksCopy, { type: mimeType });
 
           if (blob.size > 0) {
@@ -149,6 +166,16 @@ export class AudioCapture {
       this.stream = null;
     }
 
+    // Disconnect audio nodes before closing context
+    if (this.sourceNode !== null) {
+      this.sourceNode.disconnect();
+      this.sourceNode = null;
+    }
+    if (this.analyserNode !== null) {
+      this.analyserNode.disconnect();
+      this.analyserNode = null;
+    }
+
     // Close the AudioContext
     if (this.audioContext !== null) {
       this.audioContext.close().catch(() => {
@@ -156,5 +183,7 @@ export class AudioCapture {
       });
       this.audioContext = null;
     }
+
+    this.isChunking = false;
   }
 }

--- a/plugins/obsidian-voicejournal/src/AudioCapture.ts
+++ b/plugins/obsidian-voicejournal/src/AudioCapture.ts
@@ -10,6 +10,8 @@ export class AudioCapture {
   private mediaRecorder: MediaRecorder | null = null;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private isChunking = false; // prevent double-trigger while onstop is in flight
+  // Tracks the async work of the current in-flight chunk (transcription + follow-up)
+  private chunkSettled: Promise<void> = Promise.resolve();
 
   constructor(settings: Pick<VoiceJournalSettings, 'silenceThreshold' | 'silenceDuration'>) {
     this.settings = settings;
@@ -116,22 +118,25 @@ export class AudioCapture {
         const recorderToStop = recorder;
         const chunksCopy = chunks;
 
-        // Stop the current recorder; wait for onstop, then process and restart
-        recorderToStop.onstop = async () => {
-          this.isChunking = false;
-          const blob = new Blob(chunksCopy, { type: mimeType });
+        // Stop the current recorder; wait for onstop, then process and restart.
+        // chunkSettled tracks the full async work so drain() can await it.
+        recorderToStop.onstop = () => {
+          this.chunkSettled = (async () => {
+            this.isChunking = false;
+            const blob = new Blob(chunksCopy, { type: mimeType });
 
-          if (blob.size > 0) {
-            await onSilence(blob);
-          }
+            if (blob.size > 0) {
+              await onSilence(blob);
+            }
 
-          // Restart only if we are still running (stop() not called)
-          if (this.intervalId !== null) {
-            const next = createRecorder();
-            recorder = next.recorder;
-            chunks = next.chunks;
-            this.mediaRecorder = recorder;
-          }
+            // Restart only if we are still running (stop() not called)
+            if (this.intervalId !== null) {
+              const next = createRecorder();
+              recorder = next.recorder;
+              chunks = next.chunks;
+              this.mediaRecorder = recorder;
+            }
+          })();
         };
 
         recorderToStop.stop();
@@ -185,5 +190,14 @@ export class AudioCapture {
     }
 
     this.isChunking = false;
+  }
+
+  /**
+   * Returns a promise that resolves when the current in-flight chunk (transcription +
+   * follow-up question) has fully settled. Call after stop() to avoid a race where the
+   * final spoken chunk's async processing completes after the caller has moved on.
+   */
+  drain(): Promise<void> {
+    return this.chunkSettled;
   }
 }

--- a/plugins/obsidian-voicejournal/src/AudioCapture.ts
+++ b/plugins/obsidian-voicejournal/src/AudioCapture.ts
@@ -1,0 +1,160 @@
+import type { VoiceJournalSettings } from './types';
+
+export class AudioCapture {
+  private settings: Pick<VoiceJournalSettings, 'silenceThreshold' | 'silenceDuration'>;
+
+  private stream: MediaStream | null = null;
+  private audioContext: AudioContext | null = null;
+  private mediaRecorder: MediaRecorder | null = null;
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+
+  constructor(settings: Pick<VoiceJournalSettings, 'silenceThreshold' | 'silenceDuration'>) {
+    this.settings = settings;
+  }
+
+  async start(
+    onSilence: (blob: Blob) => Promise<void>,
+    onStatusChange: (status: 'recording' | 'listening') => void
+  ): Promise<void> {
+    // Request microphone — throws on permission denied / no device
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    this.stream = stream;
+
+    // Set up Web Audio analysis chain
+    const audioContext = new AudioContext();
+    this.audioContext = audioContext;
+
+    const analyser = audioContext.createAnalyser();
+    analyser.fftSize = 2048;
+
+    const source = audioContext.createMediaStreamSource(stream);
+    source.connect(analyser);
+
+    // Determine supported MIME type
+    let mimeType: string;
+    try {
+      if (MediaRecorder.isTypeSupported('audio/webm;codecs=opus')) {
+        mimeType = 'audio/webm;codecs=opus';
+      } else {
+        mimeType = 'audio/webm';
+      }
+    } catch {
+      mimeType = 'audio/webm';
+    }
+
+    // Internal helper: creates and starts a fresh MediaRecorder, returns it and its chunks array
+    const createRecorder = (): { recorder: MediaRecorder; chunks: Blob[] } => {
+      const chunks: Blob[] = [];
+      let recorder: MediaRecorder;
+      try {
+        recorder = new MediaRecorder(stream, { mimeType });
+      } catch {
+        recorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
+      }
+      recorder.ondataavailable = (e: BlobEvent) => {
+        if (e.data.size > 0) chunks.push(e.data);
+      };
+      recorder.start(1000); // 1-second timeslice
+      return { recorder, chunks };
+    };
+
+    let { recorder, chunks } = createRecorder();
+    this.mediaRecorder = recorder;
+
+    // Silence-detection state
+    const bufferLength = analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    let silenceCounter = 0;
+    let currentStatus: 'recording' | 'listening' | null = null;
+
+    // Poll every 100 ms
+    this.intervalId = setInterval(() => {
+      analyser.getByteFrequencyData(dataArray);
+
+      const sum = dataArray.reduce((acc, val) => acc + val, 0);
+      const avg = sum / bufferLength;
+
+      // Avoid log10(0) which would be -Infinity
+      const db = avg > 0 ? 20 * Math.log10(avg / 255) : -Infinity;
+
+      const isSilent = db < this.settings.silenceThreshold;
+
+      // Emit status change only when it actually changes
+      const nextStatus: 'recording' | 'listening' = isSilent ? 'listening' : 'recording';
+      if (nextStatus !== currentStatus) {
+        currentStatus = nextStatus;
+        onStatusChange(nextStatus);
+      }
+
+      if (isSilent) {
+        silenceCounter++;
+      } else {
+        silenceCounter = 0;
+      }
+
+      // silenceCounter * 100ms >= silenceDuration
+      if (silenceCounter * 100 >= this.settings.silenceDuration) {
+        silenceCounter = 0;
+
+        // Capture snapshot references before async work
+        const recorderToStop = recorder;
+        const chunksCopy = chunks;
+
+        // Stop the current recorder; wait for onstop, then process and restart
+        recorderToStop.onstop = async () => {
+          const blob = new Blob(chunksCopy, { type: mimeType });
+
+          if (blob.size > 0) {
+            await onSilence(blob);
+          }
+
+          // Restart only if we are still running (stop() not called)
+          if (this.intervalId !== null) {
+            const next = createRecorder();
+            recorder = next.recorder;
+            chunks = next.chunks;
+            this.mediaRecorder = recorder;
+          }
+        };
+
+        recorderToStop.stop();
+      }
+    }, 100);
+  }
+
+  stop(): void {
+    // Clear the polling interval first so no new chunks/silence triggers fire
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+
+    // Stop the recorder (may still flush a final ondataavailable, which is fine)
+    if (this.mediaRecorder !== null) {
+      try {
+        if (this.mediaRecorder.state !== 'inactive') {
+          this.mediaRecorder.stop();
+        }
+      } catch {
+        // Recorder may already be inactive
+      }
+      this.mediaRecorder = null;
+    }
+
+    // Stop all media tracks to release the microphone indicator
+    if (this.stream !== null) {
+      for (const track of this.stream.getTracks()) {
+        track.stop();
+      }
+      this.stream = null;
+    }
+
+    // Close the AudioContext
+    if (this.audioContext !== null) {
+      this.audioContext.close().catch(() => {
+        // Ignore close errors
+      });
+      this.audioContext = null;
+    }
+  }
+}

--- a/plugins/obsidian-voicejournal/src/ClaudeClient.ts
+++ b/plugins/obsidian-voicejournal/src/ClaudeClient.ts
@@ -14,10 +14,13 @@ interface ClassificationJson {
  * Uses --no-session-persistence so journal content is never saved to session history.
  * Uses --tools "" to disable all tools (pure text generation, faster).
  */
+let _claudePath = 'claude';
+export function setClaudePath(p: string) { _claudePath = p || 'claude'; }
+
 async function callClaude(system: string, userContent: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const child = spawn(
-      'claude',
+      _claudePath,
       [
         '--print',
         '--system-prompt', system,

--- a/plugins/obsidian-voicejournal/src/ClaudeClient.ts
+++ b/plugins/obsidian-voicejournal/src/ClaudeClient.ts
@@ -1,22 +1,5 @@
+import { spawn } from 'child_process';
 import { ClassificationResult, JournalEntry } from './types';
-
-const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
-const CLAUDE_MODEL = 'claude-sonnet-4-6';
-const ANTHROPIC_VERSION = '2023-06-01';
-
-interface ClaudeMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
-interface ClaudeContentBlock {
-  type: string;
-  text: string;
-}
-
-interface ClaudeResponse {
-  content: ClaudeContentBlock[];
-}
 
 interface ClassificationJson {
   title: string;
@@ -26,45 +9,51 @@ interface ClassificationJson {
   one_line_summary: string;
 }
 
-async function callClaude(
-  system: string,
-  messages: ClaudeMessage[],
-  apiKey: string,
-  maxTokens: number,
-): Promise<string> {
-  const response = await fetch(CLAUDE_API_URL, {
-    method: 'POST',
-    headers: {
-      'x-api-key': apiKey,
-      'anthropic-version': ANTHROPIC_VERSION,
-      'content-type': 'application/json',
-    },
-    body: JSON.stringify({
-      model: CLAUDE_MODEL,
-      max_tokens: maxTokens,
-      system,
-      messages,
-    }),
+/**
+ * Calls the local `claude` CLI in non-interactive print mode.
+ * Uses --no-session-persistence so journal content is never saved to session history.
+ * Uses --tools "" to disable all tools (pure text generation, faster).
+ */
+async function callClaude(system: string, userContent: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      'claude',
+      [
+        '--print',
+        '--system-prompt', system,
+        '--tools', '',
+        '--no-session-persistence',
+      ],
+      { stdio: ['pipe', 'pipe', 'pipe'] },
+    );
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    child.stdin.write(userContent);
+    child.stdin.end();
+
+    child.on('close', (code: number | null) => {
+      if (code === 0) {
+        resolve(stdout.trim());
+      } else {
+        reject(new Error(`claude CLI error (exit ${code ?? '?'}): ${stderr.slice(0, 300)}`));
+      }
+    });
+
+    child.on('error', (err: Error) => {
+      reject(new Error(`Could not spawn claude: ${err.message}. Ensure Claude Code is installed and in PATH.`));
+    });
   });
-
-  if (!response.ok) {
-    const errorText = await response.text().catch(() => response.statusText);
-    throw new Error(`Claude API error ${response.status}: ${errorText}`);
-  }
-
-  const data = await response.json() as ClaudeResponse;
-  const block = data.content.find((b) => b.type === 'text');
-  if (!block) {
-    throw new Error('Claude API error: no text content block in response');
-  }
-  return block.text;
 }
 
 export class ClaudeClient {
   async askFollowUp(
     fullTranscript: string,
     previousQuestions: string[],
-    apiKey: string,
   ): Promise<string> {
     const system =
       'You are a depth-focused journaling coach. Your only job is to ask \n' +
@@ -78,13 +67,10 @@ export class ClaudeClient {
       `Questions already asked this session:\n${previousQuestions.length > 0 ? previousQuestions.join('\n') : 'None'}\n\n` +
       `Ask the next question.`;
 
-    return callClaude(system, [{ role: 'user', content: userMessage }], apiKey, 1024);
+    return callClaude(system, userMessage);
   }
 
-  async classifyEntry(
-    transcript: string,
-    apiKey: string,
-  ): Promise<ClassificationResult> {
+  async classifyEntry(transcript: string): Promise<ClassificationResult> {
     const system =
       'Analyze this journal entry and return ONLY valid JSON. No markdown fences. \n' +
       'No explanation. JSON only. Use this exact shape:\n' +
@@ -96,16 +82,17 @@ export class ClaudeClient {
       '  "one_line_summary": "one honest plain-language sentence"\n' +
       '}';
 
-    const rawText = await callClaude(
-      system,
-      [{ role: 'user', content: transcript }],
-      apiKey,
-      512,
-    );
+    const rawText = await callClaude(system, transcript);
+
+    // Extract JSON object even if the model wraps it in surrounding text
+    const jsonMatch = rawText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      throw new Error(`Claude classification returned no JSON object: ${rawText.slice(0, 200)}`);
+    }
 
     let parsed: ClassificationJson;
     try {
-      parsed = JSON.parse(rawText) as ClassificationJson;
+      parsed = JSON.parse(jsonMatch[0]) as ClassificationJson;
     } catch {
       throw new Error(`Claude classification returned invalid JSON: ${rawText.slice(0, 200)}`);
     }
@@ -123,10 +110,7 @@ export class ClaudeClient {
     };
   }
 
-  async generateDigest(
-    entries: JournalEntry[],
-    apiKey: string,
-  ): Promise<string> {
+  async generateDigest(entries: JournalEntry[]): Promise<string> {
     const system =
       'You are analyzing a week of private journal entries. \n' +
       'Be specific — reference actual content, not generic summaries. \n' +
@@ -157,11 +141,6 @@ export class ClaudeClient {
 
     const userMessage = `Here are this week's journal entries:\n\n${entrySections.join('\n\n')}`;
 
-    return callClaude(
-      system,
-      [{ role: 'user', content: userMessage }],
-      apiKey,
-      2048,
-    );
+    return callClaude(system, userMessage);
   }
 }

--- a/plugins/obsidian-voicejournal/src/ClaudeClient.ts
+++ b/plugins/obsidian-voicejournal/src/ClaudeClient.ts
@@ -53,7 +53,11 @@ async function callClaude(
   }
 
   const data = await response.json() as ClaudeResponse;
-  return data.content[0].text;
+  const block = data.content.find((b) => b.type === 'text');
+  if (!block) {
+    throw new Error('Claude API error: no text content block in response');
+  }
+  return block.text;
 }
 
 export class ClaudeClient {
@@ -99,14 +103,23 @@ export class ClaudeClient {
       512,
     );
 
-    const parsed = JSON.parse(rawText) as ClassificationJson;
+    let parsed: ClassificationJson;
+    try {
+      parsed = JSON.parse(rawText) as ClassificationJson;
+    } catch {
+      throw new Error(`Claude classification returned invalid JSON: ${rawText.slice(0, 200)}`);
+    }
+
+    if (!Array.isArray(parsed.tags) || !Array.isArray(parsed.themes)) {
+      throw new Error('Claude classification returned malformed JSON: tags and themes must be arrays');
+    }
 
     return {
-      title: parsed.title,
+      title: parsed.title ?? '',
       tags: parsed.tags,
-      mood: parsed.mood,
+      mood: parsed.mood ?? '',
       themes: parsed.themes,
-      oneLineSummary: parsed.one_line_summary,
+      oneLineSummary: parsed.one_line_summary ?? '',
     };
   }
 
@@ -142,7 +155,7 @@ export class ClaudeClient {
       `---`,
     );
 
-    const userMessage = `Here are this week's journal entries:\n\n${entrySections.join('\n')}`;
+    const userMessage = `Here are this week's journal entries:\n\n${entrySections.join('\n\n')}`;
 
     return callClaude(
       system,

--- a/plugins/obsidian-voicejournal/src/ClaudeClient.ts
+++ b/plugins/obsidian-voicejournal/src/ClaudeClient.ts
@@ -1,0 +1,154 @@
+import { ClassificationResult, JournalEntry } from './types';
+
+const CLAUDE_API_URL = 'https://api.anthropic.com/v1/messages';
+const CLAUDE_MODEL = 'claude-sonnet-4-6';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+interface ClaudeMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface ClaudeContentBlock {
+  type: string;
+  text: string;
+}
+
+interface ClaudeResponse {
+  content: ClaudeContentBlock[];
+}
+
+interface ClassificationJson {
+  title: string;
+  tags: string[];
+  mood: string;
+  themes: string[];
+  one_line_summary: string;
+}
+
+async function callClaude(
+  system: string,
+  messages: ClaudeMessage[],
+  apiKey: string,
+  maxTokens: number,
+): Promise<string> {
+  const response = await fetch(CLAUDE_API_URL, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+      'anthropic-version': ANTHROPIC_VERSION,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      model: CLAUDE_MODEL,
+      max_tokens: maxTokens,
+      system,
+      messages,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => response.statusText);
+    throw new Error(`Claude API error ${response.status}: ${errorText}`);
+  }
+
+  const data = await response.json() as ClaudeResponse;
+  return data.content[0].text;
+}
+
+export class ClaudeClient {
+  async askFollowUp(
+    fullTranscript: string,
+    previousQuestions: string[],
+    apiKey: string,
+  ): Promise<string> {
+    const system =
+      'You are a depth-focused journaling coach. Your only job is to ask \n' +
+      'one short follow-up question that helps the person go deeper — not \n' +
+      'broader. Prioritize emotion over event, pattern over incident. \n' +
+      'Never ask yes/no questions. Never repeat a question already asked. \n' +
+      'Max 12 words. No preamble. No explanation. Just the question.';
+
+    const userMessage =
+      `Full transcript so far:\n${fullTranscript}\n\n` +
+      `Questions already asked this session:\n${previousQuestions.length > 0 ? previousQuestions.join('\n') : 'None'}\n\n` +
+      `Ask the next question.`;
+
+    return callClaude(system, [{ role: 'user', content: userMessage }], apiKey, 1024);
+  }
+
+  async classifyEntry(
+    transcript: string,
+    apiKey: string,
+  ): Promise<ClassificationResult> {
+    const system =
+      'Analyze this journal entry and return ONLY valid JSON. No markdown fences. \n' +
+      'No explanation. JSON only. Use this exact shape:\n' +
+      '{\n' +
+      '  "title": "specific non-generic title, max 8 words",\n' +
+      '  "tags": ["3-6 lowercase tags based on themes and emotions, no # symbol"],\n' +
+      '  "mood": "mood arc from start to end e.g. anxious → reflective",\n' +
+      '  "themes": ["2-4 short theme phrases"],\n' +
+      '  "one_line_summary": "one honest plain-language sentence"\n' +
+      '}';
+
+    const rawText = await callClaude(
+      system,
+      [{ role: 'user', content: transcript }],
+      apiKey,
+      512,
+    );
+
+    const parsed = JSON.parse(rawText) as ClassificationJson;
+
+    return {
+      title: parsed.title,
+      tags: parsed.tags,
+      mood: parsed.mood,
+      themes: parsed.themes,
+      oneLineSummary: parsed.one_line_summary,
+    };
+  }
+
+  async generateDigest(
+    entries: JournalEntry[],
+    apiKey: string,
+  ): Promise<string> {
+    const system =
+      'You are analyzing a week of private journal entries. \n' +
+      'Be specific — reference actual content, not generic summaries. \n' +
+      'Plain language. No therapy-speak. Honest, even if uncomfortable.\n' +
+      'Return the weekly review using exactly these markdown sections:\n\n' +
+      '## Recurring Themes\n' +
+      '## Mood Arc\n' +
+      '## Patterns Worth Watching\n' +
+      '## One Question to Sit With\n' +
+      '## Entries This Week\n\n' +
+      'Rules:\n' +
+      '- Recurring Themes: list with (appeared Nx) counts\n' +
+      '- Mood Arc: describe the emotional trajectory across the week\n' +
+      '- Patterns Worth Watching: 2-3 honest observations, specific to content\n' +
+      '- One Question to Sit With: single most useful question, direct\n' +
+      '- Entries This Week: list as Obsidian [[wikilinks]] using exact entry titles';
+
+    const entrySections = entries.map((entry) =>
+      `---\n` +
+      `Title: ${entry.title}\n` +
+      `Date: ${entry.date}\n` +
+      `Tags: ${entry.tags.join(', ')}\n` +
+      `Mood: ${entry.mood}\n` +
+      `Themes: ${entry.themes.join(', ')}\n\n` +
+      `${entry.fullContent}\n` +
+      `---`,
+    );
+
+    const userMessage = `Here are this week's journal entries:\n\n${entrySections.join('\n')}`;
+
+    return callClaude(
+      system,
+      [{ role: 'user', content: userMessage }],
+      apiKey,
+      2048,
+    );
+  }
+}

--- a/plugins/obsidian-voicejournal/src/DigestGenerator.ts
+++ b/plugins/obsidian-voicejournal/src/DigestGenerator.ts
@@ -16,8 +16,10 @@ export class DigestGenerator {
   async generate(): Promise<void> {
     // 1. Collect journal entries from the last 7 days
     const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    // Normalize folder path: ensure trailing slash for reliable startsWith matching
+    const journalFolder = this.settings.journalFolder.replace(/\/?$/, '/');
     const files = this.app.vault.getFiles()
-      .filter(f => f.path.startsWith(this.settings.journalFolder))
+      .filter(f => f.path.startsWith(journalFolder))
       .filter(f => f.stat.mtime >= sevenDaysAgo);
 
     // 2. Filter to journal entries only using metadataCache
@@ -26,12 +28,13 @@ export class DigestGenerator {
       return cache?.frontmatter?.['type'] === 'journal-entry';
     });
 
-    // 3. Read each file's content
-    const entries: JournalEntry[] = await Promise.all(
+    // 3. Read each file's content (guard against cache invalidation between filter and map)
+    const entryResults = await Promise.all(
       journalFiles.map(async (f) => {
         const content = await this.app.vault.read(f);
-        const cache = this.app.metadataCache.getFileCache(f)!;
-        const fm = cache.frontmatter!;
+        const cache = this.app.metadataCache.getFileCache(f);
+        const fm = cache?.frontmatter;
+        if (!fm) return null; // cache was invalidated between filter and map
         return {
           title: String(fm['title'] ?? f.basename),
           date: String(fm['date'] ?? ''),
@@ -40,9 +43,10 @@ export class DigestGenerator {
           themes: Array.isArray(fm['themes']) ? fm['themes'] as string[] : [],
           fullContent: content,
           filePath: f.path,
-        };
+        } satisfies JournalEntry;
       })
     );
+    const entries = entryResults.filter((e): e is JournalEntry => e !== null);
 
     // 4. Bail early if no entries
     if (entries.length === 0) {
@@ -61,10 +65,11 @@ export class DigestGenerator {
     const noteContent = frontmatter + digestContent;
     const filename = `${dateStr}-weekly.md`;
 
-    // Ensure weeklyFolder exists
-    await this.ensureFolder(this.settings.weeklyFolder);
+    // Normalize weeklyFolder and ensure it exists
+    const weeklyFolder = this.settings.weeklyFolder.replace(/\/?$/, '/');
+    await this.ensureFolder(weeklyFolder);
 
-    const filePath = `${this.settings.weeklyFolder}${filename}`;
+    const filePath = `${weeklyFolder}${filename}`;
     const existing = this.app.vault.getFileByPath(filePath);
     if (existing) {
       await this.app.vault.modify(existing, noteContent);
@@ -85,8 +90,9 @@ export class DigestGenerator {
   private async ensureFolder(folderPath: string): Promise<void> {
     try {
       await this.app.vault.createFolder(folderPath);
-    } catch {
-      // Folder already exists — ignore
+    } catch (e) {
+      // Folder likely already exists — log for debugging but don't throw
+      console.debug('VoiceJournal: ensureFolder', folderPath, e);
     }
   }
 }

--- a/plugins/obsidian-voicejournal/src/DigestGenerator.ts
+++ b/plugins/obsidian-voicejournal/src/DigestGenerator.ts
@@ -53,8 +53,8 @@ export class DigestGenerator {
       throw new Error('No journal entries found in the last 7 days.');
     }
 
-    // 5. Call Claude for digest
-    const digestContent = await this.claudeClient.generateDigest(entries, this.settings.anthropicApiKey);
+    // 5. Call Claude CLI for digest
+    const digestContent = await this.claudeClient.generateDigest(entries);
 
     // 6. Write the weekly note
     const today = new Date();

--- a/plugins/obsidian-voicejournal/src/DigestGenerator.ts
+++ b/plugins/obsidian-voicejournal/src/DigestGenerator.ts
@@ -1,0 +1,92 @@
+import { App } from 'obsidian';
+import { VoiceJournalSettings, JournalEntry } from './types';
+import { ClaudeClient } from './ClaudeClient';
+
+export class DigestGenerator {
+  private app: App;
+  private settings: VoiceJournalSettings;
+  private claudeClient: ClaudeClient;
+
+  constructor(app: App, settings: VoiceJournalSettings, claudeClient: ClaudeClient) {
+    this.app = app;
+    this.settings = settings;
+    this.claudeClient = claudeClient;
+  }
+
+  async generate(): Promise<void> {
+    // 1. Collect journal entries from the last 7 days
+    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    const files = this.app.vault.getFiles()
+      .filter(f => f.path.startsWith(this.settings.journalFolder))
+      .filter(f => f.stat.mtime >= sevenDaysAgo);
+
+    // 2. Filter to journal entries only using metadataCache
+    const journalFiles = files.filter(f => {
+      const cache = this.app.metadataCache.getFileCache(f);
+      return cache?.frontmatter?.['type'] === 'journal-entry';
+    });
+
+    // 3. Read each file's content
+    const entries: JournalEntry[] = await Promise.all(
+      journalFiles.map(async (f) => {
+        const content = await this.app.vault.read(f);
+        const cache = this.app.metadataCache.getFileCache(f)!;
+        const fm = cache.frontmatter!;
+        return {
+          title: String(fm['title'] ?? f.basename),
+          date: String(fm['date'] ?? ''),
+          tags: Array.isArray(fm['tags']) ? fm['tags'] as string[] : [],
+          mood: String(fm['mood'] ?? ''),
+          themes: Array.isArray(fm['themes']) ? fm['themes'] as string[] : [],
+          fullContent: content,
+          filePath: f.path,
+        };
+      })
+    );
+
+    // 4. Bail early if no entries
+    if (entries.length === 0) {
+      throw new Error('No journal entries found in the last 7 days.');
+    }
+
+    // 5. Call Claude for digest
+    const digestContent = await this.claudeClient.generateDigest(entries, this.settings.anthropicApiKey);
+
+    // 6. Write the weekly note
+    const today = new Date();
+    const dateStr = today.toISOString().slice(0, 10); // YYYY-MM-DD
+    const weekOf = this.getMondayDate(today);
+
+    const frontmatter = `---\ndate: ${dateStr}\ntype: weekly-review\nweek-of: ${weekOf}\nentries-reviewed: ${entries.length}\n---\n\n`;
+    const noteContent = frontmatter + digestContent;
+    const filename = `${dateStr}-weekly.md`;
+
+    // Ensure weeklyFolder exists
+    await this.ensureFolder(this.settings.weeklyFolder);
+
+    const filePath = `${this.settings.weeklyFolder}${filename}`;
+    const existing = this.app.vault.getFileByPath(filePath);
+    if (existing) {
+      await this.app.vault.modify(existing, noteContent);
+    } else {
+      await this.app.vault.create(filePath, noteContent);
+    }
+  }
+
+  private getMondayDate(date: Date): string {
+    const d = new Date(date);
+    const day = d.getDay(); // 0 = Sunday, 1 = Monday, ...
+    // Adjust so Monday = 0: (day + 6) % 7 gives days since Monday
+    const diff = (day + 6) % 7;
+    d.setDate(d.getDate() - diff);
+    return d.toISOString().slice(0, 10);
+  }
+
+  private async ensureFolder(folderPath: string): Promise<void> {
+    try {
+      await this.app.vault.createFolder(folderPath);
+    } catch {
+      // Folder already exists — ignore
+    }
+  }
+}

--- a/plugins/obsidian-voicejournal/src/JournalView.ts
+++ b/plugins/obsidian-voicejournal/src/JournalView.ts
@@ -1,0 +1,27 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import type VoiceJournalPlugin from './main';
+
+export const VIEW_TYPE_JOURNAL = 'voice-journal-view';
+
+export class JournalView extends ItemView {
+  plugin: VoiceJournalPlugin;
+
+  constructor(leaf: WorkspaceLeaf, plugin: VoiceJournalPlugin) {
+    super(leaf);
+    this.plugin = plugin;
+  }
+
+  getViewType(): string {
+    return VIEW_TYPE_JOURNAL;
+  }
+
+  getDisplayText(): string {
+    return 'VoiceJournal';
+  }
+
+  async onOpen(): Promise<void> {}
+  async onClose(): Promise<void> {}
+
+  // Will be fully implemented in Task 7
+  generateWeeklyDigest(): void {}
+}

--- a/plugins/obsidian-voicejournal/src/JournalView.ts
+++ b/plugins/obsidian-voicejournal/src/JournalView.ts
@@ -1,14 +1,44 @@
-import { ItemView, WorkspaceLeaf } from 'obsidian';
+import { ItemView, Notice, WorkspaceLeaf } from 'obsidian';
 import type VoiceJournalPlugin from './main';
+import { AudioCapture } from './AudioCapture';
+import { WhisperClient } from './WhisperClient';
+import { ClaudeClient } from './ClaudeClient';
+import { DigestGenerator } from './DigestGenerator';
+import type { SessionState, PluginStatus } from './types';
 
 export const VIEW_TYPE_JOURNAL = 'voice-journal-view';
 
 export class JournalView extends ItemView {
   plugin: VoiceJournalPlugin;
 
+  private session: SessionState = {
+    transcriptSegments: [],
+    questionsAsked: [],
+    status: 'idle',
+  };
+
+  private audioCapture: AudioCapture;
+  private whisperClient: WhisperClient;
+  private claudeClient: ClaudeClient;
+
+  // DOM refs
+  private elStatus!: HTMLElement;
+  private elError!: HTMLElement;
+  private elTranscript!: HTMLElement;
+  private elQuestion!: HTMLElement;
+  private btnRecord!: HTMLButtonElement;
+  private btnSave!: HTMLButtonElement;
+  private btnDigest!: HTMLButtonElement;
+
+  // Auto-hide timer for error banner
+  private errorHideTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(leaf: WorkspaceLeaf, plugin: VoiceJournalPlugin) {
     super(leaf);
     this.plugin = plugin;
+    this.audioCapture = new AudioCapture(this.plugin.settings);
+    this.whisperClient = new WhisperClient();
+    this.claudeClient = new ClaudeClient();
   }
 
   getViewType(): string {
@@ -19,9 +49,267 @@ export class JournalView extends ItemView {
     return 'VoiceJournal';
   }
 
-  async onOpen(): Promise<void> {}
-  async onClose(): Promise<void> {}
+  async onOpen(): Promise<void> {
+    const container = this.contentEl;
+    container.empty();
 
-  // Will be fully implemented in Task 7
-  generateWeeklyDigest(): void {}
+    const root = container.createDiv({ cls: 'voice-journal-container' });
+
+    this.elStatus = root.createDiv({ cls: 'vj-status', text: 'Idle' });
+
+    this.elError = root.createDiv({ cls: 'vj-error' });
+    this.elError.style.display = 'none';
+
+    this.elTranscript = root.createDiv({ cls: 'vj-transcript' });
+
+    this.elQuestion = root.createDiv({ cls: 'vj-question' });
+
+    const buttonRow = root.createDiv({ cls: 'vj-buttons' });
+
+    this.btnRecord = buttonRow.createEl('button', { cls: 'vj-btn-record', text: '● Record' });
+    this.btnSave = buttonRow.createEl('button', { cls: 'vj-btn-save', text: 'Save' });
+    this.btnSave.disabled = true;
+    this.btnDigest = buttonRow.createEl('button', { cls: 'vj-btn-digest', text: 'Weekly Digest' });
+
+    this.btnRecord.addEventListener('click', () => {
+      const isRecording =
+        this.session.status === 'recording' || this.session.status === 'listening';
+      if (isRecording) {
+        void this.stopSession();
+      } else if (this.session.status === 'idle') {
+        void this.startSession();
+      }
+    });
+
+    this.btnSave.addEventListener('click', () => {
+      void this.saveSession();
+    });
+
+    this.btnDigest.addEventListener('click', () => {
+      void this.generateWeeklyDigest();
+    });
+  }
+
+  async onClose(): Promise<void> {
+    this.audioCapture.stop();
+  }
+
+  // ────────────────────────────────────────────────
+  // Core session methods
+  // ────────────────────────────────────────────────
+
+  private async startSession(): Promise<void> {
+    this.updateStatus('recording');
+    this.elTranscript.empty();
+    this.elQuestion.textContent = '';
+    this.elQuestion.removeClass('has-question');
+    this.session.transcriptSegments = [];
+    this.session.questionsAsked = [];
+
+    try {
+      await this.audioCapture.start(
+        async (blob: Blob) => {
+          // onSilence — transcribe the chunk
+          const apiKey = this.plugin.settings.openaiApiKey;
+          let text: string;
+          try {
+            text = await this.whisperClient.transcribe(blob, apiKey);
+          } catch {
+            this.showError('Transcription failed for this chunk');
+            return;
+          }
+
+          if (!text) return; // ambient noise / empty
+
+          this.appendTranscript(text);
+
+          // Ask a follow-up question via Claude
+          const fullTranscript = this.session.transcriptSegments.join(' ');
+          const anthropicKey = this.plugin.settings.anthropicApiKey;
+          try {
+            const question = await this.claudeClient.askFollowUp(
+              fullTranscript,
+              this.session.questionsAsked,
+              anthropicKey,
+            );
+            this.session.questionsAsked.push(question);
+            this.showQuestion(question);
+          } catch {
+            this.showError('Could not generate question');
+          }
+        },
+        (status: 'recording' | 'listening') => {
+          // onStatusChange — keep UI badge in sync while session is active
+          if (
+            this.session.status === 'recording' ||
+            this.session.status === 'listening'
+          ) {
+            this.updateStatus(status);
+          }
+        },
+      );
+    } catch (err) {
+      this.showError(err instanceof Error ? err.message : 'Could not access microphone');
+      this.updateStatus('idle');
+    }
+  }
+
+  private async stopSession(): Promise<void> {
+    this.audioCapture.stop();
+    this.updateStatus('listening');
+    // Give any in-flight onstop callback a moment to finish
+    await Promise.resolve();
+    this.updateStatus('idle');
+    // Enable save if there's content
+    this.btnSave.disabled = this.session.transcriptSegments.length === 0;
+  }
+
+  private async saveSession(): Promise<void> {
+    if (this.session.transcriptSegments.length === 0) {
+      this.showError('No transcript to save');
+      return;
+    }
+
+    this.updateStatus('processing');
+
+    const fullTranscript = this.session.transcriptSegments.join(' ');
+    const apiKey = this.plugin.settings.anthropicApiKey;
+
+    let classification;
+    try {
+      classification = await this.claudeClient.classifyEntry(fullTranscript, apiKey);
+    } catch (err) {
+      this.showError(err instanceof Error ? err.message : 'Classification failed');
+      this.updateStatus('idle');
+      return;
+    }
+
+    // Build YAML frontmatter
+    const today = new Date().toISOString().slice(0, 10);
+    const tagsYaml = classification.tags.map((t) => `  - ${t}`).join('\n');
+    const themesYaml = classification.themes.map((t) => `  - ${t}`).join('\n');
+    const frontmatter =
+      `---\n` +
+      `type: journal-entry\n` +
+      `date: ${today}\n` +
+      `title: "${classification.title}"\n` +
+      `mood: "${classification.mood}"\n` +
+      `tags:\n${tagsYaml}\n` +
+      `themes:\n${themesYaml}\n` +
+      `summary: "${classification.oneLineSummary}"\n` +
+      `---`;
+
+    const noteContent = frontmatter + '\n\n' + fullTranscript;
+    const filePath = await this.buildFilePath(today, classification.title);
+
+    try {
+      await this.app.vault.create(filePath, noteContent);
+    } catch (err) {
+      this.showError(err instanceof Error ? err.message : 'Failed to save note');
+      this.updateStatus('idle');
+      return;
+    }
+
+    new Notice(`Entry saved: ${classification.title}`);
+
+    // Reset session state
+    this.session.transcriptSegments = [];
+    this.session.questionsAsked = [];
+    this.elTranscript.empty();
+    this.elQuestion.textContent = '';
+    this.elQuestion.removeClass('has-question');
+    this.updateStatus('idle');
+  }
+
+  public async generateWeeklyDigest(): Promise<void> {
+    this.updateStatus('processing');
+    try {
+      const digestGenerator = new DigestGenerator(
+        this.app,
+        this.plugin.settings,
+        this.claudeClient,
+      );
+      await digestGenerator.generate();
+      new Notice('Weekly digest generated!');
+    } catch (err) {
+      this.showError(err instanceof Error ? err.message : 'Digest generation failed');
+    } finally {
+      this.updateStatus('idle');
+    }
+  }
+
+  // ────────────────────────────────────────────────
+  // Helper methods
+  // ────────────────────────────────────────────────
+
+  private updateStatus(status: PluginStatus): void {
+    this.session.status = status;
+
+    const labels: Record<PluginStatus, string> = {
+      idle: 'Idle',
+      recording: 'Recording...',
+      listening: 'Listening...',
+      processing: 'Processing...',
+    };
+    this.elStatus.textContent = labels[status];
+
+    const isActiveRecording = status === 'recording' || status === 'listening';
+    this.btnRecord.textContent = isActiveRecording ? '■ Stop' : '● Record';
+    this.btnRecord.disabled = status === 'processing';
+
+    // Save is only enabled when idle with transcript content
+    this.btnSave.disabled = !(
+      status === 'idle' && this.session.transcriptSegments.length > 0
+    );
+  }
+
+  private appendTranscript(text: string): void {
+    this.session.transcriptSegments.push(text);
+    const p = this.elTranscript.createEl('p', { text });
+    // Ensure the new paragraph is visible
+    void p;
+    this.elTranscript.scrollTop = this.elTranscript.scrollHeight;
+  }
+
+  private showQuestion(text: string): void {
+    this.elQuestion.textContent = text;
+    if (text) {
+      this.elQuestion.addClass('has-question');
+    } else {
+      this.elQuestion.removeClass('has-question');
+    }
+  }
+
+  private showError(message: string): void {
+    this.elError.textContent = message;
+    this.elError.style.display = 'block';
+
+    if (this.errorHideTimer !== null) {
+      clearTimeout(this.errorHideTimer);
+    }
+    this.errorHideTimer = setTimeout(() => {
+      this.elError.style.display = 'none';
+      this.errorHideTimer = null;
+    }, 5000);
+  }
+
+  async buildFilePath(date: string, title: string): Promise<string> {
+    const folder = this.plugin.settings.journalFolder.replace(/\/?$/, '/');
+    const safeName = title.replace(/[/\\?%*:|"<>]/g, '-');
+    const base = `${date} - ${safeName}`;
+
+    const primary = `${folder}${base}.md`;
+    if (!this.app.vault.getFileByPath(primary)) {
+      return primary;
+    }
+
+    let counter = 2;
+    while (true) {
+      const candidate = `${folder}${base} - ${counter}.md`;
+      if (!this.app.vault.getFileByPath(candidate)) {
+        return candidate;
+      }
+      counter++;
+    }
+  }
 }

--- a/plugins/obsidian-voicejournal/src/JournalView.ts
+++ b/plugins/obsidian-voicejournal/src/JournalView.ts
@@ -161,8 +161,9 @@ export class JournalView extends ItemView {
   private async stopSession(): Promise<void> {
     this.audioCapture.stop();
     this.updateStatus('listening');
-    // Give any in-flight onstop callback a moment to finish
-    await Promise.resolve();
+    // Wait for any in-flight chunk (transcription + follow-up) to fully settle
+    // before transitioning to idle — prevents Save being enabled prematurely.
+    await this.audioCapture.drain();
     this.updateStatus('idle'); // updateStatus handles btnSave.disabled
   }
 
@@ -204,6 +205,12 @@ export class JournalView extends ItemView {
       `---`;
 
     const noteContent = frontmatter + '\n\n' + fullTranscript;
+    const folder = this.plugin.settings.journalFolder.replace(/\/?$/, '/');
+    try {
+      await this.app.vault.createFolder(folder);
+    } catch {
+      // Folder already exists — expected on all non-first saves
+    }
     const filePath = await this.buildFilePath(today, classification.title);
 
     try {

--- a/plugins/obsidian-voicejournal/src/JournalView.ts
+++ b/plugins/obsidian-voicejournal/src/JournalView.ts
@@ -114,10 +114,13 @@ export class JournalView extends ItemView {
       await this.audioCapture.start(
         async (blob: Blob) => {
           // onSilence — transcribe the chunk
-          const apiKey = this.plugin.settings.openaiApiKey;
           let text: string;
           try {
-            text = await this.whisperClient.transcribe(blob, apiKey);
+            text = await this.whisperClient.transcribe(
+              blob,
+              this.plugin.settings.openaiApiKey,
+              this.plugin.settings.whisperBaseUrl,
+            );
           } catch {
             this.showError('Transcription failed for this chunk');
             return;
@@ -127,14 +130,12 @@ export class JournalView extends ItemView {
 
           this.appendTranscript(text);
 
-          // Ask a follow-up question via Claude
+          // Ask a follow-up question via Claude CLI
           const fullTranscript = this.session.transcriptSegments.join(' ');
-          const anthropicKey = this.plugin.settings.anthropicApiKey;
           try {
             const question = await this.claudeClient.askFollowUp(
               fullTranscript,
               this.session.questionsAsked,
-              anthropicKey,
             );
             this.session.questionsAsked.push(question);
             this.showQuestion(question);
@@ -176,11 +177,10 @@ export class JournalView extends ItemView {
     this.updateStatus('processing');
 
     const fullTranscript = this.session.transcriptSegments.join(' ');
-    const apiKey = this.plugin.settings.anthropicApiKey;
 
     let classification;
     try {
-      classification = await this.claudeClient.classifyEntry(fullTranscript, apiKey);
+      classification = await this.claudeClient.classifyEntry(fullTranscript);
     } catch (err) {
       this.showError(err instanceof Error ? err.message : 'Classification failed');
       this.updateStatus('idle');

--- a/plugins/obsidian-voicejournal/src/JournalView.ts
+++ b/plugins/obsidian-voicejournal/src/JournalView.ts
@@ -9,7 +9,7 @@ import type { SessionState, PluginStatus } from './types';
 export const VIEW_TYPE_JOURNAL = 'voice-journal-view';
 
 export class JournalView extends ItemView {
-  plugin: VoiceJournalPlugin;
+  private readonly plugin: VoiceJournalPlugin;
 
   private session: SessionState = {
     transcriptSegments: [],
@@ -91,6 +91,10 @@ export class JournalView extends ItemView {
   }
 
   async onClose(): Promise<void> {
+    if (this.errorHideTimer !== null) {
+      clearTimeout(this.errorHideTimer);
+      this.errorHideTimer = null;
+    }
     this.audioCapture.stop();
   }
 
@@ -159,9 +163,7 @@ export class JournalView extends ItemView {
     this.updateStatus('listening');
     // Give any in-flight onstop callback a moment to finish
     await Promise.resolve();
-    this.updateStatus('idle');
-    // Enable save if there's content
-    this.btnSave.disabled = this.session.transcriptSegments.length === 0;
+    this.updateStatus('idle'); // updateStatus handles btnSave.disabled
   }
 
   private async saveSession(): Promise<void> {
@@ -185,6 +187,8 @@ export class JournalView extends ItemView {
     }
 
     // Build YAML frontmatter
+    // Escape embedded double-quotes in LLM-generated string values to prevent malformed YAML
+    const escYaml = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const today = new Date().toISOString().slice(0, 10);
     const tagsYaml = classification.tags.map((t) => `  - ${t}`).join('\n');
     const themesYaml = classification.themes.map((t) => `  - ${t}`).join('\n');
@@ -192,11 +196,11 @@ export class JournalView extends ItemView {
       `---\n` +
       `type: journal-entry\n` +
       `date: ${today}\n` +
-      `title: "${classification.title}"\n` +
-      `mood: "${classification.mood}"\n` +
+      `title: "${escYaml(classification.title)}"\n` +
+      `mood: "${escYaml(classification.mood)}"\n` +
       `tags:\n${tagsYaml}\n` +
       `themes:\n${themesYaml}\n` +
-      `summary: "${classification.oneLineSummary}"\n` +
+      `summary: "${escYaml(classification.oneLineSummary)}"\n` +
       `---`;
 
     const noteContent = frontmatter + '\n\n' + fullTranscript;
@@ -265,9 +269,7 @@ export class JournalView extends ItemView {
 
   private appendTranscript(text: string): void {
     this.session.transcriptSegments.push(text);
-    const p = this.elTranscript.createEl('p', { text });
-    // Ensure the new paragraph is visible
-    void p;
+    this.elTranscript.createEl('p', { text });
     this.elTranscript.scrollTop = this.elTranscript.scrollHeight;
   }
 
@@ -293,7 +295,7 @@ export class JournalView extends ItemView {
     }, 5000);
   }
 
-  async buildFilePath(date: string, title: string): Promise<string> {
+  private async buildFilePath(date: string, title: string): Promise<string> {
     const folder = this.plugin.settings.journalFolder.replace(/\/?$/, '/');
     const safeName = title.replace(/[/\\?%*:|"<>]/g, '-');
     const base = `${date} - ${safeName}`;

--- a/plugins/obsidian-voicejournal/src/SettingsTab.ts
+++ b/plugins/obsidian-voicejournal/src/SettingsTab.ts
@@ -13,10 +13,10 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
     const { containerEl } = this;
     containerEl.empty();
 
-    // 1. OpenAI API Key
+    // 1. OpenAI API Key (not needed for local Whisper server)
     new Setting(containerEl)
       .setName('OpenAI API Key')
-      .setDesc('Used for Whisper transcription')
+      .setDesc('Required for openai.com Whisper. Leave empty when using a local Whisper server.')
       .addText((text) => {
         text.inputEl.type = 'password';
         text
@@ -28,22 +28,26 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           });
       });
 
-    // 2. Anthropic API Key
+    // 2. Whisper Base URL
     new Setting(containerEl)
-      .setName('Anthropic API Key')
-      .setDesc('Used for Claude follow-up questions and classification')
-      .addText((text) => {
-        text.inputEl.type = 'password';
+      .setName('Whisper Base URL')
+      .setDesc('OpenAI-compatible transcription endpoint. Use http://localhost:8000 for faster-whisper-server.')
+      .addText((text) =>
         text
-          .setPlaceholder('sk-ant-...')
-          .setValue(this.plugin.settings.anthropicApiKey)
+          .setPlaceholder('https://api.openai.com')
+          .setValue(this.plugin.settings.whisperBaseUrl)
           .onChange(async (value) => {
-            this.plugin.settings.anthropicApiKey = value;
+            this.plugin.settings.whisperBaseUrl = value.replace(/\/$/, '');
             await this.plugin.saveSettings();
-          });
-      });
+          })
+      );
 
-    // 3. Journal Folder
+    // 3. Claude — info only (uses Claude Code CLI, no API key needed)
+    new Setting(containerEl)
+      .setName('Claude (via Claude Code CLI)')
+      .setDesc('Follow-up questions and classification use your local `claude` install. No API key needed here.');
+
+    // 4. Journal Folder
     new Setting(containerEl)
       .setName('Journal Folder')
       .setDesc('Vault path for journal entries (default: journal/)')
@@ -57,7 +61,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           })
       );
 
-    // 4. Weekly Digest Folder
+    // 5. Weekly Digest Folder
     new Setting(containerEl)
       .setName('Weekly Digest Folder')
       .setDesc('Vault path for weekly digests (default: journal/weekly/)')
@@ -71,7 +75,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           })
       );
 
-    // 5. Silence Threshold (slider)
+    // 6. Silence Threshold (slider)
     new Setting(containerEl)
       .setName('Silence Threshold (dB)')
       .setDesc('dB level to detect silence')
@@ -86,7 +90,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           })
       );
 
-    // 6. Silence Duration (number input)
+    // 7. Silence Duration (number input)
     new Setting(containerEl)
       .setName('Silence Duration (ms)')
       .setDesc('Milliseconds of silence before triggering transcription')
@@ -104,7 +108,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           });
       });
 
-    // 7. Auto Weekly Digest (toggle)
+    // 8. Auto Weekly Digest (toggle)
     new Setting(containerEl)
       .setName('Auto Weekly Digest')
       .setDesc(

--- a/plugins/obsidian-voicejournal/src/SettingsTab.ts
+++ b/plugins/obsidian-voicejournal/src/SettingsTab.ts
@@ -42,10 +42,19 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           })
       );
 
-    // 3. Claude — info only (uses Claude Code CLI, no API key needed)
+    // 3. Claude path
     new Setting(containerEl)
-      .setName('Claude (via Claude Code CLI)')
-      .setDesc('Follow-up questions and classification use your local `claude` install. No API key needed here.');
+      .setName('Claude CLI path')
+      .setDesc('Full path to the claude executable. Run `which claude` in terminal to find it.')
+      .addText((text) =>
+        text
+          .setPlaceholder('claude')
+          .setValue(this.plugin.settings.claudePath)
+          .onChange(async (value) => {
+            this.plugin.settings.claudePath = value.trim() || 'claude';
+            await this.plugin.saveSettings();
+          })
+      );
 
     // 4. Journal Folder
     new Setting(containerEl)

--- a/plugins/obsidian-voicejournal/src/SettingsTab.ts
+++ b/plugins/obsidian-voicejournal/src/SettingsTab.ts
@@ -97,7 +97,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
           .setValue(String(this.plugin.settings.silenceDuration))
           .onChange(async (value) => {
             const parsed = parseInt(value, 10);
-            if (!isNaN(parsed)) {
+            if (!isNaN(parsed) && parsed >= 100) {
               this.plugin.settings.silenceDuration = parsed;
               await this.plugin.saveSettings();
             }

--- a/plugins/obsidian-voicejournal/src/SettingsTab.ts
+++ b/plugins/obsidian-voicejournal/src/SettingsTab.ts
@@ -1,0 +1,122 @@
+import { App, PluginSettingTab, Setting } from 'obsidian';
+import type VoiceJournalPlugin from './main';
+
+export class VoiceJournalSettingsTab extends PluginSettingTab {
+  plugin: VoiceJournalPlugin;
+
+  constructor(app: App, plugin: VoiceJournalPlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+
+    // 1. OpenAI API Key
+    new Setting(containerEl)
+      .setName('OpenAI API Key')
+      .setDesc('Used for Whisper transcription')
+      .addText((text) => {
+        text.inputEl.type = 'password';
+        text
+          .setPlaceholder('sk-...')
+          .setValue(this.plugin.settings.openaiApiKey)
+          .onChange(async (value) => {
+            this.plugin.settings.openaiApiKey = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    // 2. Anthropic API Key
+    new Setting(containerEl)
+      .setName('Anthropic API Key')
+      .setDesc('Used for Claude follow-up questions and classification')
+      .addText((text) => {
+        text.inputEl.type = 'password';
+        text
+          .setPlaceholder('sk-ant-...')
+          .setValue(this.plugin.settings.anthropicApiKey)
+          .onChange(async (value) => {
+            this.plugin.settings.anthropicApiKey = value;
+            await this.plugin.saveSettings();
+          });
+      });
+
+    // 3. Journal Folder
+    new Setting(containerEl)
+      .setName('Journal Folder')
+      .setDesc('Vault path for journal entries (default: journal/)')
+      .addText((text) =>
+        text
+          .setPlaceholder('journal/')
+          .setValue(this.plugin.settings.journalFolder)
+          .onChange(async (value) => {
+            this.plugin.settings.journalFolder = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    // 4. Weekly Digest Folder
+    new Setting(containerEl)
+      .setName('Weekly Digest Folder')
+      .setDesc('Vault path for weekly digests (default: journal/weekly/)')
+      .addText((text) =>
+        text
+          .setPlaceholder('journal/weekly/')
+          .setValue(this.plugin.settings.weeklyFolder)
+          .onChange(async (value) => {
+            this.plugin.settings.weeklyFolder = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    // 5. Silence Threshold (slider)
+    new Setting(containerEl)
+      .setName('Silence Threshold (dB)')
+      .setDesc('dB level to detect silence')
+      .addSlider((slider) =>
+        slider
+          .setLimits(-80, 0, 1)
+          .setValue(this.plugin.settings.silenceThreshold)
+          .setDynamicTooltip()
+          .onChange(async (value) => {
+            this.plugin.settings.silenceThreshold = value;
+            await this.plugin.saveSettings();
+          })
+      );
+
+    // 6. Silence Duration (number input)
+    new Setting(containerEl)
+      .setName('Silence Duration (ms)')
+      .setDesc('Milliseconds of silence before triggering transcription')
+      .addText((text) => {
+        text.inputEl.type = 'number';
+        text
+          .setPlaceholder('1500')
+          .setValue(String(this.plugin.settings.silenceDuration))
+          .onChange(async (value) => {
+            const parsed = parseInt(value, 10);
+            if (!isNaN(parsed)) {
+              this.plugin.settings.silenceDuration = parsed;
+              await this.plugin.saveSettings();
+            }
+          });
+      });
+
+    // 7. Auto Weekly Digest (toggle)
+    new Setting(containerEl)
+      .setName('Auto Weekly Digest')
+      .setDesc(
+        'Automatically generate a weekly digest every Sunday when Obsidian starts'
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.autoWeeklyDigest)
+          .onChange(async (value) => {
+            this.plugin.settings.autoWeeklyDigest = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
+}

--- a/plugins/obsidian-voicejournal/src/SettingsTab.ts
+++ b/plugins/obsidian-voicejournal/src/SettingsTab.ts
@@ -34,7 +34,7 @@ export class VoiceJournalSettingsTab extends PluginSettingTab {
       .setDesc('OpenAI-compatible transcription endpoint. Use http://localhost:8000 for faster-whisper-server.')
       .addText((text) =>
         text
-          .setPlaceholder('https://api.openai.com')
+          .setPlaceholder('http://localhost:8000')
           .setValue(this.plugin.settings.whisperBaseUrl)
           .onChange(async (value) => {
             this.plugin.settings.whisperBaseUrl = value.replace(/\/$/, '');

--- a/plugins/obsidian-voicejournal/src/WhisperClient.ts
+++ b/plugins/obsidian-voicejournal/src/WhisperClient.ts
@@ -3,7 +3,7 @@ export class WhisperClient {
     const formData = new FormData();
     formData.append('file', blob, 'chunk.webm');
     formData.append('model', 'whisper-1');
-    formData.append('language', 'en');
+    formData.append('language', 'en'); // hardcoded; add to VoiceJournalSettings if multi-language needed
 
     const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
       method: 'POST',

--- a/plugins/obsidian-voicejournal/src/WhisperClient.ts
+++ b/plugins/obsidian-voicejournal/src/WhisperClient.ts
@@ -1,0 +1,22 @@
+export class WhisperClient {
+  async transcribe(blob: Blob, apiKey: string): Promise<string> {
+    const formData = new FormData();
+    formData.append('file', blob, 'chunk.webm');
+    formData.append('model', 'whisper-1');
+    formData.append('language', 'en');
+
+    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${apiKey}` },
+      body: formData,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => response.statusText);
+      throw new Error(`Whisper API error ${response.status}: ${errorText}`);
+    }
+
+    const data = await response.json() as { text: string };
+    return data.text.trim();
+  }
+}

--- a/plugins/obsidian-voicejournal/src/WhisperClient.ts
+++ b/plugins/obsidian-voicejournal/src/WhisperClient.ts
@@ -1,13 +1,21 @@
 export class WhisperClient {
-  async transcribe(blob: Blob, apiKey: string): Promise<string> {
+  /**
+   * @param baseUrl OpenAI-compatible base URL (default: https://api.openai.com).
+   *                Set to e.g. http://localhost:8000 for faster-whisper-server.
+   * @param apiKey  API key sent as Bearer token. Empty string is fine for local servers.
+   */
+  async transcribe(blob: Blob, apiKey: string, baseUrl = 'https://api.openai.com'): Promise<string> {
     const formData = new FormData();
     formData.append('file', blob, 'chunk.webm');
     formData.append('model', 'whisper-1');
     formData.append('language', 'en'); // hardcoded; add to VoiceJournalSettings if multi-language needed
 
-    const response = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    const headers: Record<string, string> = {};
+    if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`;
+
+    const response = await fetch(`${baseUrl}/v1/audio/transcriptions`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}` },
+      headers,
       body: formData,
     });
 

--- a/plugins/obsidian-voicejournal/src/main.ts
+++ b/plugins/obsidian-voicejournal/src/main.ts
@@ -2,12 +2,14 @@ import { Plugin } from 'obsidian';
 import { VoiceJournalSettings, DEFAULT_SETTINGS } from './types';
 import { VoiceJournalSettingsTab } from './SettingsTab';
 import { JournalView, VIEW_TYPE_JOURNAL } from './JournalView';
+import { setClaudePath } from './ClaudeClient';
 
 export default class VoiceJournalPlugin extends Plugin {
   settings: VoiceJournalSettings = { ...DEFAULT_SETTINGS };
 
   async onload() {
     await this.loadSettings();
+    setClaudePath(this.settings.claudePath);
 
     // Register the side panel view
     this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));
@@ -82,5 +84,6 @@ export default class VoiceJournalPlugin extends Plugin {
 
   async saveSettings(): Promise<void> {
     await this.saveData(this.settings);
+    setClaudePath(this.settings.claudePath);
   }
 }

--- a/plugins/obsidian-voicejournal/src/main.ts
+++ b/plugins/obsidian-voicejournal/src/main.ts
@@ -1,0 +1,81 @@
+import { Plugin } from 'obsidian';
+import { VoiceJournalSettings, DEFAULT_SETTINGS } from './types';
+import { VoiceJournalSettingsTab } from './SettingsTab';
+import { JournalView, VIEW_TYPE_JOURNAL } from './JournalView';
+
+export default class VoiceJournalPlugin extends Plugin {
+  settings: VoiceJournalSettings = { ...DEFAULT_SETTINGS };
+
+  async onload() {
+    await this.loadSettings();
+
+    // Register the side panel view
+    this.registerView(VIEW_TYPE_JOURNAL, (leaf) => new JournalView(leaf, this));
+
+    // Ribbon icon — opens the journal panel
+    this.addRibbonIcon('mic', 'VoiceJournal', () => {
+      this.activateView();
+    });
+
+    // Commands
+    this.addCommand({
+      id: 'voicejournal-start',
+      name: 'Start Voice Journal',
+      callback: () => this.activateView(),
+    });
+
+    this.addCommand({
+      id: 'voicejournal-weekly',
+      name: 'Generate Weekly Digest',
+      callback: () => {
+        // Dispatch to the open view if available, otherwise show notice
+        const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_JOURNAL);
+        if (leaves.length > 0) {
+          const view = leaves[0].view as JournalView;
+          view.generateWeeklyDigest();
+        } else {
+          this.activateView().then(() => {
+            const newLeaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_JOURNAL);
+            if (newLeaves.length > 0) {
+              const view = newLeaves[0].view as JournalView;
+              view.generateWeeklyDigest();
+            }
+          });
+        }
+      },
+    });
+
+    // Settings tab
+    this.addSettingTab(new VoiceJournalSettingsTab(this.app, this));
+
+    // Auto weekly digest on Sunday
+    if (this.settings.autoWeeklyDigest && new Date().getDay() === 0) {
+      // Day 0 = Sunday
+      this.app.workspace.onLayoutReady(() => {
+        this.activateView();
+      });
+    }
+  }
+
+  onunload() {
+    this.app.workspace.detachLeavesOfType(VIEW_TYPE_JOURNAL);
+  }
+
+  private async activateView(): Promise<void> {
+    const { workspace } = this.app;
+    let leaf = workspace.getLeavesOfType(VIEW_TYPE_JOURNAL)[0];
+    if (!leaf) {
+      leaf = workspace.getRightLeaf(false) ?? workspace.getLeaf(true);
+      await leaf.setViewState({ type: VIEW_TYPE_JOURNAL, active: true });
+    }
+    workspace.revealLeaf(leaf);
+  }
+
+  async loadSettings(): Promise<void> {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings(): Promise<void> {
+    await this.saveData(this.settings);
+  }
+}

--- a/plugins/obsidian-voicejournal/src/main.ts
+++ b/plugins/obsidian-voicejournal/src/main.ts
@@ -50,9 +50,14 @@ export default class VoiceJournalPlugin extends Plugin {
 
     // Auto weekly digest on Sunday
     if (this.settings.autoWeeklyDigest && new Date().getDay() === 0) {
-      // Day 0 = Sunday
+      // Day 0 = Sunday — open panel and trigger digest after layout is ready
       this.app.workspace.onLayoutReady(() => {
-        this.activateView();
+        this.activateView().then(() => {
+          const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_JOURNAL);
+          if (leaves.length > 0) {
+            (leaves[0].view as JournalView).generateWeeklyDigest();
+          }
+        });
       });
     }
   }

--- a/plugins/obsidian-voicejournal/src/types.ts
+++ b/plugins/obsidian-voicejournal/src/types.ts
@@ -2,6 +2,7 @@
 export interface VoiceJournalSettings {
   openaiApiKey: string;
   whisperBaseUrl: string;      // default: 'http://localhost:8000' for faster-whisper-server
+  claudePath: string;          // absolute path to claude CLI (needed when Obsidian can't find it via PATH)
   journalFolder: string;       // default: 'journal/'
   weeklyFolder: string;        // default: 'journal/weekly/'
   silenceThreshold: number;    // dB level, default: -45
@@ -12,6 +13,7 @@ export interface VoiceJournalSettings {
 export const DEFAULT_SETTINGS: VoiceJournalSettings = {
   openaiApiKey: '',
   whisperBaseUrl: 'http://localhost:8000',
+  claudePath: 'claude',
   journalFolder: 'journal/',
   weeklyFolder: 'journal/weekly/',
   silenceThreshold: -45,

--- a/plugins/obsidian-voicejournal/src/types.ts
+++ b/plugins/obsidian-voicejournal/src/types.ts
@@ -25,7 +25,6 @@ export type PluginStatus = 'idle' | 'recording' | 'listening' | 'processing';
 export interface SessionState {
   transcriptSegments: string[];
   questionsAsked: string[];
-  isRecording: boolean;
   status: PluginStatus;
 }
 
@@ -35,13 +34,13 @@ export interface ClassificationResult {
   tags: string[];
   mood: string;
   themes: string[];
-  one_line_summary: string;
+  oneLineSummary: string;
 }
 
 // Journal entry metadata for digest queries
 export interface JournalEntry {
   title: string;
-  date: string;
+  date: string; // ISO 8601 format: YYYY-MM-DD
   tags: string[];
   mood: string;
   themes: string[];

--- a/plugins/obsidian-voicejournal/src/types.ts
+++ b/plugins/obsidian-voicejournal/src/types.ts
@@ -1,0 +1,50 @@
+// Plugin settings with defaults
+export interface VoiceJournalSettings {
+  openaiApiKey: string;
+  anthropicApiKey: string;
+  journalFolder: string;       // default: 'journal/'
+  weeklyFolder: string;        // default: 'journal/weekly/'
+  silenceThreshold: number;    // dB level, default: -45
+  silenceDuration: number;     // ms, default: 1500
+  autoWeeklyDigest: boolean;   // default: false
+}
+
+export const DEFAULT_SETTINGS: VoiceJournalSettings = {
+  openaiApiKey: '',
+  anthropicApiKey: '',
+  journalFolder: 'journal/',
+  weeklyFolder: 'journal/weekly/',
+  silenceThreshold: -45,
+  silenceDuration: 1500,
+  autoWeeklyDigest: false,
+};
+
+// Session recording state
+export type PluginStatus = 'idle' | 'recording' | 'listening' | 'processing';
+
+export interface SessionState {
+  transcriptSegments: string[];
+  questionsAsked: string[];
+  isRecording: boolean;
+  status: PluginStatus;
+}
+
+// Result from Claude entry classification
+export interface ClassificationResult {
+  title: string;
+  tags: string[];
+  mood: string;
+  themes: string[];
+  one_line_summary: string;
+}
+
+// Journal entry metadata for digest queries
+export interface JournalEntry {
+  title: string;
+  date: string;
+  tags: string[];
+  mood: string;
+  themes: string[];
+  fullContent: string;
+  filePath: string;
+}

--- a/plugins/obsidian-voicejournal/src/types.ts
+++ b/plugins/obsidian-voicejournal/src/types.ts
@@ -1,7 +1,7 @@
 // Plugin settings with defaults
 export interface VoiceJournalSettings {
   openaiApiKey: string;
-  anthropicApiKey: string;
+  whisperBaseUrl: string;      // default: 'https://api.openai.com' — set to local server URL for offline use
   journalFolder: string;       // default: 'journal/'
   weeklyFolder: string;        // default: 'journal/weekly/'
   silenceThreshold: number;    // dB level, default: -45
@@ -11,7 +11,7 @@ export interface VoiceJournalSettings {
 
 export const DEFAULT_SETTINGS: VoiceJournalSettings = {
   openaiApiKey: '',
-  anthropicApiKey: '',
+  whisperBaseUrl: 'https://api.openai.com',
   journalFolder: 'journal/',
   weeklyFolder: 'journal/weekly/',
   silenceThreshold: -45,

--- a/plugins/obsidian-voicejournal/src/types.ts
+++ b/plugins/obsidian-voicejournal/src/types.ts
@@ -1,7 +1,7 @@
 // Plugin settings with defaults
 export interface VoiceJournalSettings {
   openaiApiKey: string;
-  whisperBaseUrl: string;      // default: 'https://api.openai.com' — set to local server URL for offline use
+  whisperBaseUrl: string;      // default: 'http://localhost:8000' for faster-whisper-server
   journalFolder: string;       // default: 'journal/'
   weeklyFolder: string;        // default: 'journal/weekly/'
   silenceThreshold: number;    // dB level, default: -45
@@ -11,7 +11,7 @@ export interface VoiceJournalSettings {
 
 export const DEFAULT_SETTINGS: VoiceJournalSettings = {
   openaiApiKey: '',
-  whisperBaseUrl: 'https://api.openai.com',
+  whisperBaseUrl: 'http://localhost:8000',
   journalFolder: 'journal/',
   weeklyFolder: 'journal/weekly/',
   silenceThreshold: -45,

--- a/plugins/obsidian-voicejournal/tsconfig.json
+++ b/plugins/obsidian-voicejournal/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "module": "ESNext",
+    "target": "ES2018",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "bundler",
+    "importHelpers": true,
+    "isolatedModules": true,
+    "strictNullChecks": true,
+    "strict": true,
+    "lib": ["ES2018", "DOM"],
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Adds `plugins/obsidian-voicejournal/` — a full Obsidian plugin that records voice, transcribes via Whisper, asks follow-up questions via Claude, and saves structured journal entries with YAML frontmatter
- Sets up `content/` as an Obsidian vault root (gitignored journal entries and `.obsidian/` config)
- Adds `plugin:dev` / `plugin:build` scripts to root `package.json` for building the plugin from the repo root

## What the plugin does

1. **Record** — captures mic audio with silence detection (Web Audio API + MediaRecorder)
2. **Transcribe** — sends each silence-delimited chunk to OpenAI Whisper
3. **Follow-up** — asks Claude a depth-focused journaling question after each chunk
4. **Save** — classifies the full transcript (title, tags, mood, themes, summary) and writes a markdown note with YAML frontmatter to `content/journal/`
5. **Weekly digest** — scans the last 7 days of entries and generates a structured weekly review via Claude

## Test Plan

- [ ] `npm run plugin:build` succeeds with no TypeScript errors
- [ ] Open Obsidian → "Open folder as vault" → select `content/`
- [ ] Enable community plugins → VoiceJournal appears → enable it
- [ ] Mic icon appears in ribbon → click opens side panel
- [ ] Enter OpenAI + Anthropic API keys in plugin settings
- [ ] Press Record → speak → pause → transcript appears, follow-up question shown
- [ ] Press Stop → press Save → entry appears in `content/journal/` with correct frontmatter
- [ ] Press Weekly Digest → file created in `content/journal/weekly/`
- [ ] Confirm `content/journal/` is NOT committed (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)