### PR TITLE
feat(home): gallery reorder + sounds card mirrors the /sounds idle backdrop

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -13,12 +13,12 @@
 		| 'sounds';
 
 	const UNIQUE_ITEMS: { label: string; handle: ItemHandle; href: string }[] = [
+		{ label: 'self', handle: 'self', href: '/self' },
+		{ label: 'analog', handle: 'anything-but-analog', href: '/anything-but-analog' },
+		{ label: 'sounds', handle: 'sounds', href: '/sounds' },
 		{ label: 'D-ANA', handle: 'deana', href: '/deana' },
 		{ label: 'shelf', handle: 'shelf', href: '/shelf' },
-		{ label: 'analog', handle: 'anything-but-analog', href: '/anything-but-analog' },
 		{ label: 'thoughts', handle: 'thoughts', href: '/thoughts' },
-		{ label: 'sounds', handle: 'sounds', href: '/sounds' },
-		{ label: 'self', handle: 'self', href: '/self' },
 	];
 
 	const UNIQUE_COUNT = UNIQUE_ITEMS.length;
@@ -59,8 +59,10 @@
 			p = import('$lib/components/canvas/MetaballCanvas.svelte').then((m) => m.default);
 		} else if (handle === 'anything-but-analog') {
 			p = import('$lib/components/canvas/ParticleTextCanvas.svelte').then((m) => m.default);
-		} else if (handle === 'thoughts' || handle === 'sounds') {
+		} else if (handle === 'thoughts') {
 			p = import('$lib/components/art/SketchHost.svelte').then((m) => m.default);
+		} else if (handle === 'sounds') {
+			p = import('$lib/sounds/EyeOcean.svelte').then((m) => m.default);
 		} else {
 			p = Promise.resolve(undefined as unknown as Component<any>);
 		}
@@ -305,7 +307,7 @@
 							{:else if item.handle === 'thoughts'}
 								<CanvasComp slug="30" active interactive={false} />
 							{:else if item.handle === 'sounds'}
-								<CanvasComp slug="25" active />
+								<CanvasComp reactive={false} fixed={false} />
 							{/if}
 						{/await}
 					</div>

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -1,12 +1,24 @@
 <script lang="ts">
-  // Fullscreen audio-reactive "eye ocean" backdrop. Bass swells the eyes, treble
-  // speeds the noise flow, amplitude dilates pupils; a slow ambient drift when idle.
+  // Audio-reactive "eye ocean" — a grid of cream eyes displaced + flowed by 3D
+  // value noise. Two modes:
+  //   • backdrop (default): fullscreen-fixed, wired to the sounds player — bass
+  //     swells the eyes, treble speeds the flow, amplitude dilates the pupils.
+  //   • card (reactive={false} fixed={false}): sizes to its parent box and just
+  //     drifts in the idle state — used as the homepage /sounds preview tile.
   //
-  // Perf: 1× DPR (it's a soft backdrop), frame-throttled (30fps playing / 12fps
+  // Perf: 1× DPR (it's a soft backdrop), frame-throttled (30fps reacting / 12fps
   // idle), paused when the tab is hidden. No backdrop-filter is layered over it.
   import { onMount } from "svelte";
   import { makeNoise } from "$lib/art/noise";
   import { player } from "$lib/sounds/player.svelte";
+
+  interface Props {
+    /** Wire to the sounds player. false = always idle drift, no audio reactivity. */
+    reactive?: boolean;
+    /** true = fullscreen fixed backdrop; false = absolute, sized to the parent element. */
+    fixed?: boolean;
+  }
+  let { reactive = true, fixed = true }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -19,16 +31,32 @@
     let t = 0;
     let last = 0;
 
-    function resize() {
-      w = window.innerWidth;
-      h = window.innerHeight;
+    function applySize(width: number, height: number) {
+      w = Math.max(1, Math.floor(width));
+      h = Math.max(1, Math.floor(height));
       canvas.width = w; // 1× DPR — soft backdrop, big perf win on retina
       canvas.height = h;
       canvas.style.width = `${w}px`;
       canvas.style.height = `${h}px`;
     }
-    resize();
-    window.addEventListener("resize", resize);
+
+    // Backdrop tracks the viewport; card mode tracks its parent box.
+    let onResize: (() => void) | undefined;
+    let ro: ResizeObserver | undefined;
+    if (fixed) {
+      onResize = () => applySize(window.innerWidth, window.innerHeight);
+      onResize();
+      window.addEventListener("resize", onResize);
+    } else {
+      const host = canvas.parentElement ?? canvas;
+      ro = new ResizeObserver(() => {
+        const r = host.getBoundingClientRect();
+        applySize(r.width, r.height);
+      });
+      ro.observe(host);
+      const r = host.getBoundingClientRect();
+      applySize(r.width, r.height);
+    }
 
     function draw(playing: boolean) {
       const react = playing ? 1 : 0;
@@ -70,7 +98,7 @@
     function frame(now: number) {
       raf = requestAnimationFrame(frame);
       if (document.hidden) return;
-      const playing = player.playing;
+      const playing = reactive && player.playing;
       const interval = playing ? 33 : 80; // 30fps reacting, 12fps idle drift
       if (now - last < interval) return;
       last = now;
@@ -80,9 +108,14 @@
 
     return () => {
       cancelAnimationFrame(raf);
-      window.removeEventListener("resize", resize);
+      if (onResize) window.removeEventListener("resize", onResize);
+      ro?.disconnect();
     };
   });
 </script>
 
-<canvas bind:this={canvas} aria-hidden="true" style="position:fixed; inset:0; z-index:0; display:block;"></canvas>
+<canvas
+  bind:this={canvas}
+  aria-hidden="true"
+  style="position:{fixed ? 'fixed' : 'absolute'}; inset:0; z-index:0; display:block;"
+></canvas>

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -48,17 +48,23 @@
       onResize();
       window.addEventListener("resize", onResize);
     } else {
-      const host = canvas.parentElement ?? canvas;
-      ro = new ResizeObserver(() => {
+      // Card mode: track the parent box (the gallery card's fill wrapper). The
+      // RO fires once on observe() with the initial size, so the canvas catches
+      // up even if layout isn't resolved at mount.
+      const host = canvas.parentElement;
+      if (host) {
+        ro = new ResizeObserver(() => {
+          const r = host.getBoundingClientRect();
+          applySize(r.width, r.height);
+        });
+        ro.observe(host);
         const r = host.getBoundingClientRect();
         applySize(r.width, r.height);
-      });
-      ro.observe(host);
-      const r = host.getBoundingClientRect();
-      applySize(r.width, r.height);
+      }
     }
 
     function draw(playing: boolean) {
+      if (w < 2 || h < 2) return; // not sized yet (card mode can mount before layout); the RO will size us
       const react = playing ? 1 : 0;
       const bass = player.bass * react;
       const treble = player.treble * react;


### PR DESCRIPTION
Two homepage tweaks.

## Changes
- **Gallery order** is now `self → analog → sounds → deana → shelf → thoughts` (`Gallery.svelte` `UNIQUE_ITEMS`).
- **The sounds card is now a live idle EyeOcean.** It renders the actual `/sounds` backdrop component in a new card mode (`reactive={false} fixed={false}`) instead of the day25 SketchHost — so the homepage tile is a literal preview of the `/sounds` eye-ocean in its idle drift, per request.

## EyeOcean refactor
`EyeOcean.svelte` gains two props (defaults preserve the `/sounds` backdrop byte-for-byte):
- `reactive` (default true) — false ignores the player and always idle-drifts
- `fixed` (default true) — false sizes to the parent box via ResizeObserver + `position:absolute` instead of fullscreen

## Verification
- svelte-autofixer clean on both components; `pnpm check` 0 errors; `pnpm build` ✓.
- Visual + smoke suite: home + all routes pass (the gallery strip + canvases are masked in parity, so this change is validated as not disturbing surrounding layout); `/sounds` smoke passes when built with the R2 base (as prod does); `/sounds` visual parity remains intentionally skipped.
- Screenshots confirm the new order, the sounds card rendering the idle eye-field, and `self` leading + rendering correctly.
- Code-review pass: 2 findings on the new card-mode sizing hardened (null-safe parent + skip-draw-until-sized).

Note: `self` now leads; cards sit on `--black` until canvases arm, so the only cost is a brief black hero tile on cold load (no white flash). Will eyeball on the prod build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)