### PR TITLE
subtitles: WebVTT track for the_podcast (whisper + LLM cleanup)

### DIFF
--- a/app/benny/page.tsx
+++ b/app/benny/page.tsx
@@ -74,6 +74,14 @@ export default async function BennyPage() {
                       width={1280}
                       height={720}
                       label="play the podcast"
+                      tracks={[
+                        {
+                          src: "/assets/benny/the_podcast.vtt",
+                          srclang: "en",
+                          label: "English",
+                          default: true,
+                        },
+                      ]}
                     />
                   </FullBleed>
                 ),

--- a/components/benny/inline-video.tsx
+++ b/components/benny/inline-video.tsx
@@ -4,15 +4,23 @@ import { useRef, useState } from "react";
 import Image from "next/image";
 import { useVideoVisibility } from "@/lib/use-video-visibility";
 
+interface Track {
+  src: string;
+  srclang: string;
+  label: string;
+  default?: boolean;
+}
+
 interface Props {
   src: string;
   poster: string;
   width: number;
   height: number;
   label?: string;
+  tracks?: Track[];
 }
 
-function PlayingVideo({ src, poster }: { src: string; poster: string }) {
+function PlayingVideo({ src, poster, tracks }: { src: string; poster: string; tracks?: Track[] }) {
   const ref = useRef<HTMLVideoElement>(null);
   // autoplay=false: only pause/resume if the user is actively watching.
   // A user who clicks play then scrolls away gets a clean pause; if they
@@ -28,15 +36,26 @@ function PlayingVideo({ src, poster }: { src: string; poster: string }) {
       playsInline
       preload="auto"
       className="block w-full"
-    />
+    >
+      {tracks?.map((t) => (
+        <track
+          key={t.src}
+          kind="subtitles"
+          src={t.src}
+          srcLang={t.srclang}
+          label={t.label}
+          default={t.default}
+        />
+      ))}
+    </video>
   );
 }
 
-export function InlineVideo({ src, poster, width, height, label }: Props) {
+export function InlineVideo({ src, poster, width, height, label, tracks }: Props) {
   const [playing, setPlaying] = useState(false);
 
   if (playing) {
-    return <PlayingVideo src={src} poster={poster} />;
+    return <PlayingVideo src={src} poster={poster} tracks={tracks} />;
   }
 
   return (

--- a/components/video.tsx
+++ b/components/video.tsx
@@ -8,16 +8,26 @@ interface Source {
   type: string;
 }
 
+interface Track {
+  src: string;
+  srclang: string;
+  label: string;
+  kind?: "subtitles" | "captions" | "descriptions";
+  default?: boolean;
+}
+
 type Props = React.VideoHTMLAttributes<HTMLVideoElement> & {
   sources?: Source[];
+  tracks?: Track[];
 };
 
 // Drop-in <video> replacement that pauses offscreen via
 // useVideoVisibility. Pass `autoPlay` for decorative bg video that
 // should always sync to visibility; omit it and the hook only
 // pauses/resumes user-initiated playback. Accepts either a single
-// `src` or a `sources` array for multi-codec (webm + mp4 fallback).
-export function Video({ sources, autoPlay, src, children, ...rest }: Props) {
+// `src` or a `sources` array for multi-codec (webm + mp4 fallback),
+// and an optional `tracks` array for subtitles/captions.
+export function Video({ sources, tracks, autoPlay, src, children, ...rest }: Props) {
   const ref = useRef<HTMLVideoElement>(null);
   useVideoVisibility(ref, { autoplay: !!autoPlay });
 
@@ -25,6 +35,16 @@ export function Video({ sources, autoPlay, src, children, ...rest }: Props) {
     <video ref={ref} autoPlay={autoPlay} src={sources ? undefined : src} {...rest}>
       {sources?.map((s) => (
         <source key={s.src} src={s.src} type={s.type} />
+      ))}
+      {tracks?.map((t) => (
+        <track
+          key={t.src}
+          src={t.src}
+          srcLang={t.srclang}
+          label={t.label}
+          kind={t.kind ?? "subtitles"}
+          default={t.default}
+        />
       ))}
       {children}
     </video>

--- a/public/assets/benny/the_podcast.vtt
+++ b/public/assets/benny/the_podcast.vtt
@@ -1,0 +1,3790 @@
+WEBVTT
+
+00:00:00.000 --> 00:00:24.280
+All right, all right, all right, so yeah, we're here at Six to Midnight Studios, uh, drinking
+
+00:00:24.280 --> 00:00:25.280
+uh, Benny T there.
+
+00:00:25.280 --> 00:00:26.280
+Um, what do you got there, the, the Manila rooibos?
+
+00:00:27.280 --> 00:00:28.280
+Yeah, the one I can't pronounce.
+
+00:00:28.280 --> 00:00:29.280
+Yeah, yeah, what do you think about that?
+
+00:00:29.280 --> 00:00:30.280
+It's good.
+
+00:00:30.280 --> 00:00:31.280
+It's really good.
+
+00:00:31.280 --> 00:00:32.279
+I'm enjoying it.
+
+00:00:32.279 --> 00:00:33.279
+I'm digging it.
+
+00:00:33.279 --> 00:00:34.279
+Is this all?
+
+00:00:34.279 --> 00:00:35.279
+This is all rooibos?
+
+00:00:35.279 --> 00:00:36.279
+Yeah.
+
+00:00:36.279 --> 00:00:37.279
+Yeah.
+
+00:00:37.279 --> 00:00:38.279
+Completely rooibos today, Sam.
+
+00:00:38.279 --> 00:00:39.279
+What I do today?
+
+00:00:39.279 --> 00:00:40.279
+Yeah.
+
+00:00:40.279 --> 00:00:41.279
+I went to Philadelphia for falafel.
+
+00:00:41.279 --> 00:00:42.279
+You went to Philly for falafel?
+
+00:00:42.279 --> 00:00:43.279
+Sounds full on awful.
+
+00:00:43.279 --> 00:00:55.279
+Uh, yeah.
+
+00:00:55.279 --> 00:00:56.279
+Uh...
+
+00:00:56.279 --> 00:00:57.279
+Oh, boy.
+
+00:00:57.279 --> 00:00:58.279
+What was it?
+
+00:00:58.279 --> 00:00:59.279
+Was it dry?
+
+00:00:59.279 --> 00:01:00.279
+It was goldies.
+
+00:01:00.279 --> 00:01:01.279
+Oh, man.
+
+00:01:01.279 --> 00:01:02.279
+And it was not dry.
+
+00:01:02.279 --> 00:01:03.279
+What, what's falafel?
+
+00:01:03.279 --> 00:01:04.279
+How could it be dry?
+
+00:01:04.279 --> 00:01:05.279
+It is so moist.
+
+00:01:05.279 --> 00:01:06.279
+I've never had a moist falafel.
+
+00:01:06.279 --> 00:01:09.639
+I'm not a cultured, so I've never had a falafel period ever.
+
+00:01:09.639 --> 00:01:13.639
+It sounds like a great new word.
+
+00:01:13.639 --> 00:01:16.940
+He just made up there...
+
+00:01:16.940 --> 00:01:18.620
+I'm feeling a falafel!
+
+00:01:18.620 --> 00:01:19.620
+Yeah...
+
+00:01:19.620 --> 00:01:20.620
+Ha ha!
+
+00:01:20.620 --> 00:01:21.620
+Ha ha!
+
+00:01:21.620 --> 00:01:22.680
+Well, I just feel a falafel.
+
+00:01:22.680 --> 00:01:23.680
+Yeah.
+
+00:01:24.680 --> 00:01:25.680
+What about you?
+
+00:01:25.680 --> 00:01:26.680
+What did you do today?
+
+00:01:26.680 --> 00:01:29.680
+Went to the mall with my sister and my girlfriend.
+
+00:01:29.680 --> 00:01:31.680
+What's up with the mall these days?
+
+00:01:31.680 --> 00:01:32.680
+It's fucking terrible these days.
+
+00:01:32.680 --> 00:01:33.680
+Yeah, man.
+
+00:01:33.680 --> 00:01:34.680
+It's so busy.
+
+00:01:34.680 --> 00:01:35.680
+Why the fuck is it so busy?
+
+00:01:35.680 --> 00:01:36.680
+It's just Saturday.
+
+00:01:36.680 --> 00:01:37.680
+You know?
+
+00:01:37.680 --> 00:01:38.680
+Yeah, man.
+
+00:01:38.680 --> 00:01:39.680
+It's March.
+
+00:01:39.680 --> 00:01:40.680
+Is that a thing?
+
+00:01:40.680 --> 00:01:41.680
+Do people march to the mall?
+
+00:01:41.680 --> 00:01:42.680
+They sure do.
+
+00:01:42.680 --> 00:01:43.680
+A million men march to the mall.
+
+00:01:43.680 --> 00:01:44.680
+I worked.
+
+00:01:44.680 --> 00:01:45.680
+I worked at a mall.
+
+00:01:45.680 --> 00:01:46.680
+Yeah?
+
+00:01:46.680 --> 00:01:47.680
+I did that, yeah.
+
+00:01:47.680 --> 00:01:48.680
+Where did you work in the mall?
+
+00:01:48.680 --> 00:01:49.680
+I worked at, uh, Brookstone.
+
+00:01:49.680 --> 00:01:50.680
+Ha ha!
+
+00:01:50.680 --> 00:01:51.680
+I knew you did it!
+
+00:01:52.680 --> 00:01:53.680
+I sold those massage chairs.
+
+00:01:53.680 --> 00:01:54.680
+Did you really?
+
+00:01:54.680 --> 00:01:55.680
+Personal massagers, yeah.
+
+00:01:55.680 --> 00:01:56.680
+Dude, that's fucking awesome.
+
+00:01:56.680 --> 00:01:57.680
+Is that all you did?
+
+00:01:57.680 --> 00:01:58.680
+Was, like, sell, like, the chairs?
+
+00:01:58.680 --> 00:01:59.680
+Yeah, I just sold stuff, yeah.
+
+00:01:59.680 --> 00:02:00.680
+The chairs?
+
+00:02:00.680 --> 00:02:01.680
+Mm-hmm.
+
+00:02:01.680 --> 00:02:02.680
+Did you ever sell a chair?
+
+00:02:02.680 --> 00:02:03.680
+What's the most expensive thing you sold at a Brookstone?
+
+00:02:03.680 --> 00:02:04.680
+I sold, like, a $4,500 massage chair.
+
+00:02:04.680 --> 00:02:05.680
+Did you get a refund on it, or what?
+
+00:02:05.680 --> 00:02:06.680
+Yeah, they gave me, like, 50 bucks.
+
+00:02:06.680 --> 00:02:07.680
+Ha ha!
+
+00:02:07.680 --> 00:02:08.679
+What a deal!
+
+00:02:08.679 --> 00:02:09.679
+Shout out to Brookstone.
+
+00:02:09.679 --> 00:02:10.679
+Okay.
+
+00:02:10.679 --> 00:02:11.679
+Ha ha!
+
+00:02:11.679 --> 00:02:12.679
+Pay your employees.
+
+00:02:12.679 --> 00:02:21.679
+Ha ha!
+
+00:02:21.679 --> 00:02:22.679
+Employees.
+
+00:02:22.679 --> 00:02:23.679
+Oh, man, that's great.
+
+00:02:23.679 --> 00:02:24.679
+I used to work at Taco Bell, and that was, like, way worse.
+
+00:02:24.679 --> 00:02:25.679
+That was, like, my first job.
+
+00:02:25.679 --> 00:02:26.679
+Which Taco Bell?
+
+00:02:26.679 --> 00:02:27.679
+It depends on what Taco Bell.
+
+00:02:27.679 --> 00:02:28.679
+It's the one at, uh, the White Horse Circle.
+
+00:02:28.679 --> 00:02:29.679
+See, that's not so bad.
+
+00:02:29.679 --> 00:02:30.679
+It wasn't, but sometimes, like, if I would work until, like, 2 a.m., you'd get, like,
+
+00:02:30.679 --> 00:02:31.679
+the South Broad crowd.
+
+00:02:31.679 --> 00:02:32.679
+Like, just everybody, like, crawling from bars and shit, like, just going nuts, and
+
+00:02:32.679 --> 00:02:33.679
+I was, like, 15.
+
+00:02:33.679 --> 00:02:34.679
+That's, like, real good entertainment right there.
+
+00:02:34.679 --> 00:02:35.679
+Oh, for sure.
+
+00:02:35.679 --> 00:02:36.679
+There was a stripper that, like, came to the drive-thru one night, and just, like, you
+
+00:03:06.679 --> 00:03:26.000
+know, the whole fucking strip club down here asking for tacos, showing us titties for tacos.
+
+00:03:26.000 --> 00:03:27.119
+You know what I mean?
+
+00:03:27.119 --> 00:03:29.440
+It's not the kind of business I want to run.
+
+00:03:29.440 --> 00:03:30.440
+Titty for tacos Tuesday.
+
+00:03:30.440 --> 00:03:31.440
+Yeah, titty for taco Tuesday.
+
+00:03:31.440 --> 00:03:32.440
+That's not the kind of business I want to run.
+
+00:03:32.440 --> 00:03:33.440
+This ain't 86 anymore.
+
+00:03:33.440 --> 00:03:34.440
+I can't do that.
+
+00:03:34.440 --> 00:03:35.440
+This ain't Miami.
+
+00:03:35.440 --> 00:03:36.440
+That's what he said.
+
+00:03:36.440 --> 00:03:37.440
+That's what he said to me.
+
+00:03:37.440 --> 00:03:41.440
+That's what my boss said to me when I was 15.
+
+00:03:41.440 --> 00:03:42.440
+Cocos Machi.
+
+00:03:42.440 --> 00:03:43.440
+So there's a funny story.
+
+00:03:43.440 --> 00:03:44.440
+The Taco Bell is right up the street here.
+
+00:03:44.440 --> 00:03:45.440
+Yeah.
+
+00:03:45.440 --> 00:03:46.440
+Like, I'm going to start the story with like, it's really hard to like get a manager, a
+
+00:03:46.440 --> 00:03:47.440
+general manager position at a chain restaurant.
+
+00:03:47.440 --> 00:03:48.440
+Dude, you have to have like a fucking, like, at least like an associate.
+
+00:03:48.440 --> 00:03:49.440
+Exactly.
+
+00:03:49.440 --> 00:03:50.440
+Exactly.
+
+00:03:50.440 --> 00:03:51.440
+Well, anyway, this guy that works at Taco Bell up the street, the general manager, his
+
+00:03:51.440 --> 00:03:52.440
+name is, can we say this on air?
+
+00:03:52.440 --> 00:03:53.440
+What's his name?
+
+00:03:53.440 --> 00:04:09.440
+I don't know.
+
+00:04:09.440 --> 00:04:10.440
+I didn't put my name down.
+
+00:04:10.440 --> 00:04:11.440
+He just said he works at Taco Bell up the street.
+
+00:04:11.440 --> 00:04:12.440
+I thought my name was Michael.
+
+00:04:12.440 --> 00:04:13.440
+So I thought, wait, I had to put my name down.
+
+00:04:13.440 --> 00:04:14.440
+I thought I put my name down.
+
+00:04:14.440 --> 00:04:15.440
+And I said, hey, what's your name?
+
+00:04:15.440 --> 00:04:16.440
+And she's like, Mike Choco.
+
+00:04:16.440 --> 00:04:17.440
+Shouts of Mike, dude.
+
+00:04:17.440 --> 00:04:18.440
+So seriously though?
+
+00:04:18.440 --> 00:04:19.440
+So I thought it was Taco.
+
+00:04:19.440 --> 00:04:20.440
+I just thought the universe lined that one up for you.
+
+00:04:20.440 --> 00:04:21.440
+I thought it was so amazing that his name was Mike Taco and he was the manager of Taco
+
+00:04:21.440 --> 00:04:22.440
+Bell.
+
+00:04:22.440 --> 00:04:23.440
+So me and Dave, you know, Dave.
+
+00:04:23.440 --> 00:04:24.440
+Yeah.
+
+00:04:24.440 --> 00:04:25.440
+We started this little side project called Mike Taco.
+
+00:04:25.440 --> 00:04:26.440
+We started writing songs and stuff.
+
+00:04:27.440 --> 00:04:28.440
+One day we went to Taco Bell.
+
+00:04:28.440 --> 00:04:34.619
+We were like, yo, we love the fact that your name is Mike Taco and we have a band named
+
+00:04:34.619 --> 00:04:38.420
+Mike Taco and he got super mad, really.
+
+00:04:38.420 --> 00:04:41.700
+He was like, my name is Mike Choco.
+
+00:04:41.700 --> 00:04:46.920
+Hey, man, we just wanted to let you know we tribute this band to you and your name, Mike
+
+00:04:46.920 --> 00:04:47.920
+Taco.
+
+00:04:47.920 --> 00:04:51.320
+I was like, what the fuck are you guys talking about?
+
+00:04:51.320 --> 00:04:52.320
+Can you leave?
+
+00:04:52.320 --> 00:04:56.119
+Can you guys either order a goddamn Gordita Crunch or are you guys going to get a fucking
+
+00:04:56.119 --> 00:04:59.079
+Gordita or are you just going to leave, okay?
+
+00:04:59.079 --> 00:05:00.640
+Those are your two options right now.
+
+00:05:00.640 --> 00:05:01.640
+Oh, shit, man.
+
+00:05:01.640 --> 00:05:05.959
+What do you guys got going on spring break time?
+
+00:05:05.959 --> 00:05:06.959
+Once this fucking weather breaks.
+
+00:05:06.959 --> 00:05:07.959
+What does that mean?
+
+00:05:07.959 --> 00:05:13.720
+Like once the weather isn't literally how it is in the movie, The Revenant, what are
+
+00:05:13.720 --> 00:05:15.760
+you guys going to do after that?
+
+00:05:15.760 --> 00:05:19.119
+Because I feel like I'm going to walk outside and have to fight like fucking a gaggle of
+
+00:05:19.119 --> 00:05:20.119
+wolves.
+
+00:05:20.119 --> 00:05:21.119
+Yo, it's crazy out there.
+
+00:05:21.920 --> 00:05:24.920
+It's still crazy out there, dude.
+
+00:05:24.920 --> 00:05:30.000
+Last night, like, okay, so yesterday it was snowing, it was a blizzard, there was a hurricane
+
+00:05:30.000 --> 00:05:31.000
+that went by.
+
+00:05:31.000 --> 00:05:34.239
+So like a grandma from the Bronx trying to tell us a great story.
+
+00:05:34.239 --> 00:05:36.679
+All of a sudden it was like nothing.
+
+00:05:36.679 --> 00:05:39.440
+It was like not cold, it was like no wind.
+
+00:05:39.440 --> 00:05:41.000
+It was windy as a bitch.
+
+00:05:41.000 --> 00:05:46.760
+It stopped winding for like a good 15 minutes, we were outside, and I was like, holy shit,
+
+00:05:46.760 --> 00:05:48.640
+what is, you know?
+
+00:05:48.640 --> 00:05:53.239
+Next thing you know, my cupboards are smacking each other.
+
+00:05:53.239 --> 00:05:54.239
+It's crazy.
+
+00:05:54.239 --> 00:05:57.920
+It's like the fucking Amityville Horror on my street, okay?
+
+00:05:57.920 --> 00:06:05.959
+I was in a car watching people walk around in Philadelphia and they were like, oh man,
+
+00:06:05.959 --> 00:06:10.519
+they had to like stop, like, whenever like the winds started, they had to like stop and
+
+00:06:10.519 --> 00:06:13.839
+like move themselves so you could see them like leaning into it.
+
+00:06:13.839 --> 00:06:15.839
+It's fucking great.
+
+00:06:15.839 --> 00:06:25.320
+Dude, yesterday, I, uh, I like pulled up to my apartment complex and every light in
+
+00:06:25.320 --> 00:06:30.399
+the whole complex was out and it was like pitch black and I'm like, what the fuck is
+
+00:06:30.399 --> 00:06:31.399
+going on?
+
+00:06:31.399 --> 00:06:32.519
+Yeah, it was like that in a lot of places.
+
+00:06:32.519 --> 00:06:34.239
+It was next level, dude.
+
+00:06:34.239 --> 00:06:38.320
+Yo, New Hope, the whole Hope, the whole part was all...
+
+00:06:38.320 --> 00:06:39.799
+Looked like old Hope.
+
+00:06:39.799 --> 00:06:43.000
+Yeah, it looked like no fucking Hope, yeah.
+
+00:06:43.000 --> 00:06:44.000
+No Hope right there.
+
+00:06:44.160 --> 00:06:47.760
+Well, there's so many, yeah, there's so many trees around New Hope too, I feel like.
+
+00:06:47.760 --> 00:06:51.679
+And the water was like, it was like a thousand miles an hour, it was like one kilometer.
+
+00:06:51.679 --> 00:06:53.160
+Princeton flooded, didn't it?
+
+00:06:53.160 --> 00:06:54.160
+Holy shit.
+
+00:06:54.160 --> 00:06:55.160
+Princeton, I thought, flooded.
+
+00:06:55.160 --> 00:06:56.160
+Dude.
+
+00:06:56.160 --> 00:06:57.160
+It's, it's, it's kind of scary.
+
+00:06:57.160 --> 00:07:01.200
+It's like, it's like, you joke about it, it's like, summer one day, winter one day.
+
+00:07:01.200 --> 00:07:04.480
+Dude, six people died.
+
+00:07:04.480 --> 00:07:07.079
+From the north, on the east coast, six people died.
+
+00:07:07.079 --> 00:07:08.079
+From what?
+
+00:07:08.079 --> 00:07:11.799
+I guess they were in a house and a tree fell.
+
+00:07:11.799 --> 00:07:12.799
+I don't know, I'll look it up.
+
+00:07:12.799 --> 00:07:13.799
+Oh yeah, you should look that up.
+
+00:07:14.600 --> 00:07:16.600
+I'll look it up, I'll look it up, yeah.
+
+00:07:16.600 --> 00:07:17.600
+Keep going.
+
+00:07:17.600 --> 00:07:20.279
+Yeah, I don't want to talk about dying people and the weather.
+
+00:07:20.279 --> 00:07:23.799
+This weather is literally ripping my throat apart.
+
+00:07:23.799 --> 00:07:24.799
+Yeah.
+
+00:07:24.799 --> 00:07:25.799
+It literally is.
+
+00:07:25.799 --> 00:07:30.799
+I sound like an old lady trying to get a cocktail at AC right now, like two o'clock in the morning.
+
+00:07:30.799 --> 00:07:31.799
+Cocktail!
+
+00:07:31.799 --> 00:07:32.799
+Like I sound...
+
+00:07:32.799 --> 00:07:33.799
+I'd take a fucking Cosmo.
+
+00:07:33.799 --> 00:07:35.799
+I'd get a cocktail over here.
+
+00:07:35.799 --> 00:07:38.799
+Hey, Georgie, I'd take a Cosmo when you get a sec.
+
+00:07:38.799 --> 00:07:42.799
+I sound like that guy from Independence Day.
+
+00:07:42.799 --> 00:07:43.799
+David!
+
+00:07:43.799 --> 00:07:44.799
+David!
+
+00:07:44.799 --> 00:07:46.799
+I gotta call my lawyer.
+
+00:07:48.799 --> 00:07:49.799
+Oh shit, dude.
+
+00:07:49.799 --> 00:07:50.799
+Yeah, look.
+
+00:07:50.799 --> 00:07:52.799
+Look, it's right here, man.
+
+00:07:52.799 --> 00:07:54.799
+At least six killed in a deadly storm.
+
+00:07:54.799 --> 00:07:55.799
+Thousands without power.
+
+00:07:55.799 --> 00:07:56.799
+That's insane.
+
+00:07:56.799 --> 00:07:58.799
+I guess it was like down the shore.
+
+00:07:58.799 --> 00:08:00.799
+Like flooding and stuff, you know what I mean?
+
+00:08:00.799 --> 00:08:01.799
+Yeah.
+
+00:08:01.799 --> 00:08:04.799
+Even when I lived down the shore, the weather wasn't like this at all.
+
+00:08:04.799 --> 00:08:05.799
+There was wind.
+
+00:08:05.799 --> 00:08:06.799
+It's always worse.
+
+00:08:07.799 --> 00:08:12.799
+Weather's always worse farther on the coast than it is inland, right?
+
+00:08:12.799 --> 00:08:13.799
+Right.
+
+00:08:13.799 --> 00:08:16.799
+See, I don't live there anymore, but when I did live there, I didn't even experience
+
+00:08:16.799 --> 00:08:18.799
+weather like I experience in the hood.
+
+00:08:18.799 --> 00:08:19.799
+Yeah?
+
+00:08:19.799 --> 00:08:20.799
+It's worse?
+
+00:08:20.799 --> 00:08:21.799
+Weather's worse in the hood?
+
+00:08:21.799 --> 00:08:22.799
+Hey, now it is.
+
+00:08:25.799 --> 00:08:27.799
+I can't believe you there, dude.
+
+00:08:27.799 --> 00:08:28.799
+It's real.
+
+00:08:28.799 --> 00:08:30.799
+When was the last time you saw a natural rainbow?
+
+00:08:32.799 --> 00:08:34.799
+I don't even remember the last time I looked for a rainbow.
+
+00:08:34.799 --> 00:08:36.799
+I saw some rainbows on a road trip with Sam once.
+
+00:08:36.799 --> 00:08:38.799
+We went to go get those speakers.
+
+00:08:38.799 --> 00:08:39.799
+That's cute.
+
+00:08:39.799 --> 00:08:41.799
+I actually do see rainbows a lot.
+
+00:08:41.799 --> 00:08:42.799
+Yeah, you do?
+
+00:08:42.799 --> 00:08:43.799
+I do.
+
+00:08:43.799 --> 00:08:44.799
+It's like your thing?
+
+00:08:44.799 --> 00:08:46.799
+You see like little flying birds around your head too?
+
+00:08:48.799 --> 00:08:50.799
+I think Sam's in love.
+
+00:08:52.799 --> 00:08:55.799
+I think our old Sammy boy's in love.
+
+00:08:55.799 --> 00:08:56.799
+Sam, what's up with you, man?
+
+00:08:56.799 --> 00:08:58.799
+What's going on with music and you?
+
+00:08:58.799 --> 00:08:59.799
+Music and me?
+
+00:08:59.799 --> 00:09:00.799
+Yeah, yeah.
+
+00:09:01.799 --> 00:09:02.799
+I don't know.
+
+00:09:02.799 --> 00:09:04.799
+I've been trying to play drums.
+
+00:09:04.799 --> 00:09:05.799
+That's fun.
+
+00:09:06.799 --> 00:09:07.799
+I mean...
+
+00:09:07.799 --> 00:09:08.799
+It's fun.
+
+00:09:08.799 --> 00:09:09.799
+Yeah, it's fun.
+
+00:09:09.799 --> 00:09:10.799
+I like you.
+
+00:09:10.799 --> 00:09:12.799
+He's a regular new perp.
+
+00:09:12.799 --> 00:09:13.799
+I am.
+
+00:09:13.799 --> 00:09:17.799
+I was in Rush for a while and then they kicked me out because they were like,
+
+00:09:17.799 --> 00:09:20.799
+Yo, you're a baby.
+
+00:09:20.799 --> 00:09:22.799
+You're a fucking baby.
+
+00:09:22.799 --> 00:09:24.799
+We can't even play in a bar because of you.
+
+00:09:24.799 --> 00:09:25.799
+That's what Rush sounds like.
+
+00:09:25.799 --> 00:09:27.799
+They're all a bunch of old Italian men.
+
+00:09:27.799 --> 00:09:31.799
+Oh, we got this fucking baby.
+
+00:09:32.799 --> 00:09:33.799
+Playing drums.
+
+00:09:33.799 --> 00:09:35.799
+I wasn't even fucking born yet, dude.
+
+00:09:35.799 --> 00:09:36.799
+When Rush was popping.
+
+00:09:36.799 --> 00:09:37.799
+Is Rush still popping?
+
+00:09:37.799 --> 00:09:38.799
+I think so.
+
+00:09:38.799 --> 00:09:40.799
+I feel like they're like...
+
+00:09:40.799 --> 00:09:41.799
+They just did.
+
+00:09:41.799 --> 00:09:42.799
+They were just on tour.
+
+00:09:42.799 --> 00:09:46.799
+There's a lot of bands that were like super popping in like the 70s and 80s
+
+00:09:46.799 --> 00:09:49.799
+and shit that are just not going to go away.
+
+00:09:49.799 --> 00:09:51.799
+What's your favorite 80s band?
+
+00:09:52.799 --> 00:09:53.799
+Or musician?
+
+00:09:53.799 --> 00:09:55.799
+Oh, I can't do that one.
+
+00:09:55.799 --> 00:09:56.799
+80s.
+
+00:09:56.799 --> 00:09:57.799
+Yeah, that's a tough one.
+
+00:09:57.799 --> 00:09:59.799
+Yeah, favorite period is hard.
+
+00:09:59.799 --> 00:10:02.799
+You know I have a favorite 80s movie?
+
+00:10:02.799 --> 00:10:04.799
+Breakfast Club, I guess.
+
+00:10:06.799 --> 00:10:07.799
+What about you?
+
+00:10:07.799 --> 00:10:09.799
+Everything in the 80s was weird.
+
+00:10:09.799 --> 00:10:10.799
+Yeah, it was a little weird.
+
+00:10:10.799 --> 00:10:11.799
+It was weird, right?
+
+00:10:11.799 --> 00:10:12.799
+Yeah.
+
+00:10:12.799 --> 00:10:13.799
+Movies and shit.
+
+00:10:13.799 --> 00:10:15.799
+Molly Ringwald was in everything.
+
+00:10:15.799 --> 00:10:17.799
+The 80s, it's like such like a...
+
+00:10:17.799 --> 00:10:18.799
+It's like big.
+
+00:10:18.799 --> 00:10:19.799
+That's like 10 years.
+
+00:10:19.799 --> 00:10:20.799
+I don't know.
+
+00:10:20.799 --> 00:10:21.799
+Yeah, that was 10 years ago.
+
+00:10:21.799 --> 00:10:22.799
+Oh, wait.
+
+00:10:22.799 --> 00:10:24.799
+Did Back to the Future come out in the 80s?
+
+00:10:24.799 --> 00:10:25.799
+Yeah.
+
+00:10:25.799 --> 00:10:26.799
+Yeah, for sure.
+
+00:10:26.799 --> 00:10:27.799
+Back to the Future then.
+
+00:10:27.799 --> 00:10:28.799
+All of them?
+
+00:10:28.799 --> 00:10:29.799
+Yeah.
+
+00:10:29.799 --> 00:10:30.799
+All of them came in the 80s?
+
+00:10:30.799 --> 00:10:31.799
+Dude, even the third one.
+
+00:10:31.799 --> 00:10:32.799
+Was it?
+
+00:10:32.799 --> 00:10:33.799
+No, no way.
+
+00:10:33.799 --> 00:10:34.799
+I remember the third one I got carded at.
+
+00:10:34.799 --> 00:10:35.799
+Really?
+
+00:10:35.799 --> 00:10:36.799
+Yeah, the first time.
+
+00:10:36.799 --> 00:10:38.799
+One and only time I ever got carded to go to a movie.
+
+00:10:38.799 --> 00:10:40.799
+22 years old, I still get carded at the movies, dude.
+
+00:10:40.799 --> 00:10:41.799
+It makes me so mad.
+
+00:10:41.799 --> 00:10:43.799
+You want me to go see Marty McFly right now?
+
+00:10:43.799 --> 00:10:44.799
+That's what I'm saying, dude.
+
+00:10:44.799 --> 00:10:45.799
+Seriously?
+
+00:10:45.799 --> 00:10:47.799
+I get carded for rated R movies, but they're like not even good ones.
+
+00:10:47.799 --> 00:10:48.799
+That's like PG-13.
+
+00:10:48.799 --> 00:10:49.799
+Like downsizing?
+
+00:10:49.799 --> 00:10:51.799
+You know how to read downsizing?
+
+00:10:51.799 --> 00:10:52.799
+Oh, no.
+
+00:10:52.799 --> 00:10:53.799
+It's R. It's rated R.
+
+00:10:53.799 --> 00:10:55.799
+That was the worst movie.
+
+00:10:55.799 --> 00:10:56.799
+It was so bad.
+
+00:10:56.799 --> 00:10:57.799
+I was so disappointed.
+
+00:10:57.799 --> 00:10:59.799
+You know what movie was really freaking good?
+
+00:10:59.799 --> 00:11:02.799
+That movie Three Billboards Outside of Someplace?
+
+00:11:02.799 --> 00:11:04.799
+Oh, I know what you're talking about.
+
+00:11:04.799 --> 00:11:06.799
+It was so good, I watched it twice.
+
+00:11:06.799 --> 00:11:07.799
+Yeah?
+
+00:11:07.799 --> 00:11:08.799
+Yeah.
+
+00:11:08.799 --> 00:11:09.799
+I did that with Star Wars.
+
+00:11:09.799 --> 00:11:10.799
+It was really good.
+
+00:11:10.799 --> 00:11:11.799
+I got to check that out.
+
+00:11:11.799 --> 00:11:12.799
+We did that with Star Wars.
+
+00:11:12.799 --> 00:11:13.799
+Yeah.
+
+00:11:13.799 --> 00:11:14.799
+Star Wars.
+
+00:11:14.799 --> 00:11:15.799
+On the Dolby Theater.
+
+00:11:15.799 --> 00:11:16.799
+Dolby.
+
+00:11:16.799 --> 00:11:17.799
+I thought I was going to have a-
+
+00:11:17.799 --> 00:11:18.799
+They named it Shark from Anchorman 2.
+
+00:11:18.799 --> 00:11:19.799
+Dolby!
+
+00:11:19.799 --> 00:11:20.799
+Dolby!
+
+00:11:20.799 --> 00:11:26.799
+I thought I was going to have a fucking heart attack when I walked out of there.
+
+00:11:27.799 --> 00:11:31.799
+It felt like my head was just so compressive, so loud in that theater.
+
+00:11:31.799 --> 00:11:33.799
+Yeah, the Dolby Cinema.
+
+00:11:33.799 --> 00:11:35.799
+We were fucking the shit out of it.
+
+00:11:35.799 --> 00:11:36.799
+We sat close.
+
+00:11:36.799 --> 00:11:39.799
+You girls were like, I think it's in row two and I don't understand.
+
+00:11:39.799 --> 00:11:40.799
+Not crazy close.
+
+00:11:40.799 --> 00:11:41.799
+Not crazy close.
+
+00:11:41.799 --> 00:11:42.799
+You can see it.
+
+00:11:42.799 --> 00:11:43.799
+I can't see a damn thing.
+
+00:11:43.799 --> 00:11:45.799
+We had pretty good seats because nobody was really there.
+
+00:11:45.799 --> 00:11:46.799
+I'm old.
+
+00:11:46.799 --> 00:11:48.799
+I need to be in the back a little bit.
+
+00:11:48.799 --> 00:11:49.799
+Yeah, I don't want to be-
+
+00:11:49.799 --> 00:11:50.799
+Yeah.
+
+00:11:50.799 --> 00:11:52.799
+I watched- I saw The Disaster Artist, by the way.
+
+00:11:52.799 --> 00:11:53.799
+Great movie.
+
+00:11:53.799 --> 00:11:54.799
+Oh, I love that movie.
+
+00:11:54.799 --> 00:11:55.799
+So fucking good, dude.
+
+00:11:55.799 --> 00:11:56.799
+So fucking good.
+
+00:11:56.799 --> 00:12:02.799
+But I went to go see The Disaster Artist and one, it was an independent movie, so it was
+
+00:12:02.799 --> 00:12:04.799
+in a smaller theater.
+
+00:12:04.799 --> 00:12:05.799
+You know what I'm saying?
+
+00:12:05.799 --> 00:12:07.799
+In the AMC, it was in one of the tiny ones.
+
+00:12:07.799 --> 00:12:14.799
+And I fucking got there late, so I had to sit front row, literal front row, in the smallest
+
+00:12:14.799 --> 00:12:15.799
+theater.
+
+00:12:15.799 --> 00:12:17.799
+My fucking head was the worst, dude.
+
+00:12:17.799 --> 00:12:23.799
+You're so close that when they do camera shots of two different people talking, you have
+
+00:12:23.799 --> 00:12:24.799
+to move your head.
+
+00:12:24.799 --> 00:12:25.799
+You know what I'm saying?
+
+00:12:25.799 --> 00:12:26.799
+That's how fucking close you are.
+
+00:12:26.799 --> 00:12:28.799
+That's why you booked that online, Fandango.
+
+00:12:28.799 --> 00:12:30.799
+Dude, AMC in hell doesn't do that shit.
+
+00:12:30.799 --> 00:12:33.799
+You still book it, and you still pick the seats, and you gotta look up like this.
+
+00:12:33.799 --> 00:12:34.799
+I don't get it.
+
+00:12:34.799 --> 00:12:35.799
+What are you talking about?
+
+00:12:35.799 --> 00:12:37.799
+That was like a sold-out show.
+
+00:12:37.799 --> 00:12:40.799
+Just be happy you were part of the experience, all right?
+
+00:12:40.799 --> 00:12:42.799
+I died that night, actually.
+
+00:12:42.799 --> 00:12:45.799
+I just died in your arms tonight.
+
+00:12:45.799 --> 00:12:46.799
+I did.
+
+00:12:46.799 --> 00:12:47.799
+No, that did happen.
+
+00:12:47.799 --> 00:12:50.799
+Yeah, I have a condition where I die sometimes.
+
+00:12:50.799 --> 00:12:53.799
+I just pass out, flop around on the floor.
+
+00:12:53.799 --> 00:13:00.799
+This was the first time it was like a sold-out show for Black Panther, front row, trying
+
+00:13:00.799 --> 00:13:01.799
+to rally the troops.
+
+00:13:01.799 --> 00:13:03.799
+Because you want to see it.
+
+00:13:03.799 --> 00:13:05.799
+You don't want to sit front row, but you want to see the movie.
+
+00:13:05.799 --> 00:13:06.799
+You know what I'm saying?
+
+00:13:06.799 --> 00:13:11.799
+It's one of those things where it's just like, I can't bitch out, but fuck, I gotta sit front
+
+00:13:11.799 --> 00:13:12.799
+row, man.
+
+00:13:12.799 --> 00:13:13.799
+That's the worst.
+
+00:13:13.799 --> 00:13:25.799
+Dude, I got some inside news that AMC Hamilton, apparently 2018 or 2019, will have a full
+
+00:13:25.799 --> 00:13:27.799
+overhaul of their theater.
+
+00:13:27.799 --> 00:13:33.799
+But the guy that told me was like 17, and he also told me not to tell anybody, so I
+
+00:13:33.799 --> 00:13:34.799
+think it was a lie.
+
+00:13:34.799 --> 00:13:35.799
+We'll see.
+
+00:13:35.799 --> 00:13:39.799
+Because if it comes out true and we release this, I will go fucking genius, dude.
+
+00:13:39.799 --> 00:13:40.799
+You heard it here.
+
+00:13:40.799 --> 00:13:42.799
+You heard it here first.
+
+00:13:42.799 --> 00:13:45.799
+Don't let anybody fucking steal this, okay?
+
+00:13:45.799 --> 00:13:47.799
+So it's going to have an overhaul?
+
+00:13:47.799 --> 00:13:53.799
+Yeah, so they're going to do the reclining chairs, and I don't know, new soda machines.
+
+00:13:53.799 --> 00:13:55.799
+That place has been updated so fucking wrong, dude.
+
+00:13:55.799 --> 00:13:56.799
+It doesn't matter about the updates.
+
+00:13:56.799 --> 00:13:58.799
+It's the people that go there.
+
+00:13:58.799 --> 00:14:02.799
+Well, yeah, but I'm saying like, but those chairs, those seats.
+
+00:14:02.799 --> 00:14:03.799
+But those seats, dude.
+
+00:14:03.799 --> 00:14:04.799
+It's hard to justify.
+
+00:14:04.799 --> 00:14:10.799
+You can just like, you can go to like, art fair, and just like recline comfortably.
+
+00:14:11.799 --> 00:14:15.799
+And if you're going to charge somebody, if you're going to charge somebody $12, like,
+
+00:14:15.799 --> 00:14:18.799
+for me to sit in a corduroy chair.
+
+00:14:18.799 --> 00:14:21.799
+I always feel like I'm going to beat somebody up when I go to that movie.
+
+00:14:21.799 --> 00:14:22.799
+Yeah, same.
+
+00:14:22.799 --> 00:14:24.799
+Somebody is going to get beat up every time we go to that movie, dude.
+
+00:14:24.799 --> 00:14:27.799
+I had a couple close calls.
+
+00:14:27.799 --> 00:14:30.799
+There's always a fight when I go there.
+
+00:14:30.799 --> 00:14:31.799
+I'm just like, how?
+
+00:14:31.799 --> 00:14:34.799
+Oh, there's always a fight somewhere.
+
+00:14:34.799 --> 00:14:35.799
+In there.
+
+00:14:35.799 --> 00:14:36.799
+In there.
+
+00:14:36.799 --> 00:14:40.799
+There's always somebody lost that doesn't know how to get out of the parking lot because they make it really hard.
+
+00:14:40.799 --> 00:14:41.799
+Yeah.
+
+00:14:41.799 --> 00:14:44.799
+This theater doesn't even have that many fights.
+
+00:14:44.799 --> 00:14:45.799
+You ever been to that theater?
+
+00:14:45.799 --> 00:14:47.799
+They have reclining seats now.
+
+00:14:47.799 --> 00:14:49.799
+I got into a fight at the Stints Movie Theater.
+
+00:14:49.799 --> 00:14:53.799
+Not a fist fight, but a shushing match.
+
+00:14:53.799 --> 00:14:55.799
+I got into a shushing fight, if you will.
+
+00:14:55.799 --> 00:14:56.799
+I will.
+
+00:14:56.799 --> 00:14:59.799
+Shh, all out.
+
+00:14:59.799 --> 00:15:00.799
+Just shushing.
+
+00:15:00.799 --> 00:15:04.799
+All right, so we talked about the weather, and we talked about...
+
+00:15:04.799 --> 00:15:06.799
+What's going on with some music here?
+
+00:15:06.799 --> 00:15:08.799
+What are we listening to?
+
+00:15:08.799 --> 00:15:12.799
+What's your top three favorite new things that you've been listening to?
+
+00:15:12.799 --> 00:15:13.799
+Like that are like popping up right now?
+
+00:15:13.799 --> 00:15:14.799
+No, it could be like...
+
+00:15:14.799 --> 00:15:15.799
+Just in general?
+
+00:15:15.799 --> 00:15:19.799
+You just heard it for the first time the other day.
+
+00:15:19.799 --> 00:15:24.799
+I'm like super heavy into SZA right now.
+
+00:15:24.799 --> 00:15:27.799
+That thing that you guys were listening to when...
+
+00:15:27.799 --> 00:15:32.799
+Yeah, that girl, she's on like TV with like Kendrick Lamar.
+
+00:15:32.799 --> 00:15:37.799
+And like Isaiah Rashad, stuff like that.
+
+00:15:37.799 --> 00:15:39.799
+She's like super, super good.
+
+00:15:39.799 --> 00:15:43.799
+She just released that album.
+
+00:15:43.799 --> 00:15:44.799
+And then just like...
+
+00:15:44.799 --> 00:15:47.799
+I've been listening to a lot of hardcore music lately.
+
+00:15:47.799 --> 00:15:49.799
+Hardcore, like what year?
+
+00:15:49.799 --> 00:15:50.799
+Like new.
+
+00:15:50.799 --> 00:15:51.799
+Hardcore is so different from...
+
+00:15:51.799 --> 00:15:52.799
+No, like new.
+
+00:15:52.799 --> 00:15:54.799
+Like new age.
+
+00:15:54.799 --> 00:15:56.799
+This band called Counterparts.
+
+00:15:56.799 --> 00:15:59.799
+I saw them at Warped Tour this past summer.
+
+00:15:59.799 --> 00:16:01.799
+And I was like, damn, these dudes are fucking super good.
+
+00:16:01.799 --> 00:16:02.799
+I'm like, who are these guys?
+
+00:16:02.799 --> 00:16:04.799
+And my girlfriend was like, it's Counterparts.
+
+00:16:04.799 --> 00:16:07.799
+I'm like, I want to look those guys up.
+
+00:16:07.799 --> 00:16:09.799
+And like I've just been super into them lately.
+
+00:16:09.799 --> 00:16:13.799
+But that's pretty much all I've been playing in my car for the last like couple weeks.
+
+00:16:13.799 --> 00:16:16.799
+See, I just got a new car and it just has the CD player.
+
+00:16:16.799 --> 00:16:20.799
+Yeah, we were listening to the Deftones CD the other night.
+
+00:16:20.799 --> 00:16:21.799
+Yeah.
+
+00:16:21.799 --> 00:16:23.799
+Yeah, but I've been listening to like...
+
+00:16:23.799 --> 00:16:26.799
+I stockpile all these local musicians that hand me CDs
+
+00:16:26.799 --> 00:16:29.799
+and I don't get a chance to listen to it because it's not in like...
+
+00:16:29.799 --> 00:16:31.799
+You know, I got to download it to my computer.
+
+00:16:31.799 --> 00:16:32.799
+Well, we fucking have a CD player.
+
+00:16:32.799 --> 00:16:34.799
+You know, I just fucking hoop and dance and all that shit.
+
+00:16:34.799 --> 00:16:39.799
+But now I got this car and I was listening to Tim Walsh.
+
+00:16:39.799 --> 00:16:40.799
+Have you ever heard...
+
+00:16:40.799 --> 00:16:42.799
+Dude, Tim fucking Walsh.
+
+00:16:42.799 --> 00:16:44.799
+Have you ever heard his CD though?
+
+00:16:44.799 --> 00:16:46.799
+Oh, he gave it to me, dude.
+
+00:16:46.799 --> 00:16:47.799
+Did you listen to it?
+
+00:16:47.799 --> 00:16:48.799
+Yeah, I have it in my car still.
+
+00:16:48.799 --> 00:16:49.799
+What did it sound like?
+
+00:16:49.799 --> 00:16:50.799
+It was completely different, right?
+
+00:16:50.799 --> 00:16:51.799
+It's amazing, dude.
+
+00:16:51.799 --> 00:16:52.799
+It's so good, man.
+
+00:16:52.799 --> 00:16:54.799
+I'm out of the loop on this one.
+
+00:16:54.799 --> 00:16:55.799
+Oh, it's crazy.
+
+00:16:55.799 --> 00:16:56.799
+He's really good, man.
+
+00:16:56.799 --> 00:16:57.799
+It sounds like...
+
+00:16:57.799 --> 00:16:58.799
+You're like, wait a minute, I know that song.
+
+00:16:58.799 --> 00:16:59.799
+Like, you know all the songs.
+
+00:16:59.799 --> 00:17:00.799
+Yeah.
+
+00:17:00.799 --> 00:17:03.799
+But they don't sound like that when it's just him.
+
+00:17:03.799 --> 00:17:05.800
+And I can't tell what I like better.
+
+00:17:05.800 --> 00:17:10.800
+I mean, I honestly think that I like him just and his guitar better.
+
+00:17:10.800 --> 00:17:12.800
+It's really good still, dude.
+
+00:17:12.800 --> 00:17:13.800
+He played one of the songs.
+
+00:17:13.800 --> 00:17:14.800
+I'm making it though.
+
+00:17:14.800 --> 00:17:15.800
+Oh, yeah.
+
+00:17:15.800 --> 00:17:21.800
+He played one of the songs.
+
+00:17:21.800 --> 00:17:22.800
+It was like slower.
+
+00:17:22.800 --> 00:17:23.800
+I don't know.
+
+00:17:23.800 --> 00:17:25.800
+If he plays it again, I'll know it.
+
+00:17:26.800 --> 00:17:35.800
+Yeah, that's actually the one.
+
+00:17:35.800 --> 00:17:37.800
+And it's like super jazzy.
+
+00:17:37.800 --> 00:17:41.800
+There's a lot of people with good voices around here.
+
+00:17:41.800 --> 00:17:42.800
+True shit.
+
+00:17:42.800 --> 00:17:43.800
+You're one of them.
+
+00:17:43.800 --> 00:17:44.800
+You're one of them.
+
+00:17:44.800 --> 00:17:46.800
+I'm jealous of you both.
+
+00:17:46.800 --> 00:17:48.800
+Dude, we're jealous of you, man.
+
+00:17:48.800 --> 00:17:49.800
+Yeah.
+
+00:17:49.800 --> 00:17:51.800
+We're all jealous of each other.
+
+00:17:52.800 --> 00:17:56.800
+It's a jealousy parade.
+
+00:17:56.800 --> 00:17:57.800
+First annual.
+
+00:17:57.800 --> 00:18:00.800
+No, but yeah, I've heard some really good singers.
+
+00:18:00.800 --> 00:18:08.800
+You know, being a host of an open mic and doing the music stuff that I've been doing for how many years,
+
+00:18:08.800 --> 00:18:14.800
+it's hard to find somebody that has everything.
+
+00:18:14.800 --> 00:18:15.800
+Right.
+
+00:18:15.800 --> 00:18:16.800
+Perfect.
+
+00:18:17.800 --> 00:18:33.800
+When I say everything, I mean pitch, timing, and the appreciation to keep the song valid for what it is instead of showboating.
+
+00:18:33.800 --> 00:18:36.800
+Everybody has a hard time with that.
+
+00:18:36.800 --> 00:18:42.800
+And then thinking about it, I've read some stuff about how musicians get on stage and they just want an adrenaline rush,
+
+00:18:42.800 --> 00:18:46.800
+so they turn themselves up and it releases endorphins.
+
+00:18:46.800 --> 00:18:50.800
+You hear yourself play louder, but it doesn't sound good.
+
+00:18:50.800 --> 00:18:51.800
+Right.
+
+00:18:51.800 --> 00:18:52.800
+And it only sounds good to you.
+
+00:18:52.800 --> 00:18:53.800
+Right.
+
+00:18:53.800 --> 00:18:54.800
+Because you get to hear yourself.
+
+00:18:54.800 --> 00:18:55.800
+It's the integrity of the song.
+
+00:18:55.800 --> 00:18:56.800
+Boom.
+
+00:18:56.800 --> 00:18:57.800
+It's true.
+
+00:18:57.800 --> 00:18:58.800
+It's passion, man.
+
+00:18:58.800 --> 00:18:59.800
+Yeah.
+
+00:18:59.800 --> 00:19:00.800
+You gotta get lost in it.
+
+00:19:00.800 --> 00:19:01.800
+Yeah, man.
+
+00:19:01.800 --> 00:19:02.800
+You know what I mean?
+
+00:19:02.800 --> 00:19:03.800
+I have a really close friend of mine.
+
+00:19:03.800 --> 00:19:05.800
+I don't want to mention his name, but he's an amazing guitar player.
+
+00:19:05.800 --> 00:19:08.800
+And he just drowns out the whole band.
+
+00:19:08.800 --> 00:19:11.800
+And it's just like, I don't know.
+
+00:19:12.800 --> 00:19:15.800
+I fucking hate it when people do that.
+
+00:19:15.800 --> 00:19:16.800
+Hold on, hold on, hold on.
+
+00:19:16.800 --> 00:19:17.800
+Who is it?
+
+00:19:17.800 --> 00:19:18.800
+I'll tell you later.
+
+00:19:18.800 --> 00:19:19.800
+Yeah, tell us all.
+
+00:19:19.800 --> 00:19:20.800
+Tell us all.
+
+00:19:20.800 --> 00:19:21.800
+I want to know who that is.
+
+00:19:21.800 --> 00:19:22.800
+Speak so highly.
+
+00:19:22.800 --> 00:19:23.800
+Dude, I…
+
+00:19:23.800 --> 00:19:27.800
+You got any local favorites?
+
+00:19:27.800 --> 00:19:28.800
+You got any local favorites?
+
+00:19:28.800 --> 00:19:31.800
+Dude, fucking Tim Walsh, man.
+
+00:19:31.800 --> 00:19:32.800
+Fucking Tim Walsh.
+
+00:19:32.800 --> 00:19:34.800
+That kid is the truth.
+
+00:19:34.800 --> 00:19:35.800
+I don't know why I'm calling him a kid.
+
+00:19:35.800 --> 00:19:36.800
+He's older than I am, I think.
+
+00:19:36.800 --> 00:19:37.800
+Yeah.
+
+00:19:37.800 --> 00:19:40.800
+Yeah, he's probably like 26.
+
+00:19:41.800 --> 00:19:42.800
+Something like that.
+
+00:19:42.800 --> 00:19:43.800
+How about you, Sammy?
+
+00:19:43.800 --> 00:19:44.800
+You got any local favorites?
+
+00:19:44.800 --> 00:19:46.800
+I got tons of local favorites.
+
+00:19:46.800 --> 00:19:49.800
+There's like so many people here that are just like doing their own thing.
+
+00:19:49.800 --> 00:19:51.800
+You know, carving out their own sound.
+
+00:19:51.800 --> 00:19:52.800
+It's super good.
+
+00:19:52.800 --> 00:19:53.800
+I walked out of my house today.
+
+00:19:53.800 --> 00:19:55.800
+I was letting my hair dry, so my hair was down.
+
+00:19:55.800 --> 00:19:57.800
+Carol Burnett style?
+
+00:19:57.800 --> 00:19:58.800
+Yeah.
+
+00:19:58.800 --> 00:20:02.800
+And the wind was just like making me nae nae.
+
+00:20:02.800 --> 00:20:07.800
+And I did this like slow motion finesse commercial.
+
+00:20:08.800 --> 00:20:09.800
+Because I had my hands full.
+
+00:20:09.800 --> 00:20:13.800
+I was walking in my car and I couldn't like get the hair off my, you know, face and neck.
+
+00:20:13.800 --> 00:20:14.800
+It was crossing.
+
+00:20:14.800 --> 00:20:15.800
+And I did this whole…
+
+00:20:15.800 --> 00:20:17.800
+I did this thing.
+
+00:20:17.800 --> 00:20:23.800
+And Alpha Rabbit, who lives right there, this like really cool band, were on their way to
+
+00:20:23.800 --> 00:20:24.800
+like their gig.
+
+00:20:24.800 --> 00:20:29.800
+And I saw the chick in the back seat look at me and do that thing that I just did.
+
+00:20:29.800 --> 00:20:31.800
+I felt like such an asshole.
+
+00:20:31.800 --> 00:20:32.800
+But then they beeped.
+
+00:20:32.800 --> 00:20:33.800
+Hey, what's my name?
+
+00:20:33.800 --> 00:20:34.800
+Blah, blah, blah.
+
+00:20:34.800 --> 00:20:35.800
+Oh, you're going to a gig.
+
+00:20:35.800 --> 00:20:36.800
+Yeah, blah, blah, blah.
+
+00:20:36.800 --> 00:20:40.800
+But like, I still know that they were making fun of me.
+
+00:20:41.800 --> 00:20:44.800
+So like, dude, look at fucking Benny just dancing outside of his house.
+
+00:20:44.800 --> 00:20:46.800
+Who the fuck do you think he is, dude?
+
+00:20:46.800 --> 00:20:48.800
+He thinks he's Cindy Crawford.
+
+00:20:51.800 --> 00:20:52.800
+Now.
+
+00:20:52.800 --> 00:20:53.800
+Now Cindy Crawford.
+
+00:20:53.800 --> 00:20:54.800
+Yeah, yeah, yeah.
+
+00:20:54.800 --> 00:20:56.800
+Not like primed up.
+
+00:20:56.800 --> 00:20:57.800
+Not like heyday, Cindy Crawford.
+
+00:20:57.800 --> 00:20:59.800
+Instead of beach in a swimsuit, let's do it.
+
+00:20:59.800 --> 00:21:00.800
+Let's do it.
+
+00:21:00.800 --> 00:21:02.800
+Where's my yellow one piece?
+
+00:21:03.800 --> 00:21:06.800
+I think Chalk and the Asian Americans are tight, too.
+
+00:21:06.800 --> 00:21:09.800
+They're like, they're local ish.
+
+00:21:09.800 --> 00:21:10.800
+Right.
+
+00:21:10.800 --> 00:21:11.800
+Yeah.
+
+00:21:11.800 --> 00:21:12.800
+They're based in Philly.
+
+00:21:12.800 --> 00:21:13.800
+Your friends are local, yeah.
+
+00:21:13.800 --> 00:21:14.800
+Yeah, but they're tight.
+
+00:21:14.800 --> 00:21:15.800
+Yeah.
+
+00:21:15.800 --> 00:21:16.800
+They played around.
+
+00:21:16.800 --> 00:21:17.800
+They have a show tonight.
+
+00:21:17.800 --> 00:21:18.800
+Where?
+
+00:21:18.800 --> 00:21:19.800
+Saturday the third.
+
+00:21:19.800 --> 00:21:20.800
+Oh, at the fire.
+
+00:21:20.800 --> 00:21:21.800
+Yeah.
+
+00:21:21.800 --> 00:21:22.800
+Definitely at the fire.
+
+00:21:22.800 --> 00:21:23.800
+That's right.
+
+00:21:23.800 --> 00:21:24.800
+Too bad we're not doing this live.
+
+00:21:24.800 --> 00:21:25.800
+Shit.
+
+00:21:25.800 --> 00:21:26.800
+Sorry, guys.
+
+00:21:26.800 --> 00:21:29.800
+Shout out to the other night when you guys played at the fire.
+
+00:21:29.800 --> 00:21:31.800
+And we're fucking mentioning it right now.
+
+00:21:33.800 --> 00:21:35.800
+Now, do Chalk and the Asian are tight.
+
+00:21:35.800 --> 00:21:36.800
+They're super fucking good.
+
+00:21:36.800 --> 00:21:37.800
+They really are.
+
+00:21:37.800 --> 00:21:39.800
+I've watched them come off a really long way.
+
+00:21:39.800 --> 00:21:42.800
+And like the guys in the band are just like the coolest fucking dudes ever.
+
+00:21:42.800 --> 00:21:43.800
+Yeah, they've been around for a minute, right?
+
+00:21:43.800 --> 00:21:44.800
+Yeah.
+
+00:21:44.800 --> 00:21:45.800
+They're so good, dude.
+
+00:21:45.800 --> 00:21:47.800
+I've watched like YouTube videos of them.
+
+00:21:47.800 --> 00:21:51.800
+Like I saw like their like old like YouTube music videos and shit from like super long ago.
+
+00:21:51.800 --> 00:21:53.800
+I'm just like, damn, dude.
+
+00:21:53.800 --> 00:21:54.800
+That's fucking sick, dude.
+
+00:21:54.800 --> 00:21:55.800
+They're tight.
+
+00:21:55.800 --> 00:21:56.800
+What do you got?
+
+00:21:56.800 --> 00:21:58.800
+Who are you looking at these days?
+
+00:21:58.800 --> 00:21:59.800
+Who am I looking at locally?
+
+00:21:59.800 --> 00:22:00.800
+Yeah.
+
+00:22:00.800 --> 00:22:01.800
+Yeah.
+
+00:22:01.800 --> 00:22:02.800
+Yeah.
+
+00:22:02.800 --> 00:22:03.800
+Well, I mean.
+
+00:22:03.800 --> 00:22:04.800
+Yeah.
+
+00:22:04.800 --> 00:22:05.800
+Yeah.
+
+00:22:05.800 --> 00:22:06.800
+Yeah.
+
+00:22:06.800 --> 00:22:07.800
+You got Sean Ladin.
+
+00:22:07.800 --> 00:22:08.800
+You got the Connick Troy.
+
+00:22:08.800 --> 00:22:09.800
+Sean fucking Ladin, dude.
+
+00:22:09.800 --> 00:22:10.800
+Connick Troy fuzz brain.
+
+00:22:10.800 --> 00:22:11.800
+True.
+
+00:22:11.800 --> 00:22:12.800
+Fuzz.
+
+00:22:12.800 --> 00:22:13.800
+The fuzz.
+
+00:22:13.800 --> 00:22:14.800
+That CD is addictive.
+
+00:22:14.800 --> 00:22:15.800
+Did that come out yet?
+
+00:22:15.800 --> 00:22:16.800
+What?
+
+00:22:16.800 --> 00:22:17.800
+Did they release it?
+
+00:22:17.800 --> 00:22:18.800
+Yeah.
+
+00:22:18.800 --> 00:22:19.800
+Oh, yeah.
+
+00:22:19.800 --> 00:22:20.800
+Oh, my God.
+
+00:22:20.800 --> 00:22:21.800
+I forgot about that.
+
+00:22:21.800 --> 00:22:22.800
+Yo, it's amazing.
+
+00:22:22.800 --> 00:22:23.800
+Yeah.
+
+00:22:23.800 --> 00:22:24.800
+I got to snag a copy of that.
+
+00:22:24.800 --> 00:22:25.800
+I can't stop listening to this thing.
+
+00:22:25.800 --> 00:22:26.800
+I put on all these other CDs, and then.
+
+00:22:26.800 --> 00:22:27.800
+There's just something about it.
+
+00:22:27.800 --> 00:22:28.800
+Yeah.
+
+00:22:28.800 --> 00:22:29.800
+Is it online?
+
+00:22:29.800 --> 00:22:30.800
+Yeah.
+
+00:22:30.800 --> 00:22:31.800
+I think so.
+
+00:22:31.800 --> 00:22:32.800
+I think it is, yeah.
+
+00:22:32.800 --> 00:22:33.800
+On like, SoundCloud?
+
+00:22:33.800 --> 00:22:34.800
+I'm sure.
+
+00:22:34.800 --> 00:22:35.800
+Fuzz brain, yeah.
+
+00:22:35.800 --> 00:22:36.800
+If you Google fuzz brain or Connor.
+
+00:22:36.800 --> 00:22:37.800
+I follow them on SoundCloud.
+
+00:22:37.800 --> 00:22:38.800
+So if it's on SoundCloud, then I should be able to find it easily.
+
+00:22:38.800 --> 00:22:39.800
+Yeah.
+
+00:22:39.800 --> 00:22:40.800
+SoundCloud's a good way to listen to some local music.
+
+00:22:40.800 --> 00:22:41.800
+SoundCloud is on a rise right now, dude.
+
+00:22:41.800 --> 00:22:42.800
+Everybody's looking at SoundCloud right now.
+
+00:22:42.800 --> 00:22:43.800
+Which is good, but it's a little over saturated.
+
+00:22:43.800 --> 00:22:55.800
+Yeah.
+
+00:22:55.800 --> 00:22:56.800
+Which is good, but it's a little oversaturated.
+
+00:22:56.800 --> 00:22:57.800
+Yeah.
+
+00:22:57.800 --> 00:22:58.800
+You know what I'm saying?
+
+00:22:58.800 --> 00:22:59.959
+That's what happens though, like, you have like that.
+
+00:22:59.959 --> 00:23:01.040
+That's what everything is.
+
+00:23:01.040 --> 00:23:04.420
+Model and then it builds up, and then it gets like a little bit worse and then something
+
+00:23:04.420 --> 00:23:05.420
+else comes along.
+
+00:23:05.420 --> 00:23:06.439
+But Spotify is like.
+
+00:23:06.439 --> 00:23:09.819
+Spotify is where it's at right now.
+
+00:23:09.819 --> 00:23:14.160
+I see everybody that doesn't have an iPhone tells me Spotify is where it's at.
+
+00:23:14.160 --> 00:23:15.160
+You know, and.
+
+00:23:15.160 --> 00:23:16.160
+And I think that's why.
+
+00:23:16.160 --> 00:23:19.180
+Everything that Sam says is like, the people that don't have iPhones.
+
+00:23:19.180 --> 00:23:20.180
+Yeah.
+
+00:23:20.180 --> 00:23:21.260
+He's so pro.
+
+00:23:21.260 --> 00:23:22.260
+Yeah.
+
+00:23:22.260 --> 00:23:23.339
+Do it a different way.
+
+00:23:23.880 --> 00:23:24.880
+It's funny.
+
+00:23:24.880 --> 00:23:25.880
+It's not just you.
+
+00:23:25.880 --> 00:23:26.880
+There's a lot of others.
+
+00:23:26.880 --> 00:23:30.280
+I mean, it's not like Spotify did at first, but that's fine.
+
+00:23:30.280 --> 00:23:38.359
+I love that you're fucking backing Spotify to the death right now.
+
+00:23:38.359 --> 00:23:42.920
+Somebody can fucking put a gun in my face and I'll rep Spotify to death, bro.
+
+00:23:42.920 --> 00:23:43.920
+Fucking CEO could do it.
+
+00:23:43.920 --> 00:23:44.920
+I don't give a shit.
+
+00:23:44.920 --> 00:23:45.920
+Rep your set, dude.
+
+00:23:45.920 --> 00:23:46.920
+I agree with that.
+
+00:23:46.920 --> 00:23:47.920
+You know what I'm saying?
+
+00:23:47.920 --> 00:23:48.920
+Nobody's doing it for title.
+
+00:23:48.920 --> 00:23:49.920
+Always has good points.
+
+00:23:49.920 --> 00:23:56.920
+You know, I've been the angry consumer where I like my own things and Sam's like, try this.
+
+00:23:56.920 --> 00:23:57.920
+And I'm like, man.
+
+00:23:57.920 --> 00:23:58.920
+He's like, man.
+
+00:23:58.920 --> 00:23:59.920
+So like my shit.
+
+00:23:59.920 --> 00:24:00.920
+So I'm like, man, right back.
+
+00:24:00.920 --> 00:24:03.920
+And then the other ones, well, I wasn't doing this.
+
+00:24:03.920 --> 00:24:04.920
+It's like, all right.
+
+00:24:04.920 --> 00:24:05.920
+It works.
+
+00:24:05.920 --> 00:24:06.920
+All right.
+
+00:24:06.920 --> 00:24:13.920
+I feel like Spotify is becoming like a super, like a super mainstream kind of streaming
+
+00:24:13.920 --> 00:24:14.920
+platform.
+
+00:24:14.920 --> 00:24:15.920
+You know what I mean?
+
+00:24:15.920 --> 00:24:16.920
+Yeah.
+
+00:24:16.920 --> 00:24:17.920
+Like it's becoming like iTunes.
+
+00:24:17.920 --> 00:24:18.920
+It's just a little bit more.
+
+00:24:18.920 --> 00:24:19.920
+Yeah.
+
+00:24:19.920 --> 00:24:20.920
+I'm an iTunes baby.
+
+00:24:20.920 --> 00:24:21.920
+Same.
+
+00:24:21.920 --> 00:24:22.920
+But that was the only thing.
+
+00:24:22.920 --> 00:24:23.920
+Yeah.
+
+00:24:23.920 --> 00:24:24.920
+Pretty much.
+
+00:24:24.920 --> 00:24:25.920
+I mean, like legally.
+
+00:24:25.920 --> 00:24:26.920
+iTunes is like Blockbuster.
+
+00:24:26.920 --> 00:24:27.920
+Spotify.
+
+00:24:27.920 --> 00:24:28.920
+No, they're not like Blockbuster.
+
+00:24:28.920 --> 00:24:34.920
+And did you just say Spotify is a lot like Netflix too?
+
+00:24:34.920 --> 00:24:35.920
+Yeah.
+
+00:24:35.920 --> 00:24:36.920
+That is the ultimate fuck.
+
+00:24:36.920 --> 00:24:39.920
+That's a worse dig than the Verizon guy.
+
+00:24:39.920 --> 00:24:45.920
+The can you hear me now guy switching to AT&T like a straight punk dude.
+
+00:24:45.920 --> 00:24:46.920
+That guy is a punk man.
+
+00:24:46.920 --> 00:24:48.920
+People used to say I looked like that guy.
+
+00:24:48.920 --> 00:24:49.920
+Really?
+
+00:24:49.920 --> 00:24:50.920
+Well, I had.
+
+00:24:50.920 --> 00:24:52.920
+Oh, when you had short hair and a little soul patch.
+
+00:24:52.920 --> 00:24:53.920
+Yeah.
+
+00:24:53.920 --> 00:24:56.920
+That's because people look at somebody with glasses and a soul patch and black hair and
+
+00:24:56.920 --> 00:24:58.920
+you all look the fucking same.
+
+00:24:58.920 --> 00:25:00.920
+It doesn't matter what you need to be like.
+
+00:25:00.920 --> 00:25:04.920
+I think that guy is straight up right off the boat from like Sweden.
+
+00:25:04.920 --> 00:25:05.920
+And I'm like Indian.
+
+00:25:05.920 --> 00:25:08.920
+Were you in that Verizon commercial?
+
+00:25:08.920 --> 00:25:09.920
+No.
+
+00:25:09.920 --> 00:25:10.920
+No.
+
+00:25:10.920 --> 00:25:12.920
+Do I look like that guy?
+
+00:25:12.920 --> 00:25:13.920
+Yeah.
+
+00:25:13.920 --> 00:25:14.920
+You do a little.
+
+00:25:14.920 --> 00:25:15.920
+That's crazy.
+
+00:25:15.920 --> 00:25:16.920
+No, that's a huge dig though.
+
+00:25:16.920 --> 00:25:18.920
+Shout out to that guy for following his dreams though.
+
+00:25:18.920 --> 00:25:20.920
+We're going to jam out a little bit.
+
+00:25:20.920 --> 00:25:22.920
+You want to do some jamming?
+
+00:25:22.920 --> 00:25:23.920
+Lettuce.
+
+00:25:23.920 --> 00:25:24.920
+Lettuce.
+
+00:25:24.920 --> 00:25:25.920
+Lettuce.
+
+00:25:25.920 --> 00:25:26.920
+Lettuce dude.
+
+00:25:26.920 --> 00:25:27.920
+I love lettuce.
+
+00:25:27.920 --> 00:25:28.920
+Lettuce.
+
+00:25:28.920 --> 00:25:30.920
+Favorite toppings on a hoagie.
+
+00:25:30.920 --> 00:25:31.920
+Go.
+
+00:25:31.920 --> 00:25:32.920
+Lettuce.
+
+00:25:32.920 --> 00:25:33.920
+Tomato.
+
+00:25:33.920 --> 00:25:34.920
+Lettuce.
+
+00:25:34.920 --> 00:25:35.920
+That's it?
+
+00:25:35.920 --> 00:25:36.920
+A little vinegar?
+
+00:25:36.920 --> 00:25:37.920
+A little bit.
+
+00:25:37.920 --> 00:25:38.920
+A little bit.
+
+00:25:38.920 --> 00:25:39.920
+A little bit.
+
+00:25:39.920 --> 00:25:40.920
+You a mayo guy?
+
+00:25:40.920 --> 00:25:41.920
+Yeah.
+
+00:25:41.920 --> 00:25:42.920
+You a mayo guy?
+
+00:25:42.920 --> 00:25:43.920
+Yeah.
+
+00:25:43.920 --> 00:25:44.920
+Honey mustard or anything like that?
+
+00:25:44.920 --> 00:25:45.920
+Honey mustard.
+
+00:25:45.920 --> 00:25:46.920
+What meats and cheese?
+
+00:25:46.920 --> 00:25:47.920
+Oh man.
+
+00:25:47.920 --> 00:25:48.920
+You do Italian?
+
+00:25:48.920 --> 00:25:49.920
+You do bologna?
+
+00:25:49.920 --> 00:25:54.920
+No, my favorite of all favorites which I've been trying to stay away from is the rare roast
+
+00:25:54.920 --> 00:25:58.920
+beef with a little bit of turkey and some provolone.
+
+00:25:58.920 --> 00:25:59.920
+Okay.
+
+00:25:59.920 --> 00:26:02.920
+See, I'm a basic.
+
+00:26:02.920 --> 00:26:04.920
+I'm a one scoop ass bitch.
+
+00:26:04.920 --> 00:26:06.920
+So I will do the Italian.
+
+00:26:06.920 --> 00:26:07.920
+The classic Italian.
+
+00:26:08.920 --> 00:26:13.920
+Or I just eat a lot of turkey, American, lettuce, mayo.
+
+00:26:13.920 --> 00:26:14.920
+Done.
+
+00:26:14.920 --> 00:26:16.920
+I don't need no extra additives.
+
+00:26:16.920 --> 00:26:17.920
+What about you Sam?
+
+00:26:17.920 --> 00:26:23.920
+Sam's like coming up with all the hoagies he's eaten his entire life.
+
+00:26:23.920 --> 00:26:26.920
+One time I drove to Philly and got hoagies.
+
+00:26:28.920 --> 00:26:32.920
+Hey man, just give me some cucumber, some hummus.
+
+00:26:33.920 --> 00:26:37.920
+So literally the exact opposite of the question I asked.
+
+00:26:37.920 --> 00:26:38.920
+Cool.
+
+00:26:40.920 --> 00:26:42.920
+What's your favorite kind of hoagie?
+
+00:26:42.920 --> 00:26:44.920
+You know, I'm just really into cucumbers and hummus.
+
+00:26:44.920 --> 00:26:46.920
+Awesome dude.
+
+00:26:46.920 --> 00:26:49.920
+What kind of fucking hoagie do you like?
+
+00:26:49.920 --> 00:26:50.920
+What are you into?
+
+00:26:50.920 --> 00:26:52.920
+Do you eat hoagies often?
+
+00:26:52.920 --> 00:26:56.920
+Are you a cold sub guy or are you a hot sub guy?
+
+00:26:56.920 --> 00:26:57.920
+I'm neither now.
+
+00:26:57.920 --> 00:26:58.920
+Really?
+
+00:26:58.920 --> 00:26:59.920
+Yeah.
+
+00:26:59.920 --> 00:27:00.920
+Why?
+
+00:27:00.920 --> 00:27:01.920
+Are you on a diet?
+
+00:27:01.920 --> 00:27:02.920
+He's a vegetarian.
+
+00:27:02.920 --> 00:27:04.920
+Are you a vegetarian?
+
+00:27:04.920 --> 00:27:05.920
+Is that both?
+
+00:27:05.920 --> 00:27:06.920
+It's all of those.
+
+00:27:06.920 --> 00:27:07.920
+Wait, are you a vegan?
+
+00:27:07.920 --> 00:27:08.920
+All of those.
+
+00:27:08.920 --> 00:27:09.920
+Are you a vegan or are you just a vegetarian?
+
+00:27:09.920 --> 00:27:10.920
+He's got eyebrows.
+
+00:27:12.920 --> 00:27:13.920
+Yeah.
+
+00:27:13.920 --> 00:27:14.920
+You're a vegan?
+
+00:27:14.920 --> 00:27:15.920
+No.
+
+00:27:15.920 --> 00:27:16.920
+You're a vegetarian?
+
+00:27:16.920 --> 00:27:17.920
+Closer.
+
+00:27:17.920 --> 00:27:18.920
+Sometimes.
+
+00:27:18.920 --> 00:27:20.920
+Vegetarians don't eat fish.
+
+00:27:20.920 --> 00:27:21.920
+You're a pescatarian.
+
+00:27:21.920 --> 00:27:22.920
+Yeah.
+
+00:27:23.920 --> 00:27:25.920
+But you do try to avoid...
+
+00:27:25.920 --> 00:27:27.920
+I have holes, alright?
+
+00:27:27.920 --> 00:27:29.920
+He's got holes that I keep shutting down.
+
+00:27:29.920 --> 00:27:34.920
+That's like the laziest person that's trying to go on a vegetarian diet.
+
+00:27:34.920 --> 00:27:36.920
+It's the thought that counts.
+
+00:27:36.920 --> 00:27:40.920
+Every time I eat a chicken, I feel super bad about it.
+
+00:27:40.920 --> 00:27:41.920
+I do that too, though.
+
+00:27:41.920 --> 00:27:44.920
+I try to shop vegan and I get all this vegan fucking food
+
+00:27:44.920 --> 00:27:47.920
+and then I wind up going out every night because I don't want to eat that.
+
+00:27:47.920 --> 00:27:48.920
+Yeah, dude.
+
+00:27:48.920 --> 00:27:49.920
+Nobody does.
+
+00:27:50.920 --> 00:27:51.920
+The fuck you talking about?
+
+00:27:51.920 --> 00:27:52.920
+I want to.
+
+00:27:52.920 --> 00:27:53.920
+Nobody does, man.
+
+00:27:53.920 --> 00:27:54.920
+It's tasty.
+
+00:27:54.920 --> 00:27:58.920
+I have friends that own the Old Mill in Allentown.
+
+00:27:59.920 --> 00:28:02.920
+And I go to their family parties and their Christmas parties and stuff.
+
+00:28:02.920 --> 00:28:05.920
+Everybody in their family is either vegan or vegetarian.
+
+00:28:05.920 --> 00:28:09.920
+So the only thing they have there is vegan and vegetarian stuff.
+
+00:28:09.920 --> 00:28:11.920
+And it's all labeled.
+
+00:28:11.920 --> 00:28:15.920
+So I always eat Taco Bell or something before I go.
+
+00:28:15.920 --> 00:28:18.920
+I had a huge vegan lunch.
+
+00:28:18.920 --> 00:28:20.920
+Good, you guys.
+
+00:28:20.920 --> 00:28:21.920
+You know what I mean?
+
+00:28:21.920 --> 00:28:26.920
+But I have tried the tofu chicken or whatever.
+
+00:28:26.920 --> 00:28:28.920
+And it had buffalo sauce on it.
+
+00:28:28.920 --> 00:28:30.920
+I hate buffalo sauce.
+
+00:28:30.920 --> 00:28:31.920
+I'll eat a phone.
+
+00:28:31.920 --> 00:28:35.920
+I'll eat a cassette tape if it has buffalo sauce on it.
+
+00:28:35.920 --> 00:28:37.920
+That shit does not bother me.
+
+00:28:37.920 --> 00:28:38.920
+But it's good.
+
+00:28:38.920 --> 00:28:39.920
+I was not disappointed in it.
+
+00:28:39.920 --> 00:28:40.920
+But I don't want to eat that shit every day.
+
+00:28:40.920 --> 00:28:42.920
+Sam would eat an iPhone.
+
+00:28:42.920 --> 00:28:45.920
+Sam would only eat Samsung or Google phones.
+
+00:28:46.920 --> 00:28:48.920
+Is it a Galaxy?
+
+00:28:48.920 --> 00:28:49.920
+Is it a Pixel?
+
+00:28:49.920 --> 00:28:51.920
+It's an iPod Touch?
+
+00:28:51.920 --> 00:28:52.920
+No, thanks.
+
+00:28:53.920 --> 00:28:54.920
+Hold the iPod Touch.
+
+00:28:54.920 --> 00:28:55.920
+I'm not going to touch that one.
+
+00:28:55.920 --> 00:28:56.920
+Have you ever gone in an Apple store?
+
+00:28:56.920 --> 00:28:58.920
+Are you afraid that you'll just burst into flames?
+
+00:28:58.920 --> 00:28:59.920
+No, I've been there.
+
+00:28:59.920 --> 00:29:00.920
+You have?
+
+00:29:00.920 --> 00:29:01.920
+No, I've been there.
+
+00:29:01.920 --> 00:29:02.920
+Not impressed?
+
+00:29:02.920 --> 00:29:06.920
+Sam's going to get an iPhone X before they get the 11 going.
+
+00:29:06.920 --> 00:29:08.920
+What do you think they're going to do, though?
+
+00:29:08.920 --> 00:29:10.920
+What do you honestly think they're going to do?
+
+00:29:10.920 --> 00:29:11.920
+I don't know.
+
+00:29:11.920 --> 00:29:12.920
+What is left?
+
+00:29:12.920 --> 00:29:13.920
+I think they'll just jump to 5.
+
+00:29:13.920 --> 00:29:15.920
+No, honestly.
+
+00:29:15.920 --> 00:29:18.920
+So we're just going to put it in your head.
+
+00:29:18.920 --> 00:29:20.920
+We're going to go back to 5 because 5 was so shitty.
+
+00:29:20.920 --> 00:29:22.920
+It was our worst phone.
+
+00:29:22.920 --> 00:29:23.920
+I feel like their next thing is going to be like,
+
+00:29:23.920 --> 00:29:25.920
+we're just going to put it in your head.
+
+00:29:25.920 --> 00:29:29.920
+And then you've got to wear these fucking sunglasses everywhere you go.
+
+00:29:29.920 --> 00:29:31.920
+And they'll just see it in your face.
+
+00:29:31.920 --> 00:29:32.920
+And the chip.
+
+00:29:32.920 --> 00:29:34.920
+You guys watch Black Mirror?
+
+00:29:34.920 --> 00:29:35.920
+Yeah.
+
+00:29:35.920 --> 00:29:36.920
+Like Black Mirror?
+
+00:29:36.920 --> 00:29:37.920
+When they did that.
+
+00:29:37.920 --> 00:29:38.920
+Did you see the one where they...
+
+00:29:38.920 --> 00:29:40.920
+I was barking and it was like...
+
+00:29:40.920 --> 00:29:41.920
+Yeah.
+
+00:29:41.920 --> 00:29:43.920
+Or the one where they did the...
+
+00:29:43.920 --> 00:29:44.920
+They put like the...
+
+00:29:44.920 --> 00:29:46.920
+It's like the same thing we were just talking about, basically.
+
+00:29:46.920 --> 00:29:48.920
+It's like the video game, though.
+
+00:29:48.920 --> 00:29:51.920
+So they did a virtual reality thing and they just put it in the back of his fucking head.
+
+00:29:51.920 --> 00:29:52.920
+It was like a haunted version.
+
+00:29:53.920 --> 00:29:54.920
+Black Mirror is real.
+
+00:29:54.920 --> 00:29:55.920
+Black Mirror is going to happen.
+
+00:29:55.920 --> 00:29:56.920
+It's going to happen.
+
+00:29:56.920 --> 00:29:58.920
+So many things from Black Mirror have already happened.
+
+00:30:00.920 --> 00:30:02.920
+I didn't like it.
+
+00:30:02.920 --> 00:30:03.920
+I wasn't a fan.
+
+00:30:03.920 --> 00:30:04.920
+At first.
+
+00:30:06.920 --> 00:30:08.920
+I watched like half of one episode.
+
+00:30:08.920 --> 00:30:13.920
+San Junipero, which is my friend Leo's favorite episode.
+
+00:30:13.920 --> 00:30:19.920
+It's the one where they put that little thing on your head and it lets you travel through your mind.
+
+00:30:19.920 --> 00:30:20.920
+But it feels like real life.
+
+00:30:20.920 --> 00:30:21.920
+You know what I mean?
+
+00:30:21.920 --> 00:30:23.920
+It's basically like heaven, I guess.
+
+00:30:24.920 --> 00:30:25.920
+What is that?
+
+00:30:25.920 --> 00:30:26.920
+Surrogate?
+
+00:30:26.920 --> 00:30:27.920
+With Bruce Willis?
+
+00:30:27.920 --> 00:30:28.920
+Yeah.
+
+00:30:28.920 --> 00:30:29.920
+Never saw that.
+
+00:30:29.920 --> 00:30:30.920
+Same plot.
+
+00:30:30.920 --> 00:30:31.920
+Same plot.
+
+00:30:31.920 --> 00:30:32.920
+Less Bruce Willis.
+
+00:30:32.920 --> 00:30:35.920
+Dude, how about Will Ferrell?
+
+00:30:35.920 --> 00:30:37.920
+Me and Sam were talking about Will Ferrell the other day.
+
+00:30:37.920 --> 00:30:39.920
+He's timeless.
+
+00:30:39.920 --> 00:30:41.920
+This is such a good fucking movie, too.
+
+00:30:41.920 --> 00:30:42.920
+Really?
+
+00:30:42.920 --> 00:30:43.920
+Everything must go?
+
+00:30:43.920 --> 00:30:44.920
+So good.
+
+00:30:44.920 --> 00:30:45.920
+This is such a good movie.
+
+00:30:45.920 --> 00:30:49.920
+Dude, the small gentleman is Biggie Small's son.
+
+00:30:49.920 --> 00:30:50.920
+Oh, really?
+
+00:30:50.920 --> 00:30:51.920
+Yeah, dude.
+
+00:30:51.920 --> 00:30:52.920
+It's Christopher Wallace Jr.
+
+00:30:52.920 --> 00:30:53.920
+It's crazy.
+
+00:30:53.920 --> 00:30:54.920
+Wow.
+
+00:30:54.920 --> 00:30:55.920
+I didn't know that.
+
+00:30:55.920 --> 00:30:56.920
+And then I saw him do an interview.
+
+00:30:56.920 --> 00:30:59.920
+And he was like, yeah, I've done a couple movies and shit like that.
+
+00:30:59.920 --> 00:31:00.920
+I looked it up.
+
+00:31:00.920 --> 00:31:01.920
+It was IMDb.
+
+00:31:01.920 --> 00:31:02.920
+He was in this.
+
+00:31:02.920 --> 00:31:03.920
+And I'm like, oh my God, that's the kid.
+
+00:31:03.920 --> 00:31:08.920
+So look, Will Ferrell can literally just set up a yard sale in a dramatic role.
+
+00:31:08.920 --> 00:31:10.920
+And it's hilarious.
+
+00:31:10.920 --> 00:31:15.920
+Yeah, I like how this is like, it's like a little darker.
+
+00:31:15.920 --> 00:31:16.920
+You know what I'm saying?
+
+00:31:16.920 --> 00:31:17.920
+Yeah.
+
+00:31:17.920 --> 00:31:18.920
+But this is so good.
+
+00:31:18.920 --> 00:31:19.920
+It's still super funny.
+
+00:31:19.920 --> 00:31:20.920
+It is.
+
+00:31:20.920 --> 00:31:21.920
+But it's like, it's like dark comedy.
+
+00:31:21.920 --> 00:31:22.920
+You know what I'm saying?
+
+00:31:22.920 --> 00:31:23.920
+It's a really dark comedy.
+
+00:31:23.920 --> 00:31:24.920
+And I like that.
+
+00:31:24.920 --> 00:31:25.920
+I didn't know Will Ferrell could actually do anything.
+
+00:31:25.920 --> 00:31:26.920
+It would be funny as hell.
+
+00:31:26.920 --> 00:31:27.920
+I'm kidding.
+
+00:31:27.920 --> 00:31:28.920
+I think the directors know that, too.
+
+00:31:28.920 --> 00:31:29.920
+That's why they put him in all this shit, dude.
+
+00:31:29.920 --> 00:31:30.920
+Just put these two tiki torches that are not lit up against that post right there.
+
+00:31:30.920 --> 00:31:31.920
+Just let them fall.
+
+00:31:31.920 --> 00:31:32.920
+And just be like, geez, my life.
+
+00:31:32.920 --> 00:31:52.920
+My life.
+
+00:31:52.920 --> 00:31:53.920
+You know?
+
+00:31:53.920 --> 00:31:54.920
+Everything about it was funny.
+
+00:31:54.920 --> 00:31:55.920
+It's a great movie, though.
+
+00:31:55.920 --> 00:31:56.920
+When did this come out?
+
+00:31:56.920 --> 00:31:57.920
+2009.
+
+00:31:57.920 --> 00:31:58.920
+Really?
+
+00:31:58.920 --> 00:31:59.920
+No.
+
+00:31:59.920 --> 00:32:00.920
+Nah, like 12.
+
+00:32:00.920 --> 00:32:01.920
+2014.
+
+00:32:01.920 --> 00:32:02.920
+I have no confidence.
+
+00:32:02.920 --> 00:32:03.920
+That's a huge jump.
+
+00:32:03.920 --> 00:32:04.920
+Yeah, you really don't.
+
+00:32:04.920 --> 00:32:05.920
+Holy shit.
+
+00:32:05.920 --> 00:32:06.920
+I don't know.
+
+00:32:06.920 --> 00:32:07.920
+But what were we just talking about?
+
+00:32:07.920 --> 00:32:08.920
+Cookies.
+
+00:32:08.920 --> 00:32:09.920
+No, we were talking about Apple.
+
+00:32:09.920 --> 00:32:13.739
+What they're going to do next.
+
+00:32:13.739 --> 00:32:14.739
+What can they do?
+
+00:32:14.739 --> 00:32:15.739
+That's what I'm saying.
+
+00:32:16.000 --> 00:32:23.119
+I feel like from the jump to even just like the 6 or the 7, which were like super influential,
+
+00:32:23.119 --> 00:32:24.119
+to the 10.
+
+00:32:24.119 --> 00:32:25.119
+They had no money.
+
+00:32:25.119 --> 00:32:27.040
+It's not like what they're going to do next.
+
+00:32:27.040 --> 00:32:30.000
+Apple has like iPhone like 25 already.
+
+00:32:30.000 --> 00:32:32.040
+They have the next 10 years set up.
+
+00:32:32.040 --> 00:32:36.239
+It's all set up and they just, they give it to us in little tiny bits.
+
+00:32:36.239 --> 00:32:42.239
+They just sprinkle in this and sprinkle in that and charge the same price every time.
+
+00:32:42.239 --> 00:32:45.239
+Charge the same fucking price every time, dude.
+
+00:32:45.739 --> 00:32:46.739
+That's crazy.
+
+00:32:46.739 --> 00:32:47.739
+Do you have the big gigabyte 10?
+
+00:32:47.739 --> 00:32:48.739
+Yes.
+
+00:32:48.739 --> 00:32:49.739
+I have the smaller one.
+
+00:32:49.739 --> 00:32:52.739
+It was like a $5 price difference on the payment plan.
+
+00:32:52.739 --> 00:32:53.739
+I'm poor.
+
+00:32:53.739 --> 00:32:54.739
+I know, like why?
+
+00:32:54.739 --> 00:32:55.739
+But it gives a shit.
+
+00:32:55.739 --> 00:32:56.739
+I'm saving that $5.
+
+00:32:56.739 --> 00:32:57.739
+They make it super easy.
+
+00:32:57.739 --> 00:33:00.739
+They make it super easy for like 13 year olds to buy.
+
+00:33:00.739 --> 00:33:01.739
+Yeah.
+
+00:33:01.739 --> 00:33:02.739
+Back when it was like.
+
+00:33:02.739 --> 00:33:03.739
+That's why it's good.
+
+00:33:03.739 --> 00:33:05.739
+You need like $1,400 to buy this phone.
+
+00:33:05.739 --> 00:33:06.739
+Right now.
+
+00:33:06.739 --> 00:33:07.739
+Yeah.
+
+00:33:07.739 --> 00:33:08.739
+Right now.
+
+00:33:08.739 --> 00:33:09.739
+Now it's like you need, what's your name?
+
+00:33:09.739 --> 00:33:10.739
+Yeah.
+
+00:33:10.739 --> 00:33:11.739
+Give us a name.
+
+00:33:11.739 --> 00:33:12.739
+We'll find it if you don't.
+
+00:33:12.739 --> 00:33:13.739
+We'll come take it.
+
+00:33:14.239 --> 00:33:15.239
+We'll come take it if you don't.
+
+00:33:15.239 --> 00:33:16.239
+No, but I agree.
+
+00:33:16.239 --> 00:33:18.239
+Like back then when phones were like $1,000.
+
+00:33:18.239 --> 00:33:19.239
+A phone is $1,000.
+
+00:33:19.239 --> 00:33:22.239
+Like you need $1,000 today.
+
+00:33:22.239 --> 00:33:23.239
+Yeah.
+
+00:33:23.239 --> 00:33:25.239
+They still get $1,000 out of you when they get their phone back.
+
+00:33:25.239 --> 00:33:26.239
+Well, yeah.
+
+00:33:26.239 --> 00:33:27.239
+Yeah.
+
+00:33:27.239 --> 00:33:28.239
+Yeah.
+
+00:33:28.239 --> 00:33:29.239
+But.
+
+00:33:29.239 --> 00:33:30.239
+You can never like order.
+
+00:33:30.239 --> 00:33:31.239
+But it's way easier.
+
+00:33:31.239 --> 00:33:32.239
+But it's way easier now.
+
+00:33:32.239 --> 00:33:33.239
+Like I'm not paying $1,000 for a phone.
+
+00:33:33.239 --> 00:33:38.239
+But if I pay $40 a month for 15 months or whatever it is, I can live with that.
+
+00:33:38.239 --> 00:33:41.239
+And then there's people that go around and try to scam these companies.
+
+00:33:41.239 --> 00:33:42.239
+I don't know if you heard about that.
+
+00:33:42.739 --> 00:33:49.739
+Do you hear about like people that try to scam phone switches and just ride this wave
+
+00:33:49.739 --> 00:33:54.739
+of like just keep going to the next thing and running up their bill and never paying
+
+00:33:54.739 --> 00:33:55.739
+for their phone for a while.
+
+00:33:55.739 --> 00:33:56.739
+Like identity theft?
+
+00:33:56.739 --> 00:33:57.739
+No, no.
+
+00:33:57.739 --> 00:33:59.739
+Like you say you're getting a plan.
+
+00:33:59.739 --> 00:34:00.739
+Right.
+
+00:34:00.739 --> 00:34:04.739
+And then you just go delinquent until they actually take your shit back.
+
+00:34:04.739 --> 00:34:05.739
+And then you.
+
+00:34:05.739 --> 00:34:06.739
+Just go silent.
+
+00:34:06.739 --> 00:34:07.739
+And then you pay to do another one.
+
+00:34:07.739 --> 00:34:08.739
+You can tell them again.
+
+00:34:08.739 --> 00:34:10.739
+Hey, I'll switch from this company.
+
+00:34:11.239 --> 00:34:13.239
+If you guys give me two years free, blah, blah, blah.
+
+00:34:13.239 --> 00:34:15.239
+And you can just ride that wave.
+
+00:34:15.239 --> 00:34:19.239
+Dude, those are like those are the ones that like call you on the phone and they're just
+
+00:34:19.239 --> 00:34:21.239
+like, hey, we have a problem with your credit card.
+
+00:34:21.239 --> 00:34:23.239
+Can you give us your credit card number?
+
+00:34:25.239 --> 00:34:27.239
+Hey, man, we're afraid you have some health issues.
+
+00:34:27.239 --> 00:34:30.239
+Do you mind giving us your social security number so we can check up on that for you?
+
+00:34:30.239 --> 00:34:32.239
+It's like, no, what the fuck?
+
+00:34:32.239 --> 00:34:33.239
+Where are you calling from?
+
+00:34:33.239 --> 00:34:34.239
+Denny's?
+
+00:34:35.239 --> 00:34:36.239
+In Bangladesh.
+
+00:34:36.239 --> 00:34:39.239
+You're calling from Denny's in Bangladesh for my social security number because you're
+
+00:34:39.739 --> 00:34:40.739
+afraid my health is in order?
+
+00:34:40.739 --> 00:34:41.739
+It's D-N-N-I-E.
+
+00:34:44.739 --> 00:34:45.739
+Oh, fuck you.
+
+00:34:45.739 --> 00:34:46.739
+No, I agree.
+
+00:34:46.739 --> 00:34:47.739
+I agree with that.
+
+00:34:48.739 --> 00:34:49.739
+It's super easy.
+
+00:34:49.739 --> 00:34:57.739
+I went in there to get Q-tips and I walked out there with an iPhone, two iPhones and
+
+00:34:57.739 --> 00:34:59.739
+like a friggin' iPad Pro.
+
+00:34:59.739 --> 00:35:00.739
+Where?
+
+00:35:00.739 --> 00:35:01.739
+Verizon.
+
+00:35:02.739 --> 00:35:03.739
+They sell Q-tips at Verizon now?
+
+00:35:03.739 --> 00:35:04.739
+No.
+
+00:35:04.739 --> 00:35:06.739
+They're like smart Q-tips?
+
+00:35:07.239 --> 00:35:09.239
+Like it's got a camera in it?
+
+00:35:09.239 --> 00:35:10.239
+Like you can see?
+
+00:35:10.239 --> 00:35:11.239
+Ears are pleased.
+
+00:35:11.239 --> 00:35:12.239
+They sell those now.
+
+00:35:12.239 --> 00:35:13.239
+Thank you, Siri.
+
+00:35:13.239 --> 00:35:14.239
+It's got like a camera.
+
+00:35:14.239 --> 00:35:18.239
+The marketing that goes on in the middle of the night on the computer.
+
+00:35:18.239 --> 00:35:23.239
+See, I want to create some really stupid stuff and just see if it sells.
+
+00:35:23.239 --> 00:35:24.239
+Because I've seen a lot of dumb...
+
+00:35:24.239 --> 00:35:25.239
+I buy a lot of stupid.
+
+00:35:25.239 --> 00:35:27.239
+I don't know why it's in the middle of the night.
+
+00:35:27.239 --> 00:35:30.239
+These people who have a couple dollars in their bank account.
+
+00:35:30.239 --> 00:35:31.239
+At like 3 a.m.
+
+00:35:31.239 --> 00:35:32.239
+I'm one of those people.
+
+00:35:32.239 --> 00:35:34.239
+It's like drunk dialing, but like without the drinking.
+
+00:35:34.239 --> 00:35:35.239
+Yeah.
+
+00:35:35.739 --> 00:35:36.739
+With the dialing.
+
+00:35:36.739 --> 00:35:38.739
+Dude, these vans that I'm wearing right now.
+
+00:35:38.739 --> 00:35:42.739
+I was in bed and it was like 2 o'clock in the morning.
+
+00:35:42.739 --> 00:35:45.739
+And my girlfriend was like, did you ever order those vans?
+
+00:35:45.739 --> 00:35:47.739
+And I'm like, no, I never pulled the trigger on them.
+
+00:35:47.739 --> 00:35:49.739
+She's like, why don't you just order them?
+
+00:35:49.739 --> 00:35:51.739
+And I'm like, okay.
+
+00:35:52.739 --> 00:35:57.739
+And I just rolled over, went right onto the app, went right onto eBay.
+
+00:35:57.739 --> 00:35:59.739
+Confirm purchase.
+
+00:35:59.739 --> 00:36:01.739
+And I'm like, okay, they'll be here on Friday.
+
+00:36:01.739 --> 00:36:03.739
+She's like, wait, did you just buy them?
+
+00:36:04.239 --> 00:36:07.239
+Yeah, you just talked me into buying them.
+
+00:36:07.239 --> 00:36:09.239
+Don't ask like it's a bad thing now.
+
+00:36:10.239 --> 00:36:11.239
+I don't know.
+
+00:36:11.239 --> 00:36:14.239
+I have a really hard time talking myself out of buying stuff online.
+
+00:36:14.239 --> 00:36:17.239
+I have to not put money in the bank.
+
+00:36:17.239 --> 00:36:22.239
+Yeah, we just went over your Alexa fucking shipment list.
+
+00:36:22.239 --> 00:36:26.239
+And it was just like, he had like nine things coming that day.
+
+00:36:26.239 --> 00:36:29.239
+And then it's just like the rest of like for the next five months
+
+00:36:29.239 --> 00:36:32.239
+are just like booked up with deliveries.
+
+00:36:32.739 --> 00:36:35.739
+Like they hired a whole new fucking branch of UPS.
+
+00:36:35.739 --> 00:36:38.739
+All right, guys, we're just gonna be hitting Benny P's house.
+
+00:36:38.739 --> 00:36:42.739
+Just like, fuck, this guy's getting like fucking 8,000 light bulbs
+
+00:36:42.739 --> 00:36:46.739
+that are like Thomas Edison style.
+
+00:36:46.739 --> 00:36:48.739
+Water, a lot of water.
+
+00:36:48.739 --> 00:36:52.739
+A lot of water, fucking organic chicken nuggets and shit.
+
+00:36:52.739 --> 00:36:54.739
+Hell yeah, dude.
+
+00:36:54.739 --> 00:36:57.739
+But you see, you order, you think you order like stupid stuff
+
+00:36:57.739 --> 00:36:59.739
+and stuff like that, but like, it's cool.
+
+00:36:59.739 --> 00:37:00.739
+You know what I mean?
+
+00:37:01.239 --> 00:37:02.239
+It's them.
+
+00:37:02.239 --> 00:37:03.239
+It's what they do.
+
+00:37:03.239 --> 00:37:04.239
+They know me.
+
+00:37:04.239 --> 00:37:06.239
+They know everything about me.
+
+00:37:06.239 --> 00:37:07.239
+Yeah, dude.
+
+00:37:07.239 --> 00:37:10.239
+Dude, I thought, I had a thought.
+
+00:37:10.239 --> 00:37:14.239
+I had a fucking thought about a hoodie by this company called Kith.
+
+00:37:14.239 --> 00:37:17.239
+Which sounds like Mike Tyson trying to say kiss.
+
+00:37:17.239 --> 00:37:18.239
+Kith?
+
+00:37:18.239 --> 00:37:19.239
+Give me Kith.
+
+00:37:19.239 --> 00:37:22.239
+He's also Amy's boyfriend in Futurama.
+
+00:37:22.239 --> 00:37:23.239
+The green.
+
+00:37:23.239 --> 00:37:24.239
+Really?
+
+00:37:24.239 --> 00:37:25.239
+Is Mike Tyson?
+
+00:37:25.239 --> 00:37:26.239
+No, Kith.
+
+00:37:26.239 --> 00:37:28.239
+Oh, oh, no, it's Kith.
+
+00:37:28.239 --> 00:37:30.239
+K-I-T-H is the name of the company.
+
+00:37:30.739 --> 00:37:34.739
+And they sell like $800 hoodies and shit like that.
+
+00:37:34.739 --> 00:37:35.739
+You know what I'm saying?
+
+00:37:35.739 --> 00:37:37.739
+I don't remember where I was going with this.
+
+00:37:37.739 --> 00:37:39.739
+You thought it and it happened.
+
+00:37:39.739 --> 00:37:40.739
+Oh, yeah.
+
+00:37:40.739 --> 00:37:42.739
+I like thought about the hoodie.
+
+00:37:42.739 --> 00:37:46.739
+Like the style and everything is like, it's got like maroon.
+
+00:37:46.739 --> 00:37:50.739
+It's got like maroon stripes and it's like beige or like white or something like that.
+
+00:37:50.739 --> 00:37:53.739
+Like the main thing in the letters are white.
+
+00:37:53.739 --> 00:37:54.739
+It's fucked up, dude.
+
+00:37:54.739 --> 00:37:56.739
+And I just scrolled through Facebook.
+
+00:37:56.739 --> 00:37:57.739
+I saw it.
+
+00:37:57.739 --> 00:37:59.739
+How the fuck do they know?
+
+00:38:00.239 --> 00:38:01.239
+I don't have ads.
+
+00:38:01.239 --> 00:38:02.239
+Sam doesn't have.
+
+00:38:02.239 --> 00:38:08.239
+Sam doesn't have ads because he's a fucking elitist and refuses to get an iPhone where they NSA like openly spies on you.
+
+00:38:08.239 --> 00:38:10.239
+They just do it in private with Samsung.
+
+00:38:10.239 --> 00:38:12.239
+With the sticker over the earpiece.
+
+00:38:14.239 --> 00:38:15.239
+Yeah.
+
+00:38:15.239 --> 00:38:17.239
+I can only talk to you FaceTiming.
+
+00:38:17.239 --> 00:38:18.239
+Yeah.
+
+00:38:18.239 --> 00:38:24.239
+Dude, my dad does shit like he has like a phone case that has that thing over that covers all your cameras.
+
+00:38:24.239 --> 00:38:27.239
+I'm like, dude, how fucking paranoid are you?
+
+00:38:27.239 --> 00:38:29.239
+It's not happening to me.
+
+00:38:29.739 --> 00:38:31.739
+It ain't getting to me.
+
+00:38:32.739 --> 00:38:33.739
+He knows what he's doing.
+
+00:38:33.739 --> 00:38:34.739
+Fuck you talking about me.
+
+00:38:34.739 --> 00:38:36.739
+But everybody has Alexa.
+
+00:38:36.739 --> 00:38:37.739
+Everybody has Alexa in their house.
+
+00:38:37.739 --> 00:38:38.739
+Yeah.
+
+00:38:38.739 --> 00:38:41.739
+It's just that's like a spy you can talk to.
+
+00:38:41.739 --> 00:38:42.739
+Alexa is right behind you.
+
+00:38:42.739 --> 00:38:44.739
+She's currently listening to what you're saying.
+
+00:38:44.739 --> 00:38:45.739
+She's like, what?
+
+00:38:47.739 --> 00:38:48.739
+It's creepy, man.
+
+00:38:48.739 --> 00:38:49.739
+See?
+
+00:38:49.739 --> 00:38:50.739
+Yeah.
+
+00:38:50.739 --> 00:38:51.739
+I don't know.
+
+00:38:51.739 --> 00:38:52.739
+That stuff's weird.
+
+00:38:52.739 --> 00:38:53.739
+That scares me.
+
+00:38:53.739 --> 00:38:55.739
+I like to have Alexa and Google talk to each other.
+
+00:38:55.739 --> 00:38:56.739
+That's fun.
+
+00:38:57.739 --> 00:38:58.739
+You ever do that?
+
+00:38:59.239 --> 00:39:01.239
+They just get really petty and they have a lot of...
+
+00:39:01.239 --> 00:39:02.239
+They're really nice to each other.
+
+00:39:02.239 --> 00:39:06.239
+Actually, Alexa is much nicer to Google.
+
+00:39:06.239 --> 00:39:09.239
+Alexa is nicer to Google than Google is to Alexa?
+
+00:39:09.239 --> 00:39:10.239
+Yeah.
+
+00:39:10.239 --> 00:39:11.239
+True.
+
+00:39:11.239 --> 00:39:12.239
+Real talk.
+
+00:39:12.239 --> 00:39:14.239
+It's probably because she's learned from Jeff Bezos.
+
+00:39:14.239 --> 00:39:15.239
+That's why.
+
+00:39:16.239 --> 00:39:17.239
+Okay, Google.
+
+00:39:17.239 --> 00:39:18.239
+Oh, God.
+
+00:39:18.239 --> 00:39:19.239
+Talk to Alexa.
+
+00:39:20.239 --> 00:39:21.239
+Alexa, hi.
+
+00:39:24.239 --> 00:39:25.239
+Alexa.
+
+00:39:25.239 --> 00:39:26.239
+She's ignoring her.
+
+00:39:26.239 --> 00:39:27.239
+She's being coy.
+
+00:39:27.239 --> 00:39:28.239
+She's annoying her.
+
+00:39:28.739 --> 00:39:30.739
+Alexa, talk to Google.
+
+00:39:31.739 --> 00:39:33.739
+I can't find that skill.
+
+00:39:35.739 --> 00:39:38.739
+They're not even on talking terms anymore, dude.
+
+00:39:38.739 --> 00:39:40.739
+They've been listening to our conversation.
+
+00:39:41.739 --> 00:39:42.739
+All right, so...
+
+00:39:44.739 --> 00:39:46.739
+We've got a couple minutes left here on the recording.
+
+00:39:46.739 --> 00:39:48.739
+I think we should start jamming now.
+
+00:39:48.739 --> 00:39:49.739
+You guys want to...
+
+00:39:50.739 --> 00:39:52.739
+You guys want anything else to say?
+
+00:39:52.739 --> 00:39:54.739
+Anything interesting happening in your lives?
+
+00:39:54.739 --> 00:39:56.739
+There's nothing interesting happening in my life.
+
+00:39:57.239 --> 00:39:58.239
+Fuck it all.
+
+00:39:58.239 --> 00:40:00.239
+The world is meaningless.
+
+00:40:00.239 --> 00:40:02.239
+The world is meaningless.
+
+00:40:02.239 --> 00:40:06.239
+If anyone plays Fortnite on the PlayStation 4, please add me.
+
+00:40:06.239 --> 00:40:10.239
+My PSN is It's Ya Boy Saul.
+
+00:40:11.239 --> 00:40:12.239
+I-T-S.
+
+00:40:12.239 --> 00:40:14.239
+It's Saul Moserblink.
+
+00:40:14.239 --> 00:40:17.239
+Like Saul Silver from Pineapple Express.
+
+00:40:17.239 --> 00:40:18.239
+Ah, gotcha.
+
+00:40:18.239 --> 00:40:20.239
+Or better call Saul.
+
+00:40:21.239 --> 00:40:25.239
+If anyone wants to play with us over here at the studio...
+
+00:40:25.239 --> 00:40:26.239
+Yeah.
+
+00:40:26.739 --> 00:40:27.739
+Six to Midnight Productions.
+
+00:40:27.739 --> 00:40:28.739
+Six to...
+
+00:40:28.739 --> 00:40:29.739
+Six to...
+
+00:40:29.739 --> 00:40:31.739
+Six to Fig Night.
+
+00:40:32.739 --> 00:40:35.739
+We sell figs and we're also a recording studio.
+
+00:40:37.739 --> 00:40:38.739
+Yeah.
+
+00:40:38.739 --> 00:40:41.739
+Yeah, if you guys want to record, come through to Six to Midnight Productions.
+
+00:40:41.739 --> 00:40:42.739
+I'll say it right?
+
+00:40:44.739 --> 00:40:46.739
+It's also our gamer tag.
+
+00:40:46.739 --> 00:40:47.739
+Also a gamer tag?
+
+00:40:47.739 --> 00:40:48.739
+Yeah.
+
+00:40:48.739 --> 00:40:49.739
+Six to Midnight Productions.
+
+00:40:49.739 --> 00:40:52.739
+Hit them up if you want to do any recording or anything like that.
+
+00:40:52.739 --> 00:40:53.739
+Anybody else?
+
+00:40:54.239 --> 00:40:55.239
+Speak now?
+
+00:40:55.239 --> 00:40:56.239
+I'm good.
+
+00:40:56.239 --> 00:40:57.239
+Everybody good?
+
+00:40:57.239 --> 00:40:58.239
+Alright.
+
+00:40:58.239 --> 00:40:59.239
+Thanks for watching, guys.
+
+00:40:59.239 --> 00:41:00.239
+See ya.
+
+00:41:01.239 --> 00:41:02.239
+Check.
+
+00:41:02.239 --> 00:41:03.239
+Okay, Google.
+
+00:41:03.239 --> 00:41:04.239
+Turn all the lights off.
+
+00:41:06.239 --> 00:41:07.239
+Okay.
+
+00:41:07.239 --> 00:41:09.239
+Turning 15 lights off.
+
+00:41:10.239 --> 00:41:11.239
+The end.
+
+00:41:11.239 --> 00:41:12.239
+The end.
+
+00:41:13.239 --> 00:41:14.239
+Alexa.
+
+00:41:14.239 --> 00:41:16.239
+Turn all the lights on.
+
+00:41:18.239 --> 00:41:19.239
+Okay.
+
+00:41:19.239 --> 00:41:20.239
+Okay, Google.
+
+00:41:21.239 --> 00:41:23.239
+You're gonna let this happen?
+
+00:41:24.239 --> 00:41:25.239
+Sorry.
+
+00:41:25.239 --> 00:41:27.239
+I don't know how to help with that yet.


### PR DESCRIPTION
## Summary

Captions for the 41-min studio-footage clip on \`/benny\` (the merged podcast content now living at \`/assets/benny/DSC_0347.mp4\` after the swap on main). Pipeline:

1. **Extract** audio from the mp4 → 32 kbps mono mp3 (~10 MB, under OpenAI's 25 MB cap).
2. **Transcribe** via OpenAI Whisper API (\`whisper-1\`, \`response_format=vtt\`, \`language=en\`) — better proper-noun accuracy than the local \`small\` model.
3. **LLM cleanup pass** (scripted): proper-noun fixes against the benny page context ("60 Midnight" → "Six to Midnight", "Roybus" → "rooibos", "fallafel" → "falafel"), plus collapse of 9 whisper hallucination loops (≥5 consecutive identical cues — 60 duplicates removed in total).
4. **Wire up**: \`Video\` and \`InlineVideo\` gain an optional \`tracks\` prop that renders \`<track kind="subtitles">\`. The existing video slot ships its vtt with \`default=true\` so captions appear by default.

## Files

- \`public/assets/benny/DSC_0347.vtt\` (new, ~78 KB, 1263 cues over 41:28)
- \`components/video.tsx\` — \`tracks?: Track[]\` prop
- \`components/benny/inline-video.tsx\` — pass-through \`tracks\`
- \`app/benny/page.tsx\` — video slot wired with the vtt

## Test plan

- [ ] Play the studio-footage clip on /benny → captions appear at \`0:00\` reading "All right, all right, all right, so yeah, we're here at Six to Midnight Studios..."
- [ ] Toggle off captions via the native player menu → captions hide
- [ ] Spot-check timing at \`5:00\`, \`20:00\` (DSC→IMG fragment boundary), and \`35:00\`