### PR TITLE
fix: prerender markdown routes (hotfix — prod was missing body content)

### DIFF
--- a/src/routes/benny/+page.server.ts
+++ b/src/routes/benny/+page.server.ts
@@ -4,6 +4,8 @@ import { splitMarkdownContent } from "$lib/markdown";
 
 export type { ContentPart } from "$lib/markdown";
 
+export const prerender = true;
+
 export const load: PageServerLoad = async () => {
   const raw = await getContent("benny");
   const parts = raw ? splitMarkdownContent(raw) : null;

--- a/src/routes/canvas/self/+page.server.ts
+++ b/src/routes/canvas/self/+page.server.ts
@@ -1,6 +1,8 @@
 import { getContent } from '$lib/content';
 import type { PageServerLoad } from './$types';
 
+export const prerender = true;
+
 export const load: PageServerLoad = async () => {
   const markdown = await getContent('self');
   return { markdown };

--- a/src/routes/dad/+page.server.ts
+++ b/src/routes/dad/+page.server.ts
@@ -1,6 +1,8 @@
 import { getContent } from "$lib/content";
 import type { PageServerLoad } from "./$types";
 
+export const prerender = true;
+
 export const load: PageServerLoad = async () => {
   const markdown = await getContent("dad");
   return { markdown };


### PR DESCRIPTION
## The bug

prod /canvas/self was serving just the hero — no markdown body. confirmed via curl: SSR HTML contained the hero `<div>` and `<h1>self</h1>` but no `<article>`/`<Prose>` block. same root cause on /dad and /benny.

## Root cause

`src/lib/content.ts` reads markdown via `fs.readFile(join(process.cwd(), 'content', ...))`. Vercel's serverless functions run with `process.cwd() === '/var/task'` — the `content/` directory at the repo root is NOT bundled into the function. The try/catch silently swallows ENOENT and returns `null`. Pages render with `markdown = null` → empty body.

## Fix

`export const prerender = true` on the three affected `+page.server.ts` files. At build time `process.cwd()` IS the repo root, the read succeeds, HTML is baked. Zero runtime filesystem dependency. Same pattern PR #30 used for `/shelf`.

verified locally: prerendered `canvas/self.html` contains `Dad`, `Trenton`, `Benny` markdown body refs (grep matched).

## Test plan

- [x] `pnpm check`: 0 errors
- [x] `pnpm build`: clean, all 3 routes prerendered
- [x] grep of prerendered HTML confirms markdown body baked in

## Merge

Merge commit (no squash) per the usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)