### PR TITLE
Gallery perf: throttle, idle pause, framebuffer drops

### DIFF
--- a/components/art/sketch-host.tsx
+++ b/components/art/sketch-host.tsx
@@ -5,6 +5,7 @@ import type { SketchAPI } from "@/lib/art/types";
 import { mulberry32 } from "@/lib/art/rng";
 import { makeNoise } from "@/lib/art/noise";
 import { getSketch } from "@/lib/art/registry";
+import { shouldSkipThrottledFrame } from "@/lib/perf-flags";
 
 interface Props {
   slug: string;
@@ -125,6 +126,11 @@ export function SketchHost({ slug, seed, active }: Props) {
     function tickFrame() {
       rafId = 0;
       if (!activeRef.current || !api || !tick) return;
+      if (shouldSkipThrottledFrame(frame)) {
+        frame++;
+        rafId = requestAnimationFrame(tickFrame);
+        return;
+      }
       tick(api, frame++);
       rafId = requestAnimationFrame(tickFrame);
     }

--- a/components/canvas/metaball-canvas.tsx
+++ b/components/canvas/metaball-canvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { shouldSkipThrottledFrame } from "@/lib/perf-flags";
 
 const NUM_BALLS = 12;
 const PIXEL_SIZE = 6.0;
@@ -128,12 +129,16 @@ export function MetaballCanvas({
     let pointerActive = false;
     const balls: Ball[] = [];
 
+    // The shader pixelates in world coords via `uResolution`, so dropping
+    // the framebuffer below CSS resolution is invisible — visible blocks
+    // stay PIXEL_SIZE logical pixels per side regardless.
+    const RES_SCALE = 0.5;
     function resize() {
       w = canvas!.clientWidth;
       h = canvas!.clientHeight;
-      canvas!.width = w;
-      canvas!.height = h;
-      gl!.viewport(0, 0, w, h);
+      canvas!.width = Math.max(1, Math.round(w * RES_SCALE));
+      canvas!.height = Math.max(1, Math.round(h * RES_SCALE));
+      gl!.viewport(0, 0, canvas!.width, canvas!.height);
       const rect = canvas!.getBoundingClientRect();
       rectLeft = rect.left;
       rectTop = rect.top;
@@ -207,24 +212,17 @@ export function MetaballCanvas({
 
     let raf = 0;
     let isVisible = true; // IO below flips this on attach
+    let throttleFrame = 0;
     const t0 = performance.now();
-    // Metaball motion is slow enough that 40fps is indistinguishable from
-    // 60fps to the eye, but the fragment-shader cost (per-pixel
-    // smooth-min over N balls) is the heaviest continuously-running
-    // thing on the homepage. Throttling cuts its share of the frame
-    // budget by a third.
-    let lastTickTime = 0;
-    const MIN_TICK_INTERVAL = 25; // ms — ~40fps
 
     function tick() {
       raf = 0;
       if (!isVisible) return;
-      const now = performance.now();
-      if (now - lastTickTime < MIN_TICK_INTERVAL) {
+      if (shouldSkipThrottledFrame(++throttleFrame)) {
         raf = requestAnimationFrame(tick);
         return;
       }
-      lastTickTime = now;
+      const now = performance.now();
       const t = (now - t0) / 1000;
 
       // resolve attraction point (target prop wins over cursor)

--- a/components/canvas/particle-text-canvas.tsx
+++ b/components/canvas/particle-text-canvas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { shouldSkipThrottledFrame } from "@/lib/perf-flags";
 
 // Physics constants — kept as shader uniforms / constants where used
 const SPEED = 0.3;
@@ -234,6 +235,9 @@ interface ParticleTextCanvasProps {
   // Cursor repulsion radius in CSS pixels. Large hero values make the
   // cursor feel commanding; smaller values (~40–60) are right for thumbs.
   repelRadius?: number;
+  // Render at 1× CSS pixels instead of devicePixelRatio. Right for
+  // small thumbnails where retina sharpness isn't worth the 4× cost.
+  lowDpr?: boolean;
 }
 
 export function ParticleTextCanvas({
@@ -241,6 +245,7 @@ export function ParticleTextCanvas({
   hideText = false,
   pointSize = 1.0,
   repelRadius,
+  lowDpr = false,
 }: ParticleTextCanvasProps = {}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const textCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -252,7 +257,7 @@ export function ParticleTextCanvas({
     const glCanvas = glCanvasRef.current;
     if (!container || !textCanvas || !glCanvas) return;
 
-    const dpr = window.devicePixelRatio || 1;
+    const dpr = lowDpr ? 1 : (window.devicePixelRatio || 1);
     const picked = pickParticleCount();
     const PARTICLE_COUNT = countOverride ?? picked.count;
     const animate = picked.animate;
@@ -276,6 +281,7 @@ export function ParticleTextCanvas({
     let mouseY = -1;
     let activeIdx = 0;
     let particlesInitialized = false;
+    let throttleFrame = 0;
 
     // R8 letter mask in CSS pixels. Consulted at particle spawn so no
     // particle starts inside a glyph — the collision shader can't push
@@ -656,6 +662,10 @@ export function ParticleTextCanvas({
     function tick() {
       rafId = 0;
       if (!gl || !particlesInitialized || !textTexture || !isVisible) return;
+      if (animate && shouldSkipThrottledFrame(++throttleFrame)) {
+        rafId = requestAnimationFrame(tick);
+        return;
+      }
 
       const inIdx = activeIdx;
       // Static rendering for prefers-reduced-motion: skip the physics pass
@@ -778,7 +788,7 @@ export function ParticleTextCanvas({
       glCanvas.removeEventListener("webglcontextrestored", onContextRestored);
       teardownGL();
     };
-  }, [countOverride, hideText, pointSize, repelRadius]);
+  }, [countOverride, hideText, pointSize, repelRadius, lowDpr]);
 
   return (
     <div

--- a/components/canvas/voronoi-canvas.tsx
+++ b/components/canvas/voronoi-canvas.tsx
@@ -270,6 +270,10 @@ interface VoronoiCanvasProps {
   mobileImageSrc?: string;
   scale?: number;
   fit?: "contain" | "cover";
+  // Internal-framebuffer scale relative to the CSS box. Drop below 1
+  // for thumbnails / chunky-cell uses where the bilinear upscale is
+  // invisible.
+  renderScale?: number;
 }
 
 function parseHex(hex: string) {
@@ -280,7 +284,7 @@ function parseHex(hex: string) {
   ];
 }
 
-export function VoronoiCanvas({ invert = false, showLetters = true, imageSrc, mobileImageSrc, scale, fit = "contain" }: VoronoiCanvasProps) {
+export function VoronoiCanvas({ invert = false, showLetters = true, imageSrc, mobileImageSrc, scale, fit = "contain", renderScale = 1 }: VoronoiCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
   useEffect(() => {
@@ -427,8 +431,8 @@ export function VoronoiCanvas({ invert = false, showLetters = true, imageSrc, mo
 
     function resize() {
       if (!canvas) return;
-      canvas.width = canvas.offsetWidth;
-      canvas.height = canvas.offsetHeight;
+      canvas.width = Math.max(1, Math.round(canvas.offsetWidth * renderScale));
+      canvas.height = Math.max(1, Math.round(canvas.offsetHeight * renderScale));
       gl!.viewport(0, 0, canvas.width, canvas.height);
       gl!.uniform2f(uResolution, canvas.width, canvas.height);
 
@@ -504,7 +508,7 @@ export function VoronoiCanvas({ invert = false, showLetters = true, imageSrc, mo
       gl.deleteBuffer(buf);
       if (texture) gl.deleteTexture(texture);
     };
-  }, [invert, imageSrc, mobileImageSrc, showLetters, scale, fit]);
+  }, [invert, imageSrc, mobileImageSrc, showLetters, scale, fit, renderScale]);
 
   return (
     <canvas

--- a/components/gallery/gallery.tsx
+++ b/components/gallery/gallery.tsx
@@ -8,6 +8,7 @@ import { ParticleTextCanvas } from "@/components/canvas/particle-text-canvas";
 import { SketchHost } from "@/components/art/sketch-host";
 import { EmojiCardBg } from "@/components/messages/emoji-card-bg";
 import { DanaLabel } from "@/components/messages/dana-label";
+import { setCanvasThrottled } from "@/lib/perf-flags";
 
 const HERO_MAP: Record<string, () => ReactNode> = {
   self: () => (
@@ -17,12 +18,13 @@ const HERO_MAP: Record<string, () => ReactNode> = {
       imageSrc="/assets/self-hero-mobile.png"
       scale={20}
       fit="cover"
+      renderScale={0.65}
     />
   ),
   deana: () => <EmojiCardBg />,
   shelf: () => <MetaballCanvas color={[0.91, 0.64, 0.09]} />,
   "anything-but-analog": () => (
-    <ParticleTextCanvas countOverride={10000} hideText pointSize={2} repelRadius={50} />
+    <ParticleTextCanvas countOverride={4000} hideText pointSize={2} repelRadius={50} lowDpr />
   ),
   // Under-construction routes preview their sketch background via
   // SketchHost — day30 (crowd walkers) for /thoughts and day25
@@ -123,8 +125,18 @@ export function Gallery() {
         measured = true;
       }
     }
-    const ro = new ResizeObserver(measure);
+    const ro = new ResizeObserver(() => {
+      measure();
+      wake();
+    });
     ro.observe(section);
+
+    function wake() {
+      if (!rafRef.current) {
+        lastRef.current = performance.now();
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    }
 
     function tick(now: number) {
       const dt = Math.min((now - lastRef.current) / 1000, 0.1);
@@ -150,6 +162,12 @@ export function Gallery() {
       offsetRef.current = ((offsetRef.current % stripW) + stripW) % stripW;
       strip!.style.transform = `translate3d(${-offsetRef.current}px,0,0)`;
 
+      const isMoving =
+        Math.abs(speedRef.current) > 0.5 ||
+        Math.abs(drag.velocity) > 0.5 ||
+        drag.active;
+      setCanvasThrottled(isMoving);
+
       // Virtualization window update. Stride = one card + gap; the visible
       // slice of the strip is [offset, offset + sectionW]. We expand it by
       // LOOKAHEAD cards on each side, convert to card indices, and clamp
@@ -173,13 +191,28 @@ export function Gallery() {
         }
       }
 
+      // Stop scheduling the rAF when the strip has settled — wake()
+      // restarts it on any input that resumes motion.
+      const isIdle =
+        targetSpeedRef.current === 0 &&
+        speedRef.current === 0 &&
+        Math.abs(drag.velocity) < 0.5 &&
+        !drag.active;
+      if (isIdle) {
+        rafRef.current = 0;
+        setCanvasThrottled(false);
+        return;
+      }
       rafRef.current = requestAnimationFrame(tick);
     }
 
     rafRef.current = requestAnimationFrame(tick);
 
     function onEnter() { targetSpeedRef.current = 0; }
-    function onLeave() { targetSpeedRef.current = SPEED; }
+    function onLeave() {
+      targetSpeedRef.current = SPEED;
+      wake();
+    }
 
     function onDown(e: PointerEvent) {
       didDrag.current = false;
@@ -191,6 +224,7 @@ export function Gallery() {
         lastTime: performance.now(),
         velocity: 0,
       };
+      wake();
     }
 
     function onMove(e: PointerEvent) {
@@ -214,6 +248,7 @@ export function Gallery() {
         e.preventDefault();
         dragRef.current.velocity = 0;
         offsetRef.current += e.deltaX;
+        wake();
       }
     }
 
@@ -235,6 +270,8 @@ export function Gallery() {
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onUp);
       section.removeEventListener("wheel", onWheel);
+      // Release the throttle so sketches/canvases on the next route run at full rate.
+      setCanvasThrottled(false);
     };
   }, []);
 
@@ -306,7 +343,7 @@ export function Gallery() {
               )}
               <span
                 data-card-label
-                className="absolute bottom-5 left-5 z-10 rounded-2xl px-4 py-2 font-mono text-3xl font-bold uppercase tracking-[0.3em] transition-colors duration-300"
+                className="absolute bottom-5 left-5 z-10 rounded-2xl p-2.5 font-mono text-xl font-bold uppercase tracking-[0.3em] transition-colors duration-300 lg:text-2xl"
                 style={{ backgroundColor: "var(--black)", color: "var(--white)" }}
               >
                 {LABEL_MAP[item.handle]?.() || item.label}

--- a/lib/perf-flags.ts
+++ b/lib/perf-flags.ts
@@ -1,0 +1,14 @@
+// Module-level flag the gallery sets while its strip is translating, read
+// by hero canvases to skip alternate frames. Stays false on routes that
+// don't mount the gallery, so heroes used elsewhere tick at full rate.
+let canvasThrottled = false;
+
+export const isCanvasThrottled = () => canvasThrottled;
+
+export const setCanvasThrottled = (v: boolean) => {
+  if (canvasThrottled === v) return;
+  canvasThrottled = v;
+};
+
+export const shouldSkipThrottledFrame = (frame: number) =>
+  canvasThrottled && (frame & 1) === 1;


### PR DESCRIPTION
## Summary
- New \`lib/perf-flags.ts\` module: gallery sets \`isCanvasThrottled\` while the strip translates; metaball / particle-text / sketch-host (covers day30) skip alternate frames via shared \`shouldSkipThrottledFrame(frame)\` helper.
- Gallery rAF pauses when fully idle (target=0, speed=0, no drag inertia). \`wake()\` restarts on hover-leave / pointerdown / wheel / resize.
- Voronoi gains \`renderScale\` prop (default 1, so existing callers unchanged); gallery card opts into 0.65×.
- Metaball framebuffer drops to 0.5× — its shader pixelates in world coords so the bilinear upscale is invisible. The old 40fps throttle is gone (now back to 60fps), restoring snappiness on hover-track.
- ParticleTextCanvas gains \`lowDpr\`; analog gallery card drops countOverride 10k → 4k and opts into lowDpr.
- Gallery card title scaled down (text-xl lg:text-2xl, unified p-2.5) so "THOUGHTS" doesn't overflow.

## Test plan
- [ ] Homepage gallery: visual scroll, hover-pause, drag inertia, idle parking — all still smooth
- [ ] /canvas/[handle] hero (uses VoronoiCanvas) — still crisp at default renderScale=1
- [ ] /thoughts background day30 — runs at full rate (gallery flag stays false there)
- [ ] /anything-but-analog hero particles — full retina, full count (only the gallery card opts in to lowDpr / 4k)
- [ ] /shelf metaballs — back at 60fps, no banding from 0.5× framebuffer