### PR TITLE
video: shared visibility-aware player (pause offscreen)

### DIFF
--- a/app/benny/page.tsx
+++ b/app/benny/page.tsx
@@ -8,6 +8,7 @@ import { SixToMidnightBanner } from "@/components/benny/banner";
 import { BennyPhotoMosaic } from "@/components/benny/photo-mosaic";
 import { InlineVideo } from "@/components/benny/inline-video";
 import { FullBleed } from "@/components/benny/full-bleed";
+import { Video } from "@/components/video";
 import { BENNY_PLAYLISTS } from "./playlists";
 
 export const metadata: Metadata = {
@@ -25,7 +26,7 @@ export default async function BennyPage() {
       style={{ color: "var(--white)" }}
     >
       <section className="relative grid min-h-[80vh] place-content-center overflow-hidden text-center">
-        <video
+        <Video
           autoPlay
           loop
           muted
@@ -34,10 +35,11 @@ export default async function BennyPage() {
           poster="/assets/sixtomidnight-tribute-poster.jpg"
           className="absolute inset-0 h-full w-full object-cover opacity-50"
           aria-label="six to midnight productions montage"
-        >
-          <source src="/assets/sixtomidnight-tribute.webm" type="video/webm" />
-          <source src="/assets/sixtomidnight-tribute.mp4" type="video/mp4" />
-        </video>
+          sources={[
+            { src: "/assets/sixtomidnight-tribute.webm", type: "video/webm" },
+            { src: "/assets/sixtomidnight-tribute.mp4", type: "video/mp4" },
+          ]}
+        />
         <div className="relative z-10 px-6">
           <h2 className="font-mono text-sm uppercase tracking-[0.22em] text-[var(--coin)] md:text-base">
             remembering

--- a/components/benny/inline-video.tsx
+++ b/components/benny/inline-video.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import Image from "next/image";
+import { useVideoVisibility } from "@/lib/use-video-visibility";
 
 interface Props {
   src: string;
@@ -11,21 +12,31 @@ interface Props {
   label?: string;
 }
 
+function PlayingVideo({ src, poster }: { src: string; poster: string }) {
+  const ref = useRef<HTMLVideoElement>(null);
+  // autoplay=false: only pause/resume if the user is actively watching.
+  // A user who clicks play then scrolls away gets a clean pause; if they
+  // scroll back, the hook resumes from where they left off.
+  useVideoVisibility(ref, { autoplay: false });
+  return (
+    <video
+      ref={ref}
+      src={src}
+      poster={poster}
+      controls
+      autoPlay
+      playsInline
+      preload="auto"
+      className="block w-full"
+    />
+  );
+}
+
 export function InlineVideo({ src, poster, width, height, label }: Props) {
   const [playing, setPlaying] = useState(false);
 
   if (playing) {
-    return (
-      <video
-        src={src}
-        poster={poster}
-        controls
-        autoPlay
-        playsInline
-        preload="auto"
-        className="block w-full"
-      />
-    );
+    return <PlayingVideo src={src} poster={poster} />;
   }
 
   return (

--- a/components/canvas/vision.tsx
+++ b/components/canvas/vision.tsx
@@ -1,3 +1,5 @@
+import { Video } from "@/components/video";
+
 interface VisionProps {
   src: string;
   poster?: string;
@@ -10,7 +12,7 @@ interface VisionProps {
 export function Vision({ src, poster }: VisionProps) {
   return (
     <section className="w-full">
-      <video
+      <Video
         className="h-auto w-full"
         src={src}
         poster={poster}

--- a/components/video.tsx
+++ b/components/video.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useRef } from "react";
+import { useVideoVisibility } from "@/lib/use-video-visibility";
+
+interface Source {
+  src: string;
+  type: string;
+}
+
+type Props = React.VideoHTMLAttributes<HTMLVideoElement> & {
+  sources?: Source[];
+};
+
+// Drop-in <video> replacement that pauses offscreen via
+// useVideoVisibility. Pass `autoPlay` for decorative bg video that
+// should always sync to visibility; omit it and the hook only
+// pauses/resumes user-initiated playback. Accepts either a single
+// `src` or a `sources` array for multi-codec (webm + mp4 fallback).
+export function Video({ sources, autoPlay, src, children, ...rest }: Props) {
+  const ref = useRef<HTMLVideoElement>(null);
+  useVideoVisibility(ref, { autoplay: !!autoPlay });
+
+  return (
+    <video ref={ref} autoPlay={autoPlay} src={sources ? undefined : src} {...rest}>
+      {sources?.map((s) => (
+        <source key={s.src} src={s.src} type={s.type} />
+      ))}
+      {children}
+    </video>
+  );
+}

--- a/lib/use-video-visibility.ts
+++ b/lib/use-video-visibility.ts
@@ -5,13 +5,14 @@ import { useEffect, useRef, type RefObject } from "react";
 interface Options {
   /**
    * When true, the video plays as soon as it scrolls into view and
-   * pauses whenever it leaves. Use for background / decorative video
-   * that should never spend CPU offscreen.
+   * pauses whenever it leaves — for background / decorative video that
+   * should never spend CPU offscreen, regardless of user state.
    *
-   * When false, the hook respects the user's play state — it only
-   * pauses on exit if the video is already playing, and only resumes
-   * on re-entry if it was playing when it left. A video the user
-   * never started stays paused.
+   * When false, the hook respects the user's play state: pauses on
+   * exit only if currently playing, resumes on re-entry only if it
+   * paused *because of visibility*. A manual pause by the user
+   * clears the auto-resume bit so a later scroll-in doesn't fight
+   * their intent.
    */
   autoplay?: boolean;
 }
@@ -27,26 +28,48 @@ export function useVideoVisibility(
   { autoplay = false }: Options = {},
 ) {
   const wasPlayingRef = useRef(false);
+  const ourPauseRef = useRef(false);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    const onPause = () => {
+      // If we triggered this pause from the IO callback, the next
+      // pause event is ours — swallow it and leave wasPlaying alone.
+      if (ourPauseRef.current) {
+        ourPauseRef.current = false;
+        return;
+      }
+      // User-initiated pause. Clear the auto-resume bit so we don't
+      // fight their intent on the next scroll-in.
+      wasPlayingRef.current = false;
+    };
+    el.addEventListener("pause", onPause);
+
     const io = new IntersectionObserver(
       ([entry]) => {
         const el = ref.current;
         if (!el) return;
         if (entry.isIntersecting) {
-          if (autoplay || wasPlayingRef.current) {
+          if (autoplay) {
+            void el.play().catch(() => {});
+          } else if (wasPlayingRef.current) {
+            wasPlayingRef.current = false;
             void el.play().catch(() => {});
           }
         } else if (!el.paused) {
-          wasPlayingRef.current = !autoplay;
+          ourPauseRef.current = true;
+          if (!autoplay) wasPlayingRef.current = true;
           el.pause();
         }
       },
       { threshold: 0 },
     );
     io.observe(el);
-    return () => io.disconnect();
+    return () => {
+      el.removeEventListener("pause", onPause);
+      io.disconnect();
+    };
   }, [autoplay, ref]);
 }

--- a/lib/use-video-visibility.ts
+++ b/lib/use-video-visibility.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+interface Options {
+  /**
+   * When true, the video plays as soon as it scrolls into view and
+   * pauses whenever it leaves. Use for background / decorative video
+   * that should never spend CPU offscreen.
+   *
+   * When false, the hook respects the user's play state — it only
+   * pauses on exit if the video is already playing, and only resumes
+   * on re-entry if it was playing when it left. A video the user
+   * never started stays paused.
+   */
+  autoplay?: boolean;
+}
+
+/**
+ * Pause offscreen video, resume when it re-enters view. Saves CPU,
+ * battery, and bandwidth on long pages where multiple video elements
+ * coexist. Tied to the video ref so it works for both shared <Video>
+ * wrappers and custom video components with their own UI.
+ */
+export function useVideoVisibility(
+  ref: RefObject<HTMLVideoElement | null>,
+  { autoplay = false }: Options = {},
+) {
+  const wasPlayingRef = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        const el = ref.current;
+        if (!el) return;
+        if (entry.isIntersecting) {
+          if (autoplay || wasPlayingRef.current) {
+            void el.play().catch(() => {});
+          }
+        } else if (!el.paused) {
+          wasPlayingRef.current = !autoplay;
+          el.pause();
+        }
+      },
+      { threshold: 0 },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [autoplay, ref]);
+}


### PR DESCRIPTION
## Summary

All three \`<video>\` elements on the site (\`app/benny/page.tsx\` hero, \`components/canvas/vision.tsx\`, \`components/benny/inline-video.tsx\`) now route through a shared \`useVideoVisibility\` hook that uses IntersectionObserver to pause offscreen and resume on-screen.

**Behavior by mode:**
- **\`autoplay=true\`** (decorative bg video — benny hero, Vision): always pause when scrolled out, always resume when back in. No CPU spent on offscreen video.
- **\`autoplay=false\`** (user-initiated — InlineVideo): only pauses if the user has actually played it. If the user clicks play, scrolls away, and scrolls back: it resumes. If they never played it, scrolling alone doesn't start it.

Adds \`<Video>\` wrapper in \`components/video.tsx\` for the simple autoplay cases (accepts \`sources[]\` for multi-codec). InlineVideo keeps its custom poster+play UI but wires the hook on the playing video ref.

## Files

- \`lib/use-video-visibility.ts\` — the hook
- \`components/video.tsx\` — wrapper for plain autoplay video
- \`app/benny/page.tsx\` — hero \`<video>\` → \`<Video>\`
- \`components/canvas/vision.tsx\` — \`<video>\` → \`<Video>\`
- \`components/benny/inline-video.tsx\` — playing branch wired with the hook

## Test plan

- [ ] \`/benny\` hero video plays on load, pauses when scrolled past, resumes if scrolled back to top
- [ ] InlineVideo: click play, scroll past, scroll back — resumes; refresh, scroll past without clicking — never plays
- [ ] Vision (on /canvas/self when used) — same as hero