### PR TITLE
Spacing system: multiples-of-3 scale (1.5/3/6/9/12/18/24/36)

### DIFF
--- a/app/anything-but-analog/[slug]/page.tsx
+++ b/app/anything-but-analog/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function SketchPage({ params }: Props) {
   const target = `/anything-but-analog#${sketch.slug}`;
   return (
     <main
-      className="flex h-[100dvh] items-center justify-center"
+      className="flex h-dvh items-center justify-center"
       style={{ backgroundColor: "var(--black)", color: "var(--white)" }}
     >
       <ArtRedirect target={target} />

--- a/app/anything-but-analog/page.tsx
+++ b/app/anything-but-analog/page.tsx
@@ -21,14 +21,14 @@ export default function AnythingButAnalogPage() {
   return (
     <main
       id="art-scroller"
-      className="h-[100dvh] snap-y snap-mandatory overflow-y-scroll"
+      className="h-dvh snap-y snap-mandatory overflow-y-scroll"
       style={{ backgroundColor: "var(--black)" }}
     >
       <ArtScrollSync />
       <section
         id="hero"
         data-art-slug="hero"
-        className="relative h-[100dvh] w-full snap-start overflow-hidden"
+        className="relative h-dvh w-full snap-start overflow-hidden"
       >
         <ParticleTextCanvas />
       </section>

--- a/app/anything-but-analog/raw/[slug]/page.tsx
+++ b/app/anything-but-analog/raw/[slug]/page.tsx
@@ -35,7 +35,7 @@ export default async function RawSketchPage({ params }: Props) {
   if (!sketch) notFound();
 
   return (
-    <main className="relative h-[100dvh] w-full overflow-hidden" style={{ backgroundColor: "var(--black)" }}>
+    <main className="relative h-dvh w-full overflow-hidden" style={{ backgroundColor: "var(--black)" }}>
       <SketchHost slug={sketch.slug} active />
       <div className="pointer-events-none absolute inset-x-0 top-6 z-10 flex items-baseline justify-between px-6 font-mono text-xs uppercase tracking-[0.25em] md:top-10 md:px-10 md:text-sm">
         <Link

--- a/app/anything-but-analog/raw/[slug]/page.tsx
+++ b/app/anything-but-analog/raw/[slug]/page.tsx
@@ -37,7 +37,7 @@ export default async function RawSketchPage({ params }: Props) {
   return (
     <main className="relative h-dvh w-full overflow-hidden" style={{ backgroundColor: "var(--black)" }}>
       <SketchHost slug={sketch.slug} active />
-      <div className="pointer-events-none absolute inset-x-0 top-6 z-10 flex items-baseline justify-between px-6 font-mono text-xs uppercase tracking-[0.25em] md:top-10 md:px-10 md:text-sm">
+      <div className="pointer-events-none absolute inset-x-0 top-6 z-10 flex items-baseline justify-between px-6 font-mono text-xs uppercase tracking-[0.25em] md:top-9 md:px-9 md:text-sm">
         <Link
           href="/anything-but-analog"
           className="pointer-events-auto transition-opacity hover:opacity-60"

--- a/app/benny/page.tsx
+++ b/app/benny/page.tsx
@@ -36,7 +36,7 @@ export default async function BennyPage() {
             remembering
           </h2>
           <h1
-            className="mt-4 font-mono text-3xl font-bold uppercase tracking-[0.1em] md:text-6xl"
+            className="mt-3 font-mono text-3xl font-bold uppercase tracking-[0.1em] md:text-6xl"
             style={{ color: "var(--white)" }}
           >
             102 Jackson Street
@@ -44,8 +44,8 @@ export default async function BennyPage() {
         </div>
       </section>
 
-      <section className="pt-12 md:pt-16">
-        <h3 className="mb-4 px-6 font-mono text-sm font-bold uppercase tracking-[0.22em] text-[var(--coin)] md:px-8">
+      <section className="pt-12 md:pt-18">
+        <h3 className="mb-3 px-6 font-mono text-sm font-bold uppercase tracking-[0.22em] text-[var(--coin)] md:px-9">
           playlists
         </h3>
         <PlaylistSlider playlists={BENNY_PLAYLISTS} />
@@ -53,18 +53,18 @@ export default async function BennyPage() {
 
       {markdown && (
         <section>
-          <div className="mx-auto max-w-3xl px-6 py-20 md:px-8 md:py-28">
+          <div className="mx-auto max-w-3xl px-6 py-18 md:px-9 md:py-24">
             <Prose content={markdown} />
           </div>
         </section>
       )}
 
-      <section className="pb-16">
+      <section className="pb-18">
         <div className="mx-auto flex w-max flex-col items-center rounded-2xl border border-zinc-700 p-6 shadow-[inset_0_0_2px_black]">
           <h3 className="m-0 font-mono text-sm font-bold uppercase tracking-[0.22em] text-[var(--coin)]">
             Social Links
           </h3>
-          <span className="mt-1 text-xs text-zinc-400">(archived)</span>
+          <span className="mt-1.5 text-xs text-zinc-400">(archived)</span>
           <div className="mt-3 flex h-12 flex-row items-center gap-6">
             <a
               href="https://www.facebook.com/pages/Six-to-Midnight-Production-Studios/166143110389253"
@@ -77,7 +77,7 @@ export default async function BennyPage() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="h-10 w-10"
+                className="h-9 w-9"
                 aria-hidden="true"
               >
                 <path d="M22 12c0-5.523-4.477-10-10-10S2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.878v-6.987h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.988C18.343 21.128 22 16.991 22 12Z" />
@@ -94,7 +94,7 @@ export default async function BennyPage() {
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
                 fill="currentColor"
-                className="h-10 w-10"
+                className="h-9 w-9"
                 aria-hidden="true"
               >
                 <path d="M12 2.163c3.204 0 3.584.012 4.85.07 1.366.062 2.633.336 3.608 1.311.975.975 1.249 2.242 1.311 3.608.058 1.266.069 1.646.069 4.85s-.011 3.584-.069 4.85c-.062 1.366-.336 2.633-1.311 3.608-.975.975-2.242 1.249-3.608 1.311-1.266.058-1.646.069-4.85.069s-3.584-.011-4.85-.069c-1.366-.062-2.633-.336-3.608-1.311-.975-.975-1.249-2.242-1.311-3.608C2.175 15.747 2.163 15.367 2.163 12s.012-3.584.07-4.85c.062-1.366.336-2.633 1.311-3.608.975-.975 2.242-1.249 3.608-1.311C8.416 2.175 8.796 2.163 12 2.163Zm0 1.802c-3.141 0-3.5.012-4.732.069-1.018.046-1.926.21-2.633.917-.708.708-.871 1.616-.917 2.633C3.66 8.5 3.648 8.859 3.648 12c0 3.141.012 3.5.069 4.732.046 1.018.21 1.926.917 2.633.708.708 1.616.871 2.633.917 1.232.057 1.591.069 4.732.069s3.5-.012 4.732-.069c1.018-.046 1.926-.21 2.633-.917.708-.708.871-1.616.917-2.633.057-1.232.069-1.591.069-4.732s-.012-3.5-.069-4.732c-.046-1.018-.21-1.926-.917-2.633-.708-.708-1.616-.871-2.633-.917C15.5 3.977 15.141 3.965 12 3.965Zm0 3.063A4.973 4.973 0 1 0 12 17a4.973 4.973 0 0 0 0-9.972Zm0 8.205a3.232 3.232 0 1 1 0-6.464 3.232 3.232 0 0 1 0 6.464ZM18.406 6.78a1.163 1.163 0 1 0-.001-2.327 1.163 1.163 0 0 0 .001 2.327Z" />

--- a/app/canvas/[handle]/page.tsx
+++ b/app/canvas/[handle]/page.tsx
@@ -48,7 +48,7 @@ export default async function CanvasPage({ params }: Props) {
   return (
     <div className="canvas-snap">
       <div
-        className={`relative w-full overflow-hidden ${heroImage ? "h-[100dvh]" : "h-[50dvh]"}`}
+        className={`relative w-full overflow-hidden ${heroImage ? "h-dvh" : "h-[50dvh]"}`}
       >
         {heroType === "voronoi" ? (
           <>

--- a/app/canvas/[handle]/page.tsx
+++ b/app/canvas/[handle]/page.tsx
@@ -69,7 +69,7 @@ export default async function CanvasPage({ params }: Props) {
 
       {markdown && (
         <section
-          className="tier-essay mx-auto max-w-3xl px-6 py-16 md:px-8 md:py-24"
+          className="tier-essay mx-auto max-w-3xl px-6 py-12 md:px-9 md:py-24"
           style={{ color: "var(--black)" }}
         >
           <Prose

--- a/app/case-studies/cro-ecommerce-systems/page.tsx
+++ b/app/case-studies/cro-ecommerce-systems/page.tsx
@@ -2,14 +2,14 @@ import Link from "next/link";
 
 export default function CroEcommerceSystemsPage() {
   return (
-    <main className="mx-auto min-h-screen max-w-4xl px-6 py-14 md:px-8">
+    <main className="mx-auto min-h-screen max-w-4xl px-6 py-12 md:px-9">
       <Link href="/resonance" className="text-xs text-zinc-400 hover:text-zinc-200">
         ← back to resonance
       </Link>
-      <h1 className="mt-5 text-3xl font-semibold text-zinc-100">
+      <h1 className="mt-6 text-3xl font-semibold text-zinc-100">
         CRO &amp; Ecommerce Systems
       </h1>
-      <p className="mt-5 text-sm leading-7 text-zinc-300 md:text-base">
+      <p className="mt-6 text-sm leading-7 text-zinc-300 md:text-base">
         Placeholder case study scaffold for experimentation frameworks,
         instrumentation strategies, and conversion system architecture.
       </p>

--- a/app/case-studies/generative-art-experiments/page.tsx
+++ b/app/case-studies/generative-art-experiments/page.tsx
@@ -2,14 +2,14 @@ import Link from "next/link";
 
 export default function GenerativeArtExperimentsPage() {
   return (
-    <main className="mx-auto min-h-screen max-w-4xl px-6 py-14 md:px-8">
+    <main className="mx-auto min-h-screen max-w-4xl px-6 py-12 md:px-9">
       <Link href="/signal" className="text-xs text-zinc-400 hover:text-zinc-200">
         ← back to signal
       </Link>
-      <h1 className="mt-5 text-3xl font-semibold text-zinc-100">
+      <h1 className="mt-6 text-3xl font-semibold text-zinc-100">
         Generative Art Experiments
       </h1>
-      <p className="mt-5 text-sm leading-7 text-zinc-300 md:text-base">
+      <p className="mt-6 text-sm leading-7 text-zinc-300 md:text-base">
         Placeholder case study scaffold for shader studies, procedural systems,
         and audio-reactive visual experiments.
       </p>

--- a/app/case-studies/made-in-cookware/page.tsx
+++ b/app/case-studies/made-in-cookware/page.tsx
@@ -2,14 +2,14 @@ import Link from "next/link";
 
 export default function MadeInCookwarePage() {
   return (
-    <main className="mx-auto min-h-screen max-w-4xl px-6 py-14 md:px-8">
+    <main className="mx-auto min-h-screen max-w-4xl px-6 py-12 md:px-9">
       <Link href="/resonance" className="text-xs text-zinc-400 hover:text-zinc-200">
         ← back to resonance
       </Link>
-      <h1 className="mt-5 text-3xl font-semibold text-zinc-100">
+      <h1 className="mt-6 text-3xl font-semibold text-zinc-100">
         Made In Cookware
       </h1>
-      <p className="mt-5 text-sm leading-7 text-zinc-300 md:text-base">
+      <p className="mt-6 text-sm leading-7 text-zinc-300 md:text-base">
         Placeholder case study scaffold for headless commerce implementation
         notes, architecture decisions, and performance learnings.
       </p>

--- a/app/case-studies/sixtom/page.tsx
+++ b/app/case-studies/sixtom/page.tsx
@@ -2,16 +2,16 @@ import Link from "next/link";
 
 export default function SixtomCaseStudyPage() {
   return (
-    <main className="mx-auto min-h-screen max-w-4xl px-6 py-14 md:px-8">
+    <main className="mx-auto min-h-screen max-w-4xl px-6 py-12 md:px-9">
       <Link href="/resonance" className="text-xs text-zinc-400 hover:text-zinc-200">
         ← back to resonance
       </Link>
 
-      <h1 className="mt-5 text-3xl font-semibold text-zinc-100">
+      <h1 className="mt-6 text-3xl font-semibold text-zinc-100">
         Sixtom — AI-driven ecommerce systems
       </h1>
 
-      <section className="section-shell mt-8 rounded-2xl p-6">
+      <section className="section-shell mt-9 rounded-2xl p-6">
         <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           problem
         </h2>
@@ -26,7 +26,7 @@ export default function SixtomCaseStudyPage() {
         <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           system architecture
         </h2>
-        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-7 text-zinc-300 md:text-base">
+        <ul className="mt-3 list-disc space-y-1.5 pl-6 text-sm leading-7 text-zinc-300 md:text-base">
           <li>Next.js application layer for storefront and internal tooling.</li>
           <li>Shopify commerce backbone for catalog, checkout, and operations.</li>
           <li>

--- a/app/dad/page.tsx
+++ b/app/dad/page.tsx
@@ -22,14 +22,14 @@ export default async function DadPage() {
           <AsciiImage srcs={["/assets/dad-1.jpg"]} className="h-full w-full" inverted />
         </LazyMount>
         <h1
-          className="pointer-events-none absolute bottom-6 left-6 z-10 font-mono text-3xl font-bold uppercase tracking-[0.1em] md:bottom-20 md:left-20 md:text-8xl"
+          className="pointer-events-none absolute bottom-6 left-6 z-10 font-mono text-3xl font-bold uppercase tracking-[0.1em] md:bottom-18 md:left-18 md:text-8xl"
           style={{ color: "var(--white)" }}
         >
           dad
         </h1>
       </section>
 
-      <section className="mx-auto max-w-3xl px-6 pb-24 pt-20 md:px-8 md:pt-32">
+      <section className="mx-auto max-w-3xl px-6 pb-24 pt-18 md:px-9 md:pt-36">
         <div className="tier-essay">
           {markdown ? (
             <Prose content={markdown} />

--- a/app/dad/page.tsx
+++ b/app/dad/page.tsx
@@ -17,7 +17,7 @@ export default async function DadPage() {
       className="min-h-screen bg-zinc-900"
       style={{ color: "var(--white)" }}
     >
-      <section className="relative h-[100dvh] w-full overflow-hidden bg-zinc-900">
+      <section className="relative h-dvh w-full overflow-hidden bg-zinc-900">
         <LazyMount className="absolute inset-0">
           <AsciiImage srcs={["/assets/dad-1.jpg"]} className="h-full w-full" inverted />
         </LazyMount>

--- a/app/deana/page.tsx
+++ b/app/deana/page.tsx
@@ -41,7 +41,7 @@ function ContentSection({ children }: { children: React.ReactNode }) {
 export default function DeanaPage() {
   return (
     <main
-      className="h-[100dvh] snap-y snap-proximity overflow-y-scroll"
+      className="h-dvh snap-y snap-proximity overflow-y-scroll"
       style={{ backgroundColor: "var(--white)" }}
     >
       <AsciiImageSection src={DEANA_IMAGES[0]} />

--- a/app/deana/page.tsx
+++ b/app/deana/page.tsx
@@ -14,11 +14,11 @@ export const metadata: Metadata = {
   description: "102,549 messages. 10 years. One conversation.",
 };
 
-const g = "gap-3 md:gap-4";
+const g = "gap-3 md:gap-6";
 
 function M({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
-    <div className={`rounded-3xl bg-white border border-zinc-200 p-5 md:p-6 ${className}`}>
+    <div className={`rounded-3xl bg-white border border-zinc-200 p-6 md:p-9 ${className}`}>
       {children}
     </div>
   );
@@ -30,7 +30,7 @@ function ContentSection({ children }: { children: React.ReactNode }) {
     // images, not the data cards. Content flows naturally between
     // (and past) the image sections.
     <section
-      className="w-full px-3 py-16 md:px-4 md:py-24"
+      className="w-full px-3 py-12 md:px-6 md:py-24"
       style={{ backgroundColor: "var(--white)" }}
     >
       <div className={`mx-auto w-full max-w-7xl flex flex-col ${g}`}>{children}</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,7 +9,7 @@ import { Gallery } from "@/components/gallery/gallery";
 // in-layout instead of pushing the page taller.
 export default function Home() {
   return (
-    <div className="flex h-[100dvh] w-full flex-col overflow-hidden">
+    <div className="flex h-dvh w-full flex-col overflow-hidden">
       <section className="relative h-[25dvh] w-full overflow-hidden">
         <CloudCanvas mirror />
       </section>

--- a/app/resonance/page.tsx
+++ b/app/resonance/page.tsx
@@ -34,23 +34,23 @@ const IMPACT_ITEMS = [
 
 export default function ResonancePage() {
   return (
-    <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-16 pt-20 md:px-8">
+    <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-18 pt-18 md:px-9">
       <h1 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         resonance
       </h1>
-      <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         the impact that reaches others and leaves the world better. experiences
         created for clients, generative pieces that move people, knowledge
         shared. value delivered.
       </p>
 
-      <div className="mt-8 grid gap-4 md:grid-cols-2">
+      <div className="mt-9 grid gap-3 md:grid-cols-2">
         {IMPACT_ITEMS.map((item) => (
           <WorkCard key={item.title} {...item} />
         ))}
       </div>
 
-      <section className="section-shell mt-12 rounded-2xl p-6 md:p-8">
+      <section className="section-shell mt-12 rounded-2xl p-6 md:p-9">
         <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           work with me
         </h2>

--- a/app/shelf/page.tsx
+++ b/app/shelf/page.tsx
@@ -26,7 +26,7 @@ function BookCover({ book, eager }: { book: Book; eager?: boolean }) {
       href={`https://www.goodreads.com/book/show/${book.id}`}
       target="_blank"
       rel="noopener noreferrer"
-      className="group relative block break-inside-avoid p-1 md:transition-[background-color,box-shadow] md:duration-300 md:ease-out md:hover:z-10 md:hover:bg-[var(--coin)] md:hover:shadow-[0_0_0_4px_var(--coin)]"
+      className="group relative block break-inside-avoid p-1.5 md:transition-[background-color,box-shadow] md:duration-300 md:ease-out md:hover:z-10 md:hover:bg-[var(--coin)] md:hover:shadow-[0_0_0_4px_var(--coin)]"
     >
       {book.coverUrl ? (
         <img
@@ -37,7 +37,7 @@ function BookCover({ book, eager }: { book: Book; eager?: boolean }) {
           className="block w-full md:transition-[filter] md:duration-300 md:group-hover:grayscale"
         />
       ) : (
-        <div className="flex aspect-[2/3] w-full items-center justify-center bg-zinc-900 p-3 text-center text-xs text-zinc-600">
+        <div className="flex aspect-2/3 w-full items-center justify-center bg-zinc-900 p-3 text-center text-xs text-zinc-600">
           {book.cleanTitle}
         </div>
       )}
@@ -65,7 +65,7 @@ export default async function ShelfPage() {
 
   return (
     <main
-      className="copy-lower min-h-screen pb-16"
+      className="copy-lower min-h-screen pb-18"
       style={{ background: "linear-gradient(to bottom, var(--black) 40%, var(--white))", color: "var(--white)" } as React.CSSProperties}
     >
       <ShelfHero featured={featured} featuredLabel={featuredLabel} />

--- a/app/shelf/page.tsx
+++ b/app/shelf/page.tsx
@@ -70,7 +70,7 @@ export default async function ShelfPage() {
     >
       <ShelfHero featured={featured} featuredLabel={featuredLabel} />
 
-      <section className="columns-4 gap-0 overflow-hidden py-1 sm:columns-6 md:columns-8 lg:columns-10 xl:columns-12">
+      <section className="columns-4 gap-0 overflow-hidden py-1.5 sm:columns-6 md:columns-8 lg:columns-10 xl:columns-12">
         {sorted.map((book, i) => (
           <BookCover key={book.id} book={book} eager={i < 24} />
         ))}

--- a/app/signal/page.tsx
+++ b/app/signal/page.tsx
@@ -27,18 +27,18 @@ const EXPERIMENTS = [
 export default function SignalPage() {
   return (
     <AudioReactiveProvider>
-      <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-16 pt-20 md:px-8">
+      <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-18 pt-18 md:px-9">
         <h1 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           signal
         </h1>
-        <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+        <p className="mt-3 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
           sound, visuals, generative art, philosophy. the creative output —
           what gets manifested from the expanses in my head. code is the current
           tool but being abstracted by ai — what remains is vision, logic, and
           taste.
         </p>
 
-        <div className="mt-8">
+        <div className="mt-9">
           <Link
             href="/"
             className="section-shell inline-block rounded-2xl p-6 transition hover:border-white/30 hover:bg-black/50"
@@ -46,7 +46,7 @@ export default function SignalPage() {
             <h3 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
               generative hero
             </h3>
-            <p className="mt-2 text-sm leading-7 text-zinc-400">
+            <p className="mt-1.5 text-sm leading-7 text-zinc-400">
               the living proof — interactive audio-reactive particle system
               on the homepage. play a track and watch it respond.
             </p>
@@ -59,19 +59,19 @@ export default function SignalPage() {
         <h2 className="mt-12 font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           experiments
         </h2>
-        <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        <div className="mt-3 grid gap-3 sm:grid-cols-2">
           {EXPERIMENTS.map((exp) => (
             <div
               key={exp.title}
-              className="section-shell rounded-2xl p-5"
+              className="section-shell rounded-2xl p-6"
             >
               <h3 className="font-mono text-xs uppercase tracking-[0.16em] text-zinc-200">
                 {exp.title}
               </h3>
-              <p className="mt-2 text-sm leading-6 text-zinc-400">
+              <p className="mt-1.5 text-sm leading-6 text-zinc-400">
                 {exp.description}
               </p>
-              <p className="mt-2 font-mono text-[10px] tracking-wider text-zinc-500">
+              <p className="mt-1.5 font-mono text-[10px] tracking-wider text-zinc-500">
                 {exp.tech}
               </p>
             </div>

--- a/app/sounds/page.tsx
+++ b/app/sounds/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default function SoundsPage() {
   return (
     <main
-      className="relative h-[100dvh] w-full overflow-hidden"
+      className="relative h-dvh w-full overflow-hidden"
       style={{ backgroundColor: "var(--black)" }}
     >
       <SketchHost slug="25" active />

--- a/app/source/page.tsx
+++ b/app/source/page.tsx
@@ -13,32 +13,32 @@ const entries = stepData.entries as StepEntry[];
 
 export default function SourcePage() {
   return (
-    <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-16 pt-20 md:px-8">
+    <main className="copy-lower mx-auto min-h-screen max-w-6xl px-6 pb-18 pt-18 md:px-9">
       <h1 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         source
       </h1>
-      <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         body, mind, 20 years of holistic discipline. maintain the source and
         the output takes care of itself. spiritual, multiverse-aware,
         comfortable being uncomfortable.
       </p>
 
-      <section className="section-shell mt-12 rounded-2xl p-6 md:p-8">
+      <section className="section-shell mt-12 rounded-2xl p-6 md:p-9">
         <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           daily movement
         </h2>
-        <p className="mt-3 mb-5 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+        <p className="mt-3 mb-6 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
           step tracking with calendar view, weekly totals, and annual trend.
           the discipline is the practice — not the metric.
         </p>
         <StepDashboard entries={entries} />
       </section>
 
-      <section className="section-shell mt-8 rounded-2xl p-6 md:p-8">
+      <section className="section-shell mt-9 rounded-2xl p-6 md:p-9">
         <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
           philosophy
         </h2>
-        <div className="mt-4 space-y-4 text-sm leading-7 text-zinc-400 md:text-base">
+        <div className="mt-3 space-y-3 text-sm leading-7 text-zinc-400 md:text-base">
           <p>
             the body is the instrument. if it&apos;s not tuned, nothing
             else matters — not the code, not the art, not the business.

--- a/app/thoughts/page.tsx
+++ b/app/thoughts/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default function ThoughtsPage() {
   return (
     <main
-      className="relative h-[100dvh] w-full overflow-hidden"
+      className="relative h-dvh w-full overflow-hidden"
       style={{ backgroundColor: "var(--black)" }}
     >
       <SketchHost slug="30" active />

--- a/components/art/art-gallery.tsx
+++ b/components/art/art-gallery.tsx
@@ -83,7 +83,7 @@ export function ArtGallery({ sketches, heroCount = 1, lookahead = 1, lookback = 
             key={s.slug}
             id={s.slug}
             data-art-slug={s.slug}
-            className="relative h-[100dvh] w-full snap-start overflow-hidden"
+            className="relative h-dvh w-full snap-start overflow-hidden"
             style={{ contentVisibility: "auto", containIntrinsicSize: "100dvh" }}
           >
             <SketchHost slug={s.slug} active={active} />

--- a/components/ascii/ascii-hero.tsx
+++ b/components/ascii/ascii-hero.tsx
@@ -17,14 +17,14 @@ export function AsciiHero({ src, heading, color = "white", position = "left" }: 
   const hClass = isCenter
     ? "left-1/2 -translate-x-1/2 text-center"
     : isRight
-      ? "right-6 text-right md:right-20"
-      : "left-6 md:left-20";
+      ? "right-6 text-right md:right-18"
+      : "left-6 md:left-18";
   const vClass = isBottom
-    ? "bottom-6 md:bottom-20"
-    : "top-6 md:top-20";
+    ? "bottom-6 md:bottom-18"
+    : "top-6 md:top-18";
 
   return (
-    <div className="relative my-12 -mx-6 md:mx-0 md:w-[768px] md:max-w-[768px] md:left-1/2 md:-translate-x-1/2 overflow-hidden md:rounded-lg" style={{ height: 400, backgroundColor: "var(--white)" }}>
+    <div className="relative my-12 -mx-6 overflow-hidden md:-mx-9 md:rounded-lg" style={{ height: 400, backgroundColor: "var(--white)" }}>
       <AsciiCanvas src={src} className="absolute inset-0" />
       <span
         className={`absolute ${vClass} ${hClass} font-mono text-2xl font-bold uppercase tracking-[0.1em] md:text-5xl`}

--- a/components/audio/hero-player.tsx
+++ b/components/audio/hero-player.tsx
@@ -146,13 +146,13 @@ export function HeroPlayer() {
       />
 
       {/* track selector — top of player area */}
-      <div className="pointer-events-auto mb-2 flex flex-wrap gap-1">
+      <div className="pointer-events-auto mb-1.5 flex flex-wrap gap-1.5">
         {TRACKS.map((t, i) => (
           <button
             key={t.src}
             type="button"
             onClick={() => switchTrack(i)}
-            className={`rounded-full px-2 py-1 font-mono text-[9px] tracking-[0.12em] transition ${
+            className={`rounded-full px-1.5 py-1.5 font-mono text-[9px] tracking-[0.12em] transition ${
               i === trackIndex
                 ? "bg-amber-200/20 text-amber-100"
                 : "text-zinc-500 hover:text-zinc-300"
@@ -183,7 +183,7 @@ export function HeroPlayer() {
           )}
         </button>
 
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <span className="shrink-0 font-mono text-[9px] text-zinc-500">
             {formatTime(progress)}
           </span>

--- a/components/audio/music-player.tsx
+++ b/components/audio/music-player.tsx
@@ -124,7 +124,7 @@ export function MusicPlayer() {
   };
 
   return (
-    <div className="space-y-4 rounded-xl border border-white/10 bg-black/35 p-5">
+    <div className="space-y-3 rounded-xl border border-white/10 bg-black/35 p-6">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <h3 className="font-mono text-sm uppercase tracking-[0.2em] text-zinc-300">
@@ -137,7 +137,7 @@ export function MusicPlayer() {
         </div>
       </div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap gap-1.5">
         {TRACKS.map((t, i) => (
           <button
             key={t.src}

--- a/components/audio/reactive-controls.tsx
+++ b/components/audio/reactive-controls.tsx
@@ -7,13 +7,13 @@ export function ReactiveControls() {
     useAudioReactive();
 
   return (
-    <div className="space-y-4 rounded-xl border border-white/10 bg-black/35 p-5">
+    <div className="space-y-3 rounded-xl border border-white/10 bg-black/35 p-6">
       <h3 className="font-mono text-sm uppercase tracking-[0.2em] text-zinc-300">
         reaction controls
       </h3>
 
       <label className="block">
-        <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.15em] text-zinc-400">
+        <div className="mb-1.5 flex items-center justify-between text-xs uppercase tracking-[0.15em] text-zinc-400">
           <span>sensitivity</span>
           <span className="font-mono">{sensitivity.toFixed(2)}x</span>
         </div>
@@ -29,7 +29,7 @@ export function ReactiveControls() {
       </label>
 
       <label className="block">
-        <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.15em] text-zinc-400">
+        <div className="mb-1.5 flex items-center justify-between text-xs uppercase tracking-[0.15em] text-zinc-400">
           <span>smoothing</span>
           <span className="font-mono">{smoothing.toFixed(2)}</span>
         </div>
@@ -50,7 +50,7 @@ export function ReactiveControls() {
           setSensitivity(2);
           setSmoothing(0.94);
         }}
-        className="rounded-md border border-white/20 px-3 py-2 text-[11px] uppercase tracking-[0.16em] text-zinc-300 hover:border-white/40"
+        className="rounded-md border border-white/20 px-3 py-1.5 text-[11px] uppercase tracking-[0.16em] text-zinc-300 hover:border-white/40"
       >
         reset response
       </button>

--- a/components/benny/playlist-slider.tsx
+++ b/components/benny/playlist-slider.tsx
@@ -11,13 +11,13 @@ export function PlaylistSlider({ playlists }: Props) {
   return (
     <div className="relative">
       <div
-        className="flex snap-x snap-mandatory overflow-x-auto scroll-pl-6 pb-4 pr-6 md:scroll-pl-8 md:pr-8"
+        className="flex snap-x snap-mandatory overflow-x-auto scroll-pl-6 pb-3 pr-6 md:scroll-pl-9 md:pr-9"
         style={{ scrollbarWidth: "thin", scrollbarColor: "var(--coin) transparent" }}
       >
         {playlists.map((p) => (
           <div
             key={p.id}
-            className="snap-start overflow-hidden rounded-xl bg-zinc-800 ml-6 md:ml-8"
+            className="snap-start overflow-hidden rounded-xl bg-zinc-800 ml-6 md:ml-9"
             style={{ flex: `0 0 ${CARD_WIDTH}px`, height: `${CARD_HEIGHT}px` }}
           >
             <iframe

--- a/components/canvas/breakout.tsx
+++ b/components/canvas/breakout.tsx
@@ -10,7 +10,7 @@ interface BreakoutProps {
  */
 export function Breakout({ children }: BreakoutProps) {
   return (
-    <p className="my-16 text-2xl leading-snug text-foreground md:my-24 md:text-3xl md:leading-snug">
+    <p className="my-18 text-2xl leading-snug text-foreground md:my-24 md:text-3xl md:leading-snug">
       {children}
     </p>
   );

--- a/components/canvas/mood.tsx
+++ b/components/canvas/mood.tsx
@@ -18,7 +18,7 @@ export function Mood({ title, children }: MoodProps) {
       )}
 
       {/* Title — anchored to the bottom, floating over the visual */}
-      <h1 className="relative z-10 px-6 pb-12 font-mono text-sm tracking-[0.2em] text-foreground/70 md:px-10 md:pb-16 md:text-base">
+      <h1 className="relative z-10 px-6 pb-12 font-mono text-sm tracking-[0.2em] text-foreground/70 md:px-9 md:pb-18 md:text-base">
         {title}
       </h1>
     </section>

--- a/components/canvas/thoughts.tsx
+++ b/components/canvas/thoughts.tsx
@@ -11,8 +11,8 @@ interface ThoughtsProps {
  */
 export function Thoughts({ children }: ThoughtsProps) {
   return (
-    <section className="mx-auto max-w-2xl px-6 py-24 md:px-10 md:py-32">
-      <div className="space-y-8 text-base leading-[1.9] text-foreground/80 md:text-lg md:leading-[2]">
+    <section className="mx-auto max-w-2xl px-6 py-24 md:px-9 md:py-36">
+      <div className="space-y-9 text-base leading-[1.9] text-foreground/80 md:text-lg md:leading-[2]">
         {children}
       </div>
     </section>

--- a/components/canvas/voronoi-image.tsx
+++ b/components/canvas/voronoi-image.tsx
@@ -59,7 +59,7 @@ export function VoronoiImage({ src, alt }: VoronoiImageProps) {
 
   return (
     <div
-      className="relative my-8 rounded-lg overflow-hidden w-full md:w-[768px] md:max-w-[768px] md:left-1/2 md:-translate-x-1/2"
+      className="relative my-9 -mx-6 w-full overflow-hidden rounded-lg md:-mx-9"
       style={{ aspectRatio: aspect }}
     >
       <VoronoiCanvas imageSrc={src} invert showLetters={false} />

--- a/components/counters/counter-overview.tsx
+++ b/components/counters/counter-overview.tsx
@@ -35,11 +35,11 @@ export function CounterOverview() {
   }, []);
 
   return (
-    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-8">
+    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-9">
       <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         network counters
       </h2>
-      <div className="mt-5 grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
+      <div className="mt-6 grid grid-cols-1 gap-3 text-sm md:grid-cols-3">
         <CounterTile label="total visitors" value={counters.totalVisitors} />
         <CounterTile
           label="generative art viewers"
@@ -53,11 +53,11 @@ export function CounterOverview() {
 
 function CounterTile({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-xl border border-white/10 bg-black/30 px-4 py-4">
+    <div className="rounded-xl border border-white/10 bg-black/30 p-3">
       <div className="font-mono text-[11px] uppercase tracking-[0.18em] text-zinc-400">
         {label}
       </div>
-      <div className="mt-2 text-2xl font-semibold text-zinc-100">{value}</div>
+      <div className="mt-1.5 text-2xl font-semibold text-zinc-100">{value}</div>
     </div>
   );
 }

--- a/components/fitness/step-dashboard.tsx
+++ b/components/fitness/step-dashboard.tsx
@@ -21,17 +21,17 @@ export function StepDashboard({ entries }: StepDashboardProps) {
   const maxMonthly = Math.max(1, ...monthlyTotals.map((month) => month.total));
 
   return (
-    <div className="space-y-7 rounded-xl border border-white/10 bg-black/35 p-5">
+    <div className="space-y-6 rounded-xl border border-white/10 bg-black/35 p-6">
       <div>
         <h3 className="font-mono text-sm uppercase tracking-[0.2em] text-zinc-300">
           step calendar (last 12 weeks)
         </h3>
-        <div className="mt-4 grid grid-cols-12 gap-1.5">
+        <div className="mt-3 grid grid-cols-12 gap-1.5">
           {last84Days.map((date) => (
             <div
               key={date}
               title={`${date}: ${lookup.get(date) ?? 0} steps`}
-              className={`h-4 rounded-sm ${intensityClass(lookup.get(date) ?? 0)}`}
+              className={`h-3 rounded-sm ${intensityClass(lookup.get(date) ?? 0)}`}
             />
           ))}
         </div>
@@ -41,13 +41,13 @@ export function StepDashboard({ entries }: StepDashboardProps) {
         <h3 className="font-mono text-sm uppercase tracking-[0.2em] text-zinc-300">
           weekly totals
         </h3>
-        <div className="mt-3 grid gap-2 md:grid-cols-3">
+        <div className="mt-3 grid gap-1.5 md:grid-cols-3">
           {weeklyTotals.map((week) => (
             <div key={week.label} className="rounded-lg border border-white/10 p-3">
               <p className="font-mono text-[10px] uppercase tracking-[0.16em] text-zinc-400">
                 {week.label}
               </p>
-              <p className="mt-1 text-lg font-semibold text-zinc-100">
+              <p className="mt-1.5 text-lg font-semibold text-zinc-100">
                 {week.total.toLocaleString()} steps
               </p>
             </div>
@@ -59,11 +59,11 @@ export function StepDashboard({ entries }: StepDashboardProps) {
         <h3 className="font-mono text-sm uppercase tracking-[0.2em] text-zinc-300">
           yearly trend
         </h3>
-        <div className="mt-4 flex items-end gap-2">
+        <div className="mt-3 flex items-end gap-1.5">
           {monthlyTotals.map((month) => {
             const height = Math.max(8, (month.total / maxMonthly) * 110);
             return (
-              <div key={month.month} className="flex w-full flex-col items-center gap-1">
+              <div key={month.month} className="flex w-full flex-col items-center gap-1.5">
                 <div
                   className="w-full rounded-sm bg-gradient-to-t from-orange-600/70 to-amber-300/90"
                   style={{ height: `${height}px` }}

--- a/components/gallery/gallery.tsx
+++ b/components/gallery/gallery.tsx
@@ -342,7 +342,7 @@ export function Gallery() {
               )}
               <span
                 data-card-label
-                className="absolute bottom-5 left-5 z-10 rounded-2xl p-2.5 font-mono text-xl font-bold uppercase tracking-[0.3em] transition-colors duration-300 lg:text-2xl"
+                className="absolute bottom-6 left-6 z-10 rounded-2xl p-3 font-mono text-xl font-bold uppercase tracking-[0.3em] transition-colors duration-300 lg:text-2xl"
                 style={{ backgroundColor: "var(--black)", color: "var(--white)" }}
               >
                 {LABEL_MAP[item.handle]?.() || item.label}

--- a/components/lazy-mount.tsx
+++ b/components/lazy-mount.tsx
@@ -7,7 +7,7 @@ interface Props {
   /**
    * Minimum height reserved while the child isn't yet mounted. Prefer not
    * setting this when the parent already reserves space (e.g. a
-   * `min-h-[100dvh]` section). Default: no reserved height.
+   * `min-h-dvh` section). Default: no reserved height.
    */
   placeholderMinHeight?: string;
   /** How early to mount before visible. Config — not a dep. */

--- a/components/link.tsx
+++ b/components/link.tsx
@@ -1,2 +1,2 @@
 export const linkClasses =
-  "border-b-2 border-[var(--coin)] pb-1 hover:pb-0.5 motion-safe:hover:animate-[link-glitch_2s_ease-in-out_infinite] transition-[padding-bottom] duration-300";
+  "border-b-2 border-[var(--coin)] pb-1.5 hover:pb-0 motion-safe:hover:animate-[link-glitch_2s_ease-in-out_infinite] transition-[padding-bottom] duration-300";

--- a/components/messages/ascii-image-section.tsx
+++ b/components/messages/ascii-image-section.tsx
@@ -23,7 +23,7 @@ export function AsciiImageSection({ src, altSrcs }: Props) {
 
   return (
     <section
-      className="relative h-[100dvh] w-full snap-start overflow-hidden"
+      className="relative h-dvh w-full snap-start overflow-hidden"
       style={{
         backgroundColor: "var(--white)",
         contentVisibility: "auto",

--- a/components/messages/clock-heatmap.tsx
+++ b/components/messages/clock-heatmap.tsx
@@ -42,11 +42,11 @@ export function ClockHeatmap() {
           </div>
           {/* Grid */}
           {DAYS.map((day, dow) => (
-            <div key={day} className="flex items-center gap-1.5 mb-[2px]">
+            <div key={day} className="flex items-center gap-1.5 mb-px">
               <span className="w-7 font-mono text-[9px] text-zinc-500 text-right">
                 {day}
               </span>
-              <div className="flex flex-1 gap-[2px]">
+              <div className="flex flex-1 gap-px">
                 {Array.from({ length: 24 }, (_, h) => (
                   <div
                     key={h}

--- a/components/messages/clock-heatmap.tsx
+++ b/components/messages/clock-heatmap.tsx
@@ -19,7 +19,7 @@ function cellColor(val: number) {
 export function ClockHeatmap() {
   return (
     <div>
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-3 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           when we talked
         </span>
@@ -30,7 +30,7 @@ export function ClockHeatmap() {
       <div className="overflow-x-auto">
         <div className="min-w-150">
           {/* Hour labels */}
-          <div className="mb-1 flex" style={{ paddingLeft: 32 }}>
+          <div className="mb-1.5 flex" style={{ paddingLeft: 32 }}>
             {Array.from({ length: 24 }, (_, h) => (
               <span
                 key={h}
@@ -42,7 +42,7 @@ export function ClockHeatmap() {
           </div>
           {/* Grid */}
           {DAYS.map((day, dow) => (
-            <div key={day} className="flex items-center gap-1 mb-[2px]">
+            <div key={day} className="flex items-center gap-1.5 mb-[2px]">
               <span className="w-7 font-mono text-[9px] text-zinc-500 text-right">
                 {day}
               </span>

--- a/components/messages/clock-heatmap.tsx
+++ b/components/messages/clock-heatmap.tsx
@@ -28,7 +28,7 @@ export function ClockHeatmap() {
         </span>
       </div>
       <div className="overflow-x-auto">
-        <div className="min-w-[600px]">
+        <div className="min-w-150">
           {/* Hour labels */}
           <div className="mb-1 flex" style={{ paddingLeft: 32 }}>
             {Array.from({ length: 24 }, (_, h) => (

--- a/components/messages/compliments.tsx
+++ b/components/messages/compliments.tsx
@@ -24,7 +24,7 @@ const maxTotal = ranked[0] ? ranked[0][1].sam + ranked[0][1].dia : 1;
 export function Compliments() {
   return (
     <div>
-      <div className="mb-5 flex items-baseline justify-between">
+      <div className="mb-6 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           compliments
         </span>
@@ -32,7 +32,7 @@ export function Compliments() {
           {(complimentsData.sam_total + complimentsData.dia_total).toLocaleString()} total
         </span>
       </div>
-      <div className="mb-4 grid grid-cols-2 gap-4">
+      <div className="mb-3 grid grid-cols-2 gap-3">
         <div className="rounded-lg border border-zinc-200 p-3 text-center">
           <p className="text-xl font-bold text-black">{complimentsData.sam_total}</p>
           <p className="font-mono text-[10px] text-zinc-500">from sam</p>
@@ -42,7 +42,7 @@ export function Compliments() {
           <p className="font-mono text-[10px] text-zinc-500">from dianchik</p>
         </div>
       </div>
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         {ranked.map(([theme, { sam: s, dia: d }]) => {
           const total = s + d;
           const samPct = (s / maxTotal) * 100;
@@ -67,7 +67,7 @@ export function Compliments() {
           );
         })}
       </div>
-      <div className="mt-3 flex gap-4">
+      <div className="mt-3 flex gap-3">
         <span className="flex items-center gap-1.5 font-mono text-[10px] text-zinc-500">
           <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: "rgba(0,0,0,0.4)" }} />
           sam

--- a/components/messages/compliments.tsx
+++ b/components/messages/compliments.tsx
@@ -49,11 +49,11 @@ export function Compliments() {
           const diaPct = (d / maxTotal) * 100;
           return (
             <div key={theme}>
-              <div className="flex items-center justify-between mb-0.5">
+              <div className="flex items-center justify-between mb-1.5">
                 <span className="font-mono text-[10px] text-zinc-400">{theme}</span>
                 <span className="font-mono text-[9px] text-zinc-400">{total}</span>
               </div>
-              <div className="flex h-2.5 gap-0.5 overflow-hidden rounded-full bg-zinc-100">
+              <div className="flex h-3 gap-px overflow-hidden rounded-full bg-zinc-100">
                 <div
                   className="rounded-full"
                   style={{ width: `${samPct}%`, backgroundColor: "rgba(0,0,0,0.4)" }}

--- a/components/messages/daily-firsts.tsx
+++ b/components/messages/daily-firsts.tsx
@@ -21,7 +21,7 @@ export function DailyFirsts() {
 
   return (
     <div>
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-3 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           first message of the day
         </span>
@@ -38,14 +38,14 @@ export function DailyFirsts() {
             <p className="text-sm leading-relaxed text-black line-clamp-2">
               &quot;{f.text}&quot;
             </p>
-            <p className="mt-2 font-mono text-[9px] text-zinc-500">
+            <p className="mt-1.5 font-mono text-[9px] text-zinc-500">
               {f.sender.split(" ")[0].toLowerCase()} — {f.date}, {f.hour}:{String(f.minute ?? 0).padStart(2, "0")}
             </p>
           </div>
         ))}
       </div>
       {totalPages > 1 && (
-        <div className="mt-4 flex items-center justify-center gap-3">
+        <div className="mt-3 flex items-center justify-center gap-3">
           <button
             onClick={() => setPage((p) => Math.max(0, p - 1))}
             disabled={page === 0}

--- a/components/messages/emoji-hero.tsx
+++ b/components/messages/emoji-hero.tsx
@@ -10,15 +10,15 @@ export function EmojiHero() {
   const [charIdx, setCharIdx] = useState(0);
 
   return (
-    <div className="relative h-[50dvh] w-full overflow-hidden mb-3 md:mb-4" style={{ backgroundColor: "var(--white)" }}>
+    <div className="relative h-[50dvh] w-full overflow-hidden mb-3" style={{ backgroundColor: "var(--white)" }}>
       <AsciiGallery
         srcs={DEANA_IMAGES}
         className="absolute inset-0"
         onIndexChange={(idx) => setCharIdx(idx % CHARS.length)}
       />
-      <div className="absolute inset-0 flex items-end justify-start pointer-events-none p-6 md:p-20">
+      <div className="absolute inset-0 flex items-end justify-start pointer-events-none p-6 md:p-18">
         <h1 className="font-mono text-2xl md:text-5xl font-bold tracking-[0.1em] uppercase text-black">
-          D<span className="inline-block w-6 md:w-10 text-center">{CHARS[charIdx]}</span>ANA
+          D<span className="inline-block w-6 md:w-9 text-center">{CHARS[charIdx]}</span>ANA
         </h1>
       </div>
     </div>

--- a/components/messages/emoji-meter.tsx
+++ b/components/messages/emoji-meter.tsx
@@ -13,7 +13,7 @@ const diaMax = dia[0]?.count ?? 1;
 function EmojiBar({ emoji, count, max, color }: { emoji: string; count: number; max: number; color: string }) {
   const pct = (count / max) * 100;
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1.5">
       <span className="text-sm w-5 text-center leading-none" style={{ fontFamily: "'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', sans-serif" }}>{emoji}</span>
       <div className="flex-1 h-3 rounded-full overflow-hidden bg-zinc-100">
         <div
@@ -31,7 +31,7 @@ export function EmojiMeter() {
 
   return (
     <div>
-      <div className="mb-5 flex items-baseline justify-between">
+      <div className="mb-6 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           emoji
         </span>

--- a/components/messages/first-night.tsx
+++ b/components/messages/first-night.tsx
@@ -27,10 +27,10 @@ export function FirstNight() {
         </span>
       </div>
       <p className="mb-3 font-mono text-[10px] text-zinc-500">{firstNight.date}</p>
-      <div className="space-y-2">
+      <div className="space-y-1.5">
         {firstNight.exchange.map((msg, i) =>
           msg.sender === "ellipsis" ? (
-            <div key={i} className="py-1 text-center font-mono text-[10px] text-zinc-400">
+            <div key={i} className="py-1.5 text-center font-mono text-[10px] text-zinc-400">
               ...
             </div>
           ) : (
@@ -39,7 +39,7 @@ export function FirstNight() {
               className={`flex ${msg.sender === "sam" ? "justify-end" : "justify-start"}`}
             >
               <div
-                className={`max-w-[85%] rounded-xl px-3 py-2 text-sm leading-relaxed ${
+                className={`max-w-[85%] rounded-xl px-3 py-1.5 text-sm leading-relaxed ${
                   msg.sender === "sam"
                     ? "bg-zinc-100 text-black"
                     : "bg-amber-50 text-black"

--- a/components/messages/love-timeline.tsx
+++ b/components/messages/love-timeline.tsx
@@ -16,8 +16,8 @@ export function LoveTimeline() {
   if (!firstSam && !firstDia) return null;
 
   return (
-    <div className="my-12 rounded-2xl border border-white/5 bg-black p-5 md:p-6">
-      <div className="mb-5 flex items-baseline justify-between">
+    <div className="my-12 rounded-2xl border border-white/5 bg-black p-6 md:p-9">
+      <div className="mb-6 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           &quot;i love you&quot;
         </span>
@@ -25,25 +25,25 @@ export function LoveTimeline() {
           {count.toLocaleString()} times
         </span>
       </div>
-      <div className="grid gap-4 sm:grid-cols-2">
+      <div className="grid gap-3 sm:grid-cols-2">
         {firstSam && (
-          <div className="rounded-lg border border-white/5 p-4">
+          <div className="rounded-lg border border-white/5 p-3">
             <span className="font-mono text-[10px] text-zinc-500">sam, first</span>
-            <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+            <p className="mt-1.5 text-sm leading-relaxed text-zinc-300">
               &quot;{firstSam.text}&quot;
             </p>
-            <p className="mt-2 font-mono text-[10px] text-zinc-500">
+            <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
               {firstSam.date}
             </p>
           </div>
         )}
         {firstDia && (
-          <div className="rounded-lg border border-white/5 p-4">
+          <div className="rounded-lg border border-white/5 p-3">
             <span className="font-mono text-[10px] text-zinc-500">dianchik, first</span>
-            <p className="mt-2 text-sm leading-relaxed text-zinc-300">
+            <p className="mt-1.5 text-sm leading-relaxed text-zinc-300">
               &quot;{firstDia.text}&quot;
             </p>
-            <p className="mt-2 font-mono text-[10px] text-zinc-500">
+            <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
               {firstDia.date}
             </p>
           </div>

--- a/components/messages/message-lengths.tsx
+++ b/components/messages/message-lengths.tsx
@@ -103,7 +103,7 @@ export function MessageLengths() {
 
   return (
     <div>
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-3 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           message length over time
         </span>
@@ -111,7 +111,7 @@ export function MessageLengths() {
           avg characters per message
         </span>
       </div>
-      <div className="flex gap-4 mb-4">
+      <div className="flex gap-3 mb-3">
         <span className="flex items-center gap-1.5 font-mono text-[10px] text-zinc-400">
           <span className="inline-block h-[2px] w-3" style={{ backgroundColor: "rgba(255,255,255,0.5)" }} />
           sam

--- a/components/messages/message-timeline.tsx
+++ b/components/messages/message-timeline.tsx
@@ -135,8 +135,8 @@ export function MessageTimeline() {
 
   return (
     <div>
-      <div className="mb-4 flex items-baseline justify-between">
-        <div className="flex gap-4">
+      <div className="mb-3 flex items-baseline justify-between">
+        <div className="flex gap-3">
           <button
             onClick={() => setTab("messages")}
             className={`font-mono text-xs tracking-[0.16em] transition-colors ${tab === "messages" ? "text-black" : "text-zinc-500 hover:text-zinc-600"}`}
@@ -154,7 +154,7 @@ export function MessageTimeline() {
           {total.toLocaleString()} total
         </span>
       </div>
-      <div className="flex gap-4 mb-4">
+      <div className="flex gap-3 mb-3">
         <span className="flex items-center gap-1.5 font-mono text-[10px] text-zinc-500">
           <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: DIA_COLOR }} />
           dianchik

--- a/components/messages/milestones.tsx
+++ b/components/messages/milestones.tsx
@@ -53,7 +53,7 @@ export function MilestoneCount() {
       <p className="mt-1.5 text-2xl font-bold text-black">
         {loveCount.toLocaleString()}
       </p>
-      <p className="mt-1 font-mono text-[10px] text-zinc-500">
+      <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
         times and counting
       </p>
     </div>

--- a/components/messages/milestones.tsx
+++ b/components/messages/milestones.tsx
@@ -17,10 +17,10 @@ export function MilestoneSam() {
       <span className="font-mono text-[10px] text-zinc-500">
         first &quot;love you&quot; — sam
       </span>
-      <p className="mt-2 text-sm leading-relaxed text-black">
+      <p className="mt-1.5 text-sm leading-relaxed text-black">
         &quot;{firstSam.text}&quot;
       </p>
-      <p className="mt-2 font-mono text-[10px] text-zinc-500">
+      <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
         {firstSam.date}
       </p>
     </div>
@@ -34,10 +34,10 @@ export function MilestoneDia() {
       <span className="font-mono text-[10px] text-zinc-500">
         first &quot;love you&quot; — dianchik
       </span>
-      <p className="mt-2 text-sm leading-relaxed text-black">
+      <p className="mt-1.5 text-sm leading-relaxed text-black">
         &quot;{firstDia.text}&quot;
       </p>
-      <p className="mt-2 font-mono text-[10px] text-zinc-500">
+      <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
         {firstDia.date}
       </p>
     </div>
@@ -50,7 +50,7 @@ export function MilestoneCount() {
       <span className="font-mono text-[10px] text-zinc-500">
         &quot;i love you&quot;
       </span>
-      <p className="mt-2 text-2xl font-bold text-black">
+      <p className="mt-1.5 text-2xl font-bold text-black">
         {loveCount.toLocaleString()}
       </p>
       <p className="mt-1 font-mono text-[10px] text-zinc-500">

--- a/components/messages/pet-names.tsx
+++ b/components/messages/pet-names.tsx
@@ -13,7 +13,7 @@ const diaMax = dia[0]?.count ?? 1;
 function NameBar({ name, count, max, color }: { name: string; count: number; max: number; color: string }) {
   const pct = (count / max) * 100;
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1.5">
       <span className="w-24 shrink-0 truncate text-left font-mono text-[10px] text-zinc-400">{name}</span>
       <div className="flex-1 h-3 rounded-full overflow-hidden bg-zinc-100">
         <div
@@ -31,7 +31,7 @@ export function PetNames() {
 
   return (
     <div>
-      <div className="mb-5 flex items-baseline justify-between">
+      <div className="mb-6 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           pet names
         </span>

--- a/components/messages/word-cloud.tsx
+++ b/components/messages/word-cloud.tsx
@@ -135,7 +135,7 @@ export function WordCloud() {
 
   return (
     <div>
-      <div className="mb-4 flex items-baseline justify-between">
+      <div className="mb-3 flex items-baseline justify-between">
         <span className="font-mono text-xs tracking-[0.16em] text-zinc-400">
           word cloud
         </span>

--- a/components/messages/word-stats.tsx
+++ b/components/messages/word-stats.tsx
@@ -5,7 +5,7 @@ export function TotalWords() {
   return (
     <div>
       <span className="font-mono text-[10px] text-zinc-500">words written</span>
-      <p className="mt-2 text-2xl font-bold text-black">
+      <p className="mt-1.5 text-2xl font-bold text-black">
         {total.toLocaleString()}
       </p>
       <div className="mt-3 space-y-1">
@@ -26,10 +26,10 @@ export function BusiestDay() {
   return (
     <div>
       <span className="font-mono text-[10px] text-zinc-500">busiest day</span>
-      <p className="mt-2 text-2xl font-bold text-black">
+      <p className="mt-1.5 text-2xl font-bold text-black">
         {wordsData.peak_messages.count}
       </p>
-      <p className="mt-1 font-mono text-[10px] text-zinc-500">
+      <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
         messages on {wordsData.peak_messages.date}
       </p>
     </div>
@@ -40,10 +40,10 @@ export function MostWords() {
   return (
     <div>
       <span className="font-mono text-[10px] text-zinc-500">most words in a day</span>
-      <p className="mt-2 text-2xl font-bold text-black">
+      <p className="mt-1.5 text-2xl font-bold text-black">
         {wordsData.peak_words.count.toLocaleString()}
       </p>
-      <p className="mt-1 font-mono text-[10px] text-zinc-500">
+      <p className="mt-1.5 font-mono text-[10px] text-zinc-500">
         words on {wordsData.peak_words.date}
       </p>
     </div>

--- a/components/messages/word-stats.tsx
+++ b/components/messages/word-stats.tsx
@@ -8,7 +8,7 @@ export function TotalWords() {
       <p className="mt-1.5 text-2xl font-bold text-black">
         {total.toLocaleString()}
       </p>
-      <div className="mt-3 space-y-1">
+      <div className="mt-3 space-y-1.5">
         <div className="flex justify-between font-mono text-[10px] text-zinc-500">
           <span>sam</span>
           <span>{wordsData.sam_total_words.toLocaleString()}</span>

--- a/components/nav.tsx
+++ b/components/nav.tsx
@@ -8,10 +8,10 @@ const INTERNAL_LINKS = [
 
 export function Nav() {
   return (
-    <nav className="fixed top-0 right-0 z-50 flex items-center gap-1 p-4 md:gap-2 md:p-6">
+    <nav className="fixed top-0 right-0 z-50 flex items-center gap-1.5 p-3 md:gap-3 md:p-6">
       <Link
         href="/"
-        className="mr-2 font-mono text-xs tracking-[0.16em] text-zinc-300 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:mr-4 md:text-sm"
+        className="mr-1.5 font-mono text-xs tracking-[0.16em] text-zinc-300 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:mr-3 md:text-sm"
       >
         threesam
       </Link>
@@ -19,7 +19,7 @@ export function Nav() {
         <Link
           key={link.href}
           href={link.href}
-          className="rounded-full px-2.5 py-1 font-mono text-[10px] tracking-[0.16em] text-zinc-400 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:text-xs"
+          className="rounded-full px-3 py-1.5 font-mono text-[10px] tracking-[0.16em] text-zinc-400 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:text-xs"
         >
           {link.label}
         </Link>
@@ -28,7 +28,7 @@ export function Nav() {
         href="https://sixtom.com"
         target="_blank"
         rel="noopener noreferrer"
-        className="rounded-full px-2.5 py-1 font-mono text-[10px] tracking-[0.16em] text-zinc-400 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:text-xs"
+        className="rounded-full px-3 py-1.5 font-mono text-[10px] tracking-[0.16em] text-zinc-400 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:text-xs"
       >
         studio ↗
       </a>

--- a/components/portfolio/work-card.tsx
+++ b/components/portfolio/work-card.tsx
@@ -11,7 +11,7 @@ export function WorkCard({ title, category, summary, href }: WorkCardProps) {
   return (
     <Link
       href={href}
-      className="group rounded-xl border border-white/10 bg-black/35 p-5 transition hover:border-white/30 hover:bg-black/50"
+      className="group rounded-xl border border-white/10 bg-black/35 p-6 transition hover:border-white/30 hover:bg-black/50"
     >
       <div className="font-mono text-[10px] uppercase tracking-[0.2em] text-zinc-400">
         {category}
@@ -19,8 +19,8 @@ export function WorkCard({ title, category, summary, href }: WorkCardProps) {
       <h3 className="title-up mt-3 text-lg font-semibold tracking-[0.06em] text-zinc-100">
         {title}
       </h3>
-      <p className="mt-2 text-sm leading-6 text-zinc-400">{summary}</p>
-      <span className="mt-4 inline-block text-xs text-zinc-300 group-hover:text-zinc-100">
+      <p className="mt-1.5 text-sm leading-6 text-zinc-400">{summary}</p>
+      <span className="mt-3 inline-block text-xs text-zinc-300 group-hover:text-zinc-100">
         open study →
       </span>
     </Link>

--- a/components/prose.tsx
+++ b/components/prose.tsx
@@ -17,9 +17,9 @@ md.use({
     heading({ tokens, depth }) {
       const text = this.parser.parseInline(tokens);
       if (depth === 1)
-        return `<h1 class="mb-10 font-mono text-4xl font-bold uppercase tracking-[0.1em] md:text-6xl">${text}</h1>`;
+        return `<h1 class="mb-9 font-mono text-4xl font-bold uppercase tracking-[0.1em] md:text-6xl">${text}</h1>`;
       if (depth === 2)
-        return `<h2 class="mb-6 mt-20 font-mono text-3xl font-bold uppercase tracking-[0.08em] md:mt-28 md:text-5xl">${text}</h2>`;
+        return `<h2 class="mb-6 mt-18 font-mono text-3xl font-bold uppercase tracking-[0.08em] md:mt-24 md:text-5xl">${text}</h2>`;
       return false;
     },
     paragraph({ tokens }) {
@@ -49,15 +49,15 @@ md.use({
         const isBottom = pos.startsWith('bottom');
         const isRight = pos.includes('right');
         const isCenter = pos.includes('center');
-        let hClass = 'left-6 md:left-20';
+        let hClass = 'left-6 md:left-18';
         if (isCenter) hClass = 'left-1/2 -translate-x-1/2 text-center';
-        else if (isRight) hClass = 'right-6 text-right md:right-20';
+        else if (isRight) hClass = 'right-6 text-right md:right-18';
         const vClass = isBottom
-          ? 'bottom-6 md:bottom-20'
-          : 'top-6 md:top-20';
-        return `<div class="relative my-12 -mx-6 md:mx-0 md:w-[768px] md:max-w-[768px] md:left-1/2 md:-translate-x-1/2"><img src="${href}" alt="${heading}" class="w-full md:rounded-lg" /><span class="absolute ${vClass} ${hClass} font-mono text-2xl font-bold uppercase tracking-[0.1em] md:text-5xl" style="color: ${color}">${heading}</span></div>`;
+          ? 'bottom-6 md:bottom-18'
+          : 'top-6 md:top-18';
+        return `<div class="relative my-12 -mx-6 md:-mx-9"><img src="${href}" alt="${heading}" class="w-full md:rounded-lg" /><span class="absolute ${vClass} ${hClass} font-mono text-2xl font-bold uppercase tracking-[0.1em] md:text-5xl" style="color: ${color}">${heading}</span></div>`;
       }
-      return `<img src="${href}" alt="${text ?? ''}" class="relative my-8 rounded-lg w-full md:w-[768px] md:max-w-[768px] md:left-1/2 md:-translate-x-1/2" />`;
+      return `<img src="${href}" alt="${text ?? ''}" class="relative my-9 -mx-6 block w-full rounded-lg md:-mx-9" />`;
     },
   },
 });

--- a/components/sections/bio-section.tsx
+++ b/components/sections/bio-section.tsx
@@ -1,11 +1,11 @@
 export function BioSection() {
   return (
-    <section className="mx-auto mt-12 max-w-6xl px-6 md:px-8">
+    <section className="mx-auto mt-12 max-w-6xl px-6 md:px-9">
       <p className="max-w-3xl font-mono text-sm leading-7 text-zinc-300 md:text-base">
         artist-engineer creating at the intersection of sound, code, and human
         performance.
       </p>
-      <p className="mt-4 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         maintain the source. create the signal. let it resonate.
       </p>
     </section>

--- a/components/sections/discipline-section.tsx
+++ b/components/sections/discipline-section.tsx
@@ -6,11 +6,11 @@ const entries = stepData.entries as StepEntry[];
 
 export function DisciplineSection() {
   return (
-    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-8">
+    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-9">
       <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         fitness / discipline
       </h2>
-      <p className="mt-3 mb-5 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 mb-6 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         Daily step tracking with calendar view, weekly totals, and annual trend
         bars. Data is currently mock JSON and can be replaced with real exports
         later.

--- a/components/sections/music-section.tsx
+++ b/components/sections/music-section.tsx
@@ -3,16 +3,16 @@ import { MusicPlayer } from "@/components/audio/music-player";
 
 export function MusicSection() {
   return (
-    <section className="section-shell rounded-2xl p-6 md:p-8">
+    <section className="section-shell rounded-2xl p-6 md:p-9">
       <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         audio system
       </h2>
-      <p className="mt-3 mb-5 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 mb-6 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         local audio, direct web audio analysis, and a visualizer pipeline that
         drives the generative system in real time.
       </p>
       <MusicPlayer />
-      <div className="mt-4">
+      <div className="mt-3">
         <ReactiveControls />
       </div>
     </section>

--- a/components/sections/work-section.tsx
+++ b/components/sections/work-section.tsx
@@ -33,15 +33,15 @@ const WORK_ITEMS = [
 
 export function WorkSection() {
   return (
-    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-8">
+    <section className="section-shell mx-auto mt-12 max-w-6xl rounded-2xl p-6 md:p-9">
       <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-zinc-300">
         work / portfolio
       </h2>
-      <p className="mt-3 mb-5 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
+      <p className="mt-3 mb-6 max-w-3xl text-sm leading-7 text-zinc-400 md:text-base">
         Technical resume and build archive: companies worked with, engineering
         projects, and selected case studies.
       </p>
-      <div className="grid gap-4 md:grid-cols-2">
+      <div className="grid gap-3 md:grid-cols-2">
         {WORK_ITEMS.map((item) => (
           <WorkCard key={item.title} {...item} />
         ))}

--- a/components/shelf/shelf-hero.tsx
+++ b/components/shelf/shelf-hero.tsx
@@ -80,7 +80,7 @@ export function ShelfHero({ featured, featuredLabel }: ShelfHeroProps) {
 
   return (
     <section
-      className="relative flex min-h-[100dvh] items-start justify-center overflow-hidden px-6 pt-24 pb-16 md:items-center md:px-10 md:py-16"
+      className="relative flex min-h-dvh items-start justify-center overflow-hidden px-6 pt-24 pb-16 md:items-center md:px-10 md:py-16"
       style={{ background: "var(--black)" }}
     >
       <div
@@ -148,7 +148,7 @@ export function ShelfHero({ featured, featuredLabel }: ShelfHeroProps) {
                   style={{
                     maxHeight: expanded && contentHeight > 0 ? `${contentHeight}px` : undefined,
                   }}
-                  className={`overflow-hidden whitespace-pre-line text-sm leading-relaxed opacity-75 transition-[max-height] duration-500 ease-out md:!max-h-none md:text-base ${expanded ? "" : "max-md:max-h-[4.5rem]"}`}
+                  className={`overflow-hidden whitespace-pre-line text-sm leading-relaxed opacity-75 transition-[max-height] duration-500 ease-out md:!max-h-none md:text-base ${expanded ? "" : "max-md:max-h-18"}`}
                 >
                   {featured.description}
                 </p>

--- a/components/shelf/shelf-hero.tsx
+++ b/components/shelf/shelf-hero.tsx
@@ -80,7 +80,7 @@ export function ShelfHero({ featured, featuredLabel }: ShelfHeroProps) {
 
   return (
     <section
-      className="relative flex min-h-dvh items-start justify-center overflow-hidden px-6 pt-24 pb-16 md:items-center md:px-10 md:py-16"
+      className="relative flex min-h-dvh items-start justify-center overflow-hidden px-6 pt-24 pb-18 md:items-center md:px-9 md:py-18"
       style={{ background: "var(--black)" }}
     >
       <div
@@ -119,7 +119,7 @@ export function ShelfHero({ featured, featuredLabel }: ShelfHeroProps) {
             ) : null}
           </a>
 
-          <div className="flex flex-col gap-4 md:max-w-md" style={{ color: "var(--white)" }}>
+          <div className="flex flex-col gap-3 md:max-w-md" style={{ color: "var(--white)" }}>
             <a
               href={`https://www.goodreads.com/book/show/${featured.id}`}
               target="_blank"
@@ -155,7 +155,7 @@ export function ShelfHero({ featured, featuredLabel }: ShelfHeroProps) {
                 <button
                   type="button"
                   onClick={toggleExpanded}
-                  className="mt-2 font-mono text-xs uppercase tracking-[0.2em] underline underline-offset-4 transition-opacity hover:opacity-80 md:hidden"
+                  className="mt-1.5 font-mono text-xs uppercase tracking-[0.2em] underline underline-offset-4 transition-opacity hover:opacity-80 md:hidden"
                   style={{ color: "var(--coin)" }}
                 >
                   {expanded ? "show less" : "read more"}


### PR DESCRIPTION
## Summary

Refactor all spacing across app/ and components/ to use a low-key scale of **multiples of 1.5 in Tailwind units** (= multiples of 3 in pixels).

## Scale

| Token | Tailwind | Pixels | Use |
|---|---|---|---|
| micro | `1.5` | 6px | inline gaps, tight icon spacing |
| tight | `3` | 12px | small stack gaps |
| default | `6` | 24px | base rhythm, edge padding (mobile) |
| comfy | `9` | 36px | desktop edge, between-subsections |
| section | `12` | 48px | mobile section vertical padding |
| section-lg | `18` | 72px | desktop section vertical padding |
| jumbo | `24` | 96px | major page sections |

## Final usage distribution

- `1.5` × 66, `3` × 87, `6` × 77, `9` × 40, `12` × 22, `18` × 17, `24` × 8, `36` × 2

## Mapping rule (round to nearest scale value)

`1→1.5, 2→1.5, 4→3, 5→6, 7→6, 8→9, 10→9, 11→12, 14→12, 16→18, 20→18, 28→24, 32→36`

For mobile/desktop pairs that would collapse (e.g. `py-16 md:py-20` both → 18), preserved the responsive distinction by stepping mobile down (e.g. `py-12 md:py-18`).

## Slider convention

Horizontal scrollers now use `scroll-pl-*` on the container + `ml-*` on each card so `snap-mandatory` respects the leading padding instead of scrolling past it.

## Arbitrary value cleanup (only where shorthands exist)

- `h-[100dvh]`/`min-h-[100dvh]` → `h-dvh`/`min-h-dvh` (Tailwind v4)
- `md:w-[768px] md:max-w-[768px]` → `-mx-6 md:-mx-9` (negative-margin breakout)
- `max-h-[4.5rem]` → `max-h-18`
- `min-w-[600px]` → `min-w-150`
- `aspect-[2/3]` → `aspect-2/3`

Kept arbitrary where there's no shorthand: `text-[10px]`, `tracking-[0.16em]`, `h-[50dvh]`, `bg-[var(--coin)]`, etc.

## Stats

55 files changed, 177 / 177 insertions/deletions.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `/benny` renders correctly (slider, prose padding, social links)
- [x] `/signal` cards and audio player intact
- [x] `/deana` ASCII hero renders
- [x] `/` homepage gallery cards properly spaced
- [x] No console errors across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)