### PR TITLE
feat(sounds): fluid sixtom-style motion + layout redesign (badges, credits, film posters)

### DIFF
--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -34,6 +34,16 @@
     let flow = 0; // accumulated drift distance (noise units); persists across pauses
     let last = 0;
 
+    // Size-derived constants + per-cell jitter are frame-invariant — computed
+    // once per resize (below) instead of every frame in draw().
+    let cell = 0;
+    let base = 0;
+    let cols = 0;
+    let rows = 0;
+    let blobScale = 0;
+    const jitterX: number[] = [];
+    const jitterY: number[] = [];
+
     function applySize(width: number, height: number) {
       w = Math.max(1, Math.floor(width));
       h = Math.max(1, Math.floor(height));
@@ -41,6 +51,24 @@
       canvas.height = h;
       canvas.style.width = `${w}px`;
       canvas.style.height = `${h}px`;
+
+      cell = Math.max(48, Math.min(80, Math.min(w, h) / 12));
+      base = cell * 0.42;
+      cols = Math.ceil(w / cell) + 1;
+      rows = Math.ceil(h / cell) + 1;
+      // ~4 big contiguous blobs across the short side (sixtom: BLOBS / minDim).
+      blobScale = 4.2 / Math.min(w, h);
+      // stable per-cell jitter so the grid doesn't read as a rigid grid
+      jitterX.length = 0;
+      jitterY.length = 0;
+      for (let gy = 0; gy <= rows; gy++) {
+        for (let gx = 0; gx <= cols; gx++) {
+          const px = gx * cell;
+          const py = gy * cell;
+          jitterX.push((noise(px * 0.05, py * 0.05, 5.3) - 0.5) * cell * 0.45);
+          jitterY.push((noise(py * 0.05, px * 0.05, 8.7) - 0.5) * cell * 0.45);
+        }
+      }
     }
 
     // Backdrop tracks the viewport; card mode tracks its parent box.
@@ -82,25 +110,17 @@
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
 
-      const cell = Math.max(48, Math.min(80, Math.min(w, h) / 12));
-      const base = cell * 0.42;
-      const cols = Math.ceil(w / cell) + 1;
-      const rows = Math.ceil(h / cell) + 1;
-      // ~4 big contiguous blobs across the short side (sixtom: BLOBS / minDim).
-      const blobScale = 4.2 / Math.min(w, h);
-
+      let idx = 0;
       for (let gy = 0; gy <= rows; gy++) {
         for (let gx = 0; gx <= cols; gx++) {
           const px = gx * cell;
           const py = gy * cell;
           // the drifting field value at this cell — a blob slides through as it rises
           const n = noise(px * blobScale + driftX, py * blobScale + driftY, 0);
-          // stable per-cell jitter so it doesn't read as a rigid grid, plus a
-          // gentle lean that follows the slow current (coherent, not jittery)
-          const jx = (noise(px * 0.05, py * 0.05, 5.3) - 0.5) * cell * 0.45;
-          const jy = (noise(py * 0.05, px * 0.05, 8.7) - 0.5) * cell * 0.45;
-          const cx = px + jx + (n - 0.5) * cell * 0.3 * (1 + bass * 0.6);
-          const cy = py + jy + (n - 0.5) * cell * 0.2;
+          // precomputed per-cell jitter + a gentle lean that follows the current
+          const cx = px + jitterX[idx] + (n - 0.5) * cell * 0.3 * (1 + bass * 0.6);
+          const cy = py + jitterY[idx] + (n - 0.5) * cell * 0.2;
+          idx++;
           const size = base * (0.32 + n * 1.0) * (1 + bass * 1.15);
           if (size < 1) continue;
 

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -6,8 +6,11 @@
   //   • card (reactive={false} fixed={false}): sizes to its parent box and just
   //     drifts in the idle state — used as the homepage /sounds preview tile.
   //
-  // Perf: 1× DPR (it's a soft backdrop), frame-throttled (30fps reacting / 12fps
-  // idle), paused when the tab is hidden. No backdrop-filter is layered over it.
+  // Motion (after the sixtom hero): a low-frequency value-noise field drifts
+  // across the grid at an asymmetric rate (Y at 0.4× of X) so soft blobs of
+  // larger/brighter eyes flow through like a slow current, rather than each eye
+  // churning in place. Continuous + delta-timed at the native rAF rate; paused
+  // when hidden. Perf: 1× DPR (soft backdrop), light per-eye arcs, no blur.
   import { onMount } from "svelte";
   import { makeNoise } from "$lib/art/noise";
   import { player } from "$lib/sounds/player.svelte";
@@ -28,7 +31,7 @@
     let w = 0;
     let h = 0;
     let raf = 0;
-    let t = 0;
+    let flow = 0; // accumulated drift distance (noise units); persists across pauses
     let last = 0;
 
     function applySize(width: number, height: number) {
@@ -63,13 +66,18 @@
       }
     }
 
-    function draw(playing: boolean) {
+    function draw(playing: boolean, dt: number) {
       if (w < 2 || h < 2) return; // not sized yet (card mode can mount before layout); the RO will size us
       const react = playing ? 1 : 0;
       const bass = player.bass * react;
       const treble = player.treble * react;
       const amp = player.amp * react;
-      t += 0.03 + treble * 0.6; // per-rendered-frame drift (throttled, so larger step)
+      // Drift a low-frequency 2D noise field at an asymmetric rate (Y at 0.4× of
+      // X), so contiguous blobs of larger/brighter eyes flow across the grid like
+      // a slow current. Treble speeds the current when playing.
+      flow += dt * (0.22 + treble * 1.1);
+      const driftX = flow;
+      const driftY = flow * 0.4;
 
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
@@ -78,13 +86,22 @@
       const base = cell * 0.42;
       const cols = Math.ceil(w / cell) + 1;
       const rows = Math.ceil(h / cell) + 1;
+      // ~4 big contiguous blobs across the short side (sixtom: BLOBS / minDim).
+      const blobScale = 4.2 / Math.min(w, h);
 
       for (let gy = 0; gy <= rows; gy++) {
         for (let gx = 0; gx <= cols; gx++) {
-          const n = noise(gx * 0.16, gy * 0.16, t);
-          const cx = gx * cell + (n - 0.5) * cell * 0.5;
-          const cy = gy * cell + (noise(gx * 0.16 + 11.5, gy * 0.16, t) - 0.5) * cell * 0.5;
-          const size = base * (0.4 + n * 0.95) * (1 + bass * 1.15);
+          const px = gx * cell;
+          const py = gy * cell;
+          // the drifting field value at this cell — a blob slides through as it rises
+          const n = noise(px * blobScale + driftX, py * blobScale + driftY, 0);
+          // stable per-cell jitter so it doesn't read as a rigid grid, plus a
+          // gentle lean that follows the slow current (coherent, not jittery)
+          const jx = (noise(px * 0.05, py * 0.05, 5.3) - 0.5) * cell * 0.45;
+          const jy = (noise(py * 0.05, px * 0.05, 8.7) - 0.5) * cell * 0.45;
+          const cx = px + jx + (n - 0.5) * cell * 0.3 * (1 + bass * 0.6);
+          const cy = py + jy + (n - 0.5) * cell * 0.2;
+          const size = base * (0.32 + n * 1.0) * (1 + bass * 1.15);
           if (size < 1) continue;
 
           ctx.fillStyle = `rgba(255,250,200,${0.42 + n * 0.5})`;
@@ -103,12 +120,16 @@
 
     function frame(now: number) {
       raf = requestAnimationFrame(frame);
-      if (document.hidden) return;
-      const playing = reactive && player.playing;
-      const interval = playing ? 33 : 80; // 30fps reacting, 12fps idle drift
-      if (now - last < interval) return;
+      if (document.hidden) {
+        last = now; // don't bank elapsed time while hidden → no jump on return
+        return;
+      }
+      // Native rAF rate (≈60fps) for fluid motion; delta-time keeps the drift
+      // speed identical regardless of frame rate. Clamp dt so a backgrounded
+      // tab returning doesn't lurch the field forward.
+      const dt = last ? Math.min((now - last) / 1000, 0.05) : 0.016;
       last = now;
-      draw(playing);
+      draw(reactive && player.playing, dt);
     }
     raf = requestAnimationFrame(frame);
 

--- a/src/routes/sounds/+page.server.ts
+++ b/src/routes/sounds/+page.server.ts
@@ -1,15 +1,17 @@
 import manifest from "$lib/sounds/manifest.json";
 import type { SoundsManifest } from "$lib/sounds/types";
+import { env } from "$env/dynamic/public";
 import type { PageServerLoad } from "./$types";
 
 export const prerender = true;
 
-// In prod, PUBLIC_SOUNDS_BASE points at the R2 public origin so audio/covers
-// serve from object storage (free egress). Unset in dev → relative paths served
-// from static/. Baked into the prerendered output at build time.
+// PUBLIC_SOUNDS_BASE points at the R2 public origin so audio/covers serve from
+// object storage (free egress). Read via $env (not raw process.env) so it also
+// resolves from .env / .env.local in local dev, not just the Vercel build env.
+// Unset → relative paths served from static/. Baked into the prerender at build.
 export const load: PageServerLoad = () => {
   return {
     manifest: manifest as SoundsManifest,
-    base: process.env.PUBLIC_SOUNDS_BASE ?? "",
+    base: env.PUBLIC_SOUNDS_BASE ?? "",
   };
 };

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -139,8 +139,8 @@
       {#if HMBM_FILM.poster}
         <img src={url(HMBM_FILM.poster)} alt="how many blind mice? — film poster" onerror={imgErr} />
       {/if}
+      <span class="badge badge-score">score</span>
     </div>
-    <span class="badge badge-score">score</span>
     <h2 class="hmbm-title">{HMBM_FILM.title}</h2>
     <p class="hmbm-meta">sk+w · film score · {HMBM_FILM.year} · {manifest.scores.hmbm.length} cues</p>
     <div class="cue-list">

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -16,10 +16,26 @@
 
   const url = (p: string) => base + p; // manifest path → R2 origin (prod) / static (dev)
 
+  // Hide a cover/poster that fails to load so the "?" placeholder behind it shows
+  // through (some film posters aren't mirrored to R2 yet).
+  const imgErr = (e: Event) => ((e.currentTarget as HTMLElement).style.display = "none");
+
   // umami custom events — "what gets played". The umami script is loaded
   // site-wide in +layout.svelte; no-op (via ?.) during SSR / if it's blocked.
   const trackEvent = (name: string, data: Record<string, string | number>) =>
     (globalThis as { umami?: { track?: (n: string, d?: unknown) => void } }).umami?.track?.(name, data);
+
+  // Posters for the sk+w film scores + the HMBM film, mirrored from
+  // skeletonflowersandwater.com (Skeleton Flowers + Water) to R2.
+  const SCORE_POSTER: Record<string, string> = {
+    "quintessentially-unaware": "/audio/sounds/covers/quintessentially-unaware.jpg",
+    "polka-dot-dress": "/audio/sounds/covers/polka-dot-dress.jpg",
+  };
+  const HMBM_FILM = {
+    title: "how many blind mice?",
+    year: "2024",
+    poster: "/audio/sounds/covers/how-many-blind-mice.jpg",
+  };
 
   // fan tilt per version index (0 = newest, on top, flat)
   const fan = (i: number) => {
@@ -27,6 +43,28 @@
     const dir = i % 2 ? -1 : 1; // alternate left/right
     return dir * (4 + i * 1.6);
   };
+
+  // One flowing grid of tiles — each tagged demo|score with an optional credit
+  // shown under the title (the EP/band name for demos, the studio for scores).
+  type Kind = "demo" | "score";
+  interface Tile {
+    song: Song;
+    kind: Kind;
+    credit: string | null;
+    cover: string | null;
+  }
+  let tiles = $derived<Tile[]>([
+    ...manifest.demos.eps.flatMap((e) =>
+      e.songs.map((song) => ({ song, kind: "demo" as const, credit: e.label, cover: song.cover })),
+    ),
+    ...manifest.demos.singles.map((song) => ({ song, kind: "demo" as const, credit: null, cover: song.cover })),
+    ...manifest.scores.skw.map((song) => ({
+      song,
+      kind: "score" as const,
+      credit: "sk+w",
+      cover: SCORE_POSTER[song.slug] ?? song.cover,
+    })),
+  ]);
 
   const play = (song: Song) => {
     const v = song.versions[0];
@@ -36,7 +74,7 @@
 
   const playCue = (cue: Cue) => {
     trackEvent("sounds-play", { slug: "hmbm", variant: cue.timecode });
-    playTrack({ src: url(cue.src), title: `HMBM ${cue.timecode}`, variant: "cue", slug: cue.src });
+    playTrack({ src: url(cue.src), title: `how many blind mice? ${cue.timecode}`, variant: "cue", slug: cue.src });
   };
 
   const isCurrent = (song: Song) => player.track?.slug === song.slug;
@@ -45,9 +83,6 @@
     if (!s || !Number.isFinite(s)) return "0:00";
     return `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
   };
-
-  // One flowing grid of demo tiles; the 404 EP's 3 tiles lead (featured), the rest follow.
-  let demos = $derived([...manifest.demos.eps.flatMap((e) => e.songs), ...manifest.demos.singles]);
 </script>
 
 <SeoHead
@@ -61,19 +96,20 @@
 <div class="scrim scrim-top" aria-hidden="true"></div>
 <h1 class="brand">sounds</h1>
 
-{#snippet stack(song: Song)}
+{#snippet tile(t: Tile, featured: boolean)}
+  {@const song = t.song}
   {@const active = isCurrent(song) && player.playing}
   <figure class="stack" class:playing={active}>
     <div class="deck">
       {#each song.versions as v, i (v.src)}
         <div class="card" style="--rot:{fan(i)}deg; z-index:{40 - i};">
-          {#if song.cover}
-            <img src={url(song.cover)} alt="" draggable="false" />
-          {:else}
-            <span class="ph">?</span>
+          <span class="ph">?</span>
+          {#if t.cover}
+            <img src={url(t.cover)} alt="" draggable="false" onerror={imgErr} />
           {/if}
         </div>
       {/each}
+      <span class="badge badge-{t.kind}">{t.kind}</span>
       <button
         class="play"
         aria-label={active ? `pause ${song.title}` : `play ${song.title}`}
@@ -83,25 +119,31 @@
       </button>
     </div>
     <figcaption>
-      {song.title}{#if song.untitled}<span class="dim"> ·untitled</span>{/if}
-      {#if song.versions.length > 1}<span class="dim"> ·{song.versions.length}</span>{/if}
+      <span class="title" class:featured>{song.title}</span>
+      <span class="sub">
+        {#if t.credit}<span class="credit">{t.credit}</span>{/if}
+        {#if song.versions.length > 1}<span class="vers">{song.versions.length} versions</span>{/if}
+      </span>
     </figcaption>
   </figure>
 {/snippet}
 
 <main>
   <section class="grid">
-    {#each demos as s (s.slug)}{@render stack(s)}{/each}
+    {#each tiles as t, i (t.song.slug)}{@render tile(t, i < 3)}{/each}
   </section>
 
-  <section class="scores">
-    <h2>scores</h2>
-    {#if manifest.scores.skw.length}
-      <h3>sk+w</h3>
-      <div class="grid skw">{#each manifest.scores.skw as s (s.slug)}{@render stack(s)}{/each}</div>
-    {/if}
-    <h3>HMBM <span class="dim">· film score · {manifest.scores.hmbm.length} cues</span></h3>
-    <div class="cue-slider">
+  <section class="hmbm">
+    <div class="hmbm-poster">
+      <span class="hmbm-poster-ph" aria-hidden="true">?</span>
+      {#if HMBM_FILM.poster}
+        <img src={url(HMBM_FILM.poster)} alt="how many blind mice? — film poster" onerror={imgErr} />
+      {/if}
+    </div>
+    <span class="badge badge-score">score</span>
+    <h2 class="hmbm-title">{HMBM_FILM.title}</h2>
+    <p class="hmbm-meta">sk+w · film score · {HMBM_FILM.year} · {manifest.scores.hmbm.length} cues</p>
+    <div class="cue-list">
       {#each manifest.scores.hmbm as cue (cue.src)}
         <button
           class="cue-chip"
@@ -177,7 +219,7 @@
   .grid {
     display: grid;
     grid-template-columns: repeat(12, 1fr);
-    gap: 2rem 1.5rem;
+    gap: 2.4rem 1.5rem;
     align-items: start;
   }
   .grid > :global(.stack) {
@@ -210,6 +252,8 @@
     transition: transform 0.38s cubic-bezier(0.2, 0.8, 0.2, 1);
   }
   .card img {
+    position: absolute;
+    inset: 0;
     width: 100%;
     height: 100%;
     object-fit: cover;
@@ -241,6 +285,31 @@
     border: 2px solid var(--coin);
     pointer-events: none;
   }
+
+  /* demo / score badge, pinned over the top-left of the cover */
+  .badge {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.5rem;
+    z-index: 45;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    pointer-events: none;
+  }
+  .badge-demo {
+    color: var(--white);
+    background: rgba(0, 0, 0, 0.55);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+  }
+  .badge-score {
+    color: var(--black);
+    background: var(--coin);
+  }
+
   .play {
     position: absolute;
     inset: 0;
@@ -266,47 +335,104 @@
     opacity: 1;
     transform: scale(1);
   }
+
   figcaption {
-    margin-top: 0.8rem;
-    font-size: 0.74rem;
+    margin-top: 0.9rem;
+  }
+  /* titles read as headings — larger + bold, not the old dim caption */
+  .title {
+    display: block;
+    font-size: 1.1rem;
+    font-weight: 700;
+    line-height: 1.15;
+    letter-spacing: 0.01em;
+    color: var(--white);
+    text-shadow: 0 1px 10px rgba(0, 0, 0, 0.9);
+  }
+  .title.featured {
+    font-size: 1.3rem; /* the featured 404 tiles run a touch larger */
+  }
+  .sub {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 0.3rem;
+    font-size: 0.72rem;
     letter-spacing: 0.04em;
-    text-shadow: 0 1px 8px rgba(0, 0, 0, 0.9);
+  }
+  /* EP / studio credit under the title — band/author-like */
+  .credit {
+    color: var(--coin);
+    font-weight: 600;
+  }
+  .vers {
+    color: var(--white);
+    opacity: 0.5;
   }
   .dim {
     color: var(--coin);
     opacity: 0.7;
   }
 
-  /* scores */
-  .scores {
-    margin-top: 4rem;
+  /* HMBM film score — poster snapped right, cues flowing after it */
+  .hmbm {
+    margin-top: 4.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    padding-top: 2rem;
   }
-  .scores h2 {
-    font-size: 0.95rem;
-    text-transform: uppercase;
-    letter-spacing: 0.22em;
+  .hmbm-poster {
+    position: relative;
+    float: right;
+    width: clamp(160px, 22vw, 260px);
+    aspect-ratio: 4 / 5;
+    border-radius: 10px;
+    overflow: hidden;
+    margin: 0 0 1.5rem 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+    background: var(--black);
+  }
+  .hmbm-poster img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: grayscale(1);
+    transition: filter 0.4s ease;
+  }
+  .hmbm:hover .hmbm-poster img {
+    filter: grayscale(0);
+  }
+  .hmbm-poster-ph {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    font-size: 3rem;
+    color: var(--coin);
+  }
+  .hmbm-title {
+    margin: 0.6rem 0 0.2rem;
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.1;
+    text-shadow: 0 1px 10px rgba(0, 0, 0, 0.9);
+  }
+  .hmbm-meta {
     margin: 0 0 1.2rem;
-  }
-  .scores h3 {
-    font-size: 0.8rem;
-    text-transform: uppercase;
-    letter-spacing: 0.16em;
-    margin: 1.4rem 0 0.8rem;
+    font-size: 0.74rem;
+    letter-spacing: 0.06em;
+    color: var(--coin);
     opacity: 0.85;
   }
-  /* HMBM cue filmstrip — horizontal slider */
-  .cue-slider {
+  .cue-list {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.6rem;
-    overflow-x: auto;
-    padding-bottom: 0.6rem;
-    scroll-snap-type: x proximity;
-    scrollbar-width: thin;
-    scrollbar-color: var(--coin) transparent;
   }
   .cue-chip {
     flex: 0 0 auto;
-    scroll-snap-align: start;
     border: 1px solid color-mix(in srgb, var(--coin) 35%, transparent);
     border-radius: 7px;
     background: rgba(0, 0, 0, 0.4);
@@ -323,14 +449,6 @@
   .cue-chip.on {
     background: var(--coin);
     color: var(--black);
-  }
-  .skw {
-    margin-top: 0.5rem;
-    max-width: 560px;
-  }
-  .skw > :global(.stack),
-  .skw > :global(.stack:nth-child(-n + 3)) {
-    grid-column: span 6; /* sk+w: 2 across */
   }
 
   /* fixed black scrims — fade the scrolling grid into black at top + above player */
@@ -412,15 +530,22 @@
       padding: 3rem 1rem calc(var(--player-h) + 2rem);
     }
     .grid {
-      gap: 1.4rem 1rem;
+      gap: 1.8rem 1rem;
     }
     .grid > :global(.stack),
-    .grid > :global(.stack:nth-child(-n + 3)),
-    .skw > :global(.stack) {
+    .grid > :global(.stack:nth-child(-n + 3)) {
       grid-column: span 6; /* 2 across */
     }
-    .np {
-      min-width: 0;
+    .title,
+    .title.featured {
+      font-size: 1rem;
+    }
+    .hmbm-poster {
+      float: none;
+      display: block;
+      width: 60%;
+      max-width: 240px;
+      margin: 0 0 1.2rem;
     }
   }
 

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -540,6 +540,9 @@
     .title.featured {
       font-size: 1rem;
     }
+    .np {
+      min-width: 0; /* let now-playing shrink so the scrubber keeps room on phones */
+    }
     .hmbm-poster {
       float: none;
       display: block;

--- a/tests/sounds.spec.ts
+++ b/tests/sounds.spec.ts
@@ -1,11 +1,14 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("sounds player", () => {
-  test("renders the grid, scores, transport, and per-song play controls", async ({ page }) => {
+  test("renders the grid, badges, scores, transport, and per-song play controls", async ({ page }) => {
     await page.goto("/sounds");
     await expect(page.getByRole("heading", { name: "sounds", level: 1 })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "scores" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "HMBM" })).toBeVisible();
+    // demo/score badges replace the old section headers
+    await expect(page.getByText("demo", { exact: true }).first()).toBeVisible();
+    await expect(page.getByText("score", { exact: true }).first()).toBeVisible();
+    // HMBM film-score block, titled by its film
+    await expect(page.getByRole("heading", { name: "how many blind mice?" })).toBeVisible();
     // fixed transport with a scrubber
     await expect(page.getByLabel("seek")).toBeVisible();
     // a play disc per song (demos + sk+w ≈ 27)


### PR DESCRIPTION
Builds on the live /sounds page with motion + layout work, plus a dev-covers fix.

## Changes
- **Fluid EyeOcean motion** matched to the sixtom hero: a low-frequency 2D value-noise field drifting at an asymmetric rate (Y at 0.4× of X) so soft blobs flow across like a current, delta-timed at native rAF (no more choppy 12fps churn). Also drives the homepage sounds card.
- **/sounds redesign**: demo/score **badges** replace the section headers; EP/studio **credit under bigger (heading-size) titles** (404, fa11faster, sk+w); **film posters** for the sk+w scores; **HMBM** poster snapped right with the 14 cues after it.
- **Film posters** (how many blind mice?, polka-dot dress, quintessentially unaware) sourced + mirrored to R2.
- **fix**: read `PUBLIC_SOUNDS_BASE` via `$env/dynamic/public` (not raw `process.env`) so covers load in local dev, not just the Vercel build env.

## Verification
- `/rl` clean: 3 rounds, 3 findings fixed (badge anchoring, EyeOcean per-frame jitter precompute, mobile `.np` regression), 0 security. Round 0 security 0 findings.
- `pnpm check` 0 errors; build ✓; 60fps on /sounds + homepage card.
- Endcap visual+smoke: 35 passed; /sounds smoke updated for the new design; /sounds visual still intentionally skipped; benny visual flake confirmed (passes on re-run).

## Follow-up (noted in review, not blocking)
Film posters are wired in the page component (SCORE_POSTER/HMBM_FILM) rather than flowing through the manifest/ingest pipeline like `Song.cover`. Durable on R2 (deploy is additive), but modeling films in the manifest would make future films a data edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)