### PR TITLE
redirect: /canvas/self → /self (308)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "sveltekit",
+  "redirects": [
+    {
+      "source": "/canvas/self",
+      "destination": "/self",
+      "permanent": true
+    }
+  ],
   "headers": [
     {
       "source": "/_app/immutable/(.*)",


### PR DESCRIPTION
Permanent edge redirect for the legacy /canvas/self path. PR #33 moved the route to /self; this captures the old URL for SEO + any existing links.

- vercel.json `redirects` entry, `permanent: true` (308)
- No SvelteKit-side code (keeps the route tree clean — no resurrected /canvas/ folder just to host a redirect)
- Edge-level, fires before the function — strictly cheaper than a server handler

`pnpm check` 0 errors, `pnpm build` clean, 36/38 Playwright (2 pre-existing failures on main: home / 500 + visual snapshot mismatch, unrelated to this change).

Merge commit (no squash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)