### PR TITLE
feat(sounds): centered play/pause glyphs + cursor-tracking eyes + scroll fades

### DIFF
--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -33,6 +33,13 @@
     let raf = 0;
     let flow = 0; // accumulated drift distance (noise units); persists across pauses
     let last = 0;
+    // pointer glance — the pupils lean toward the cursor
+    let ptrClientX = 0;
+    let ptrClientY = 0;
+    let ptrIn = false;
+    let gtx = 0;
+    let gty = 0;
+    let glance = 0; // 0..1 smoothed glance strength
 
     // Size-derived constants + per-cell jitter are frame-invariant — computed
     // once per resize (below) instead of every frame in draw().
@@ -94,6 +101,17 @@
       }
     }
 
+    function onPointerMove(e: PointerEvent) {
+      ptrClientX = e.clientX;
+      ptrClientY = e.clientY;
+      ptrIn = true;
+    }
+    function onPointerLeaveWin() {
+      ptrIn = false;
+    }
+    window.addEventListener("pointermove", onPointerMove, { passive: true });
+    document.addEventListener("pointerleave", onPointerLeaveWin);
+
     function draw(playing: boolean, dt: number) {
       if (w < 2 || h < 2) return; // not sized yet (card mode can mount before layout); the RO will size us
       const react = playing ? 1 : 0;
@@ -109,6 +127,26 @@
 
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
+
+      // The eyes glance toward the cursor. Track its canvas-local position (the
+      // viewport for the fixed backdrop, the card box otherwise) and smooth the
+      // engage/disengage so pupils ease back to center when the pointer leaves.
+      let target = 0;
+      if (ptrIn) {
+        let lx = ptrClientX;
+        let ly = ptrClientY;
+        if (!fixed) {
+          const r = canvas.getBoundingClientRect();
+          lx -= r.left;
+          ly -= r.top;
+        }
+        if (lx >= 0 && lx <= w && ly >= 0 && ly <= h) {
+          target = 1;
+          gtx = lx;
+          gty = ly;
+        }
+      }
+      glance += (target - glance) * 0.12;
 
       let idx = 0;
       for (let gy = 0; gy <= rows; gy++) {
@@ -130,9 +168,19 @@
           ctx.fill();
 
           const pupil = Math.max(1.5, size * 0.3 * (1 + amp * 0.6));
+          let ppx = cx;
+          let ppy = cy;
+          if (glance > 0.01) {
+            const ddx = gtx - cx;
+            const ddy = gty - cy;
+            const dd = Math.hypot(ddx, ddy) || 1;
+            const reach = ((size - pupil) / 2) * 0.8 * glance; // pupil stays within the eye
+            ppx = cx + (ddx / dd) * reach;
+            ppy = cy + (ddy / dd) * reach;
+          }
           ctx.fillStyle = "#000";
           ctx.beginPath();
-          ctx.arc(cx, cy, pupil / 2, 0, Math.PI * 2);
+          ctx.arc(ppx, ppy, pupil / 2, 0, Math.PI * 2);
           ctx.fill();
         }
       }
@@ -156,6 +204,8 @@
     return () => {
       cancelAnimationFrame(raf);
       if (onResize) window.removeEventListener("resize", onResize);
+      window.removeEventListener("pointermove", onPointerMove);
+      document.removeEventListener("pointerleave", onPointerLeaveWin);
       ro?.disconnect();
     };
   });

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -121,7 +121,10 @@
     const moveTarget: Window | HTMLCanvasElement = fixed ? window : canvas;
     moveTarget.addEventListener("pointermove", onPointerMove as EventListener, { passive: true });
     if (fixed) {
-      document.addEventListener("pointerleave", onPointerGone);
+      // pointerleave doesn't bubble, so listen on <html> (the element the cursor
+      // actually leaves when it exits the page) — a document-level listener would
+      // never fire. blur covers leaving via tab/window switch.
+      document.documentElement.addEventListener("pointerleave", onPointerGone);
       window.addEventListener("blur", onPointerGone);
     } else {
       canvas.addEventListener("pointerleave", onPointerGone);
@@ -212,7 +215,7 @@
       if (onResize) window.removeEventListener("resize", onResize);
       moveTarget.removeEventListener("pointermove", onPointerMove as EventListener);
       if (fixed) {
-        document.removeEventListener("pointerleave", onPointerGone);
+        document.documentElement.removeEventListener("pointerleave", onPointerGone);
         window.removeEventListener("blur", onPointerGone);
       } else {
         canvas.removeEventListener("pointerleave", onPointerGone);

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -33,9 +33,11 @@
     let raf = 0;
     let flow = 0; // accumulated drift distance (noise units); persists across pauses
     let last = 0;
-    // pointer glance — the pupils lean toward the cursor
-    let ptrClientX = 0;
-    let ptrClientY = 0;
+    // pointer glance — the pupils lean toward the cursor, in canvas-local coords
+    // with NO per-frame layout read: viewport clientX/Y for the fixed backdrop,
+    // the canvas's own offsetX/Y for the card (which also gates it to hover).
+    let ptrX = 0;
+    let ptrY = 0;
     let ptrIn = false;
     let gtx = 0;
     let gty = 0;
@@ -102,15 +104,28 @@
     }
 
     function onPointerMove(e: PointerEvent) {
-      ptrClientX = e.clientX;
-      ptrClientY = e.clientY;
+      if (fixed) {
+        ptrX = e.clientX; // the fixed canvas sits at viewport 0,0
+        ptrY = e.clientY;
+      } else {
+        ptrX = e.offsetX; // canvas-local — no getBoundingClientRect needed
+        ptrY = e.offsetY;
+      }
       ptrIn = true;
     }
-    function onPointerLeaveWin() {
+    function onPointerGone() {
       ptrIn = false;
     }
-    window.addEventListener("pointermove", onPointerMove, { passive: true });
-    document.addEventListener("pointerleave", onPointerLeaveWin);
+    // Fullscreen tracks the whole window (eyes glance even when the cursor is over
+    // page content); the card tracks only its own surface (natural hover gating).
+    const moveTarget: Window | HTMLCanvasElement = fixed ? window : canvas;
+    moveTarget.addEventListener("pointermove", onPointerMove as EventListener, { passive: true });
+    if (fixed) {
+      document.addEventListener("pointerleave", onPointerGone);
+      window.addEventListener("blur", onPointerGone);
+    } else {
+      canvas.addEventListener("pointerleave", onPointerGone);
+    }
 
     function draw(playing: boolean, dt: number) {
       if (w < 2 || h < 2) return; // not sized yet (card mode can mount before layout); the RO will size us
@@ -128,25 +143,16 @@
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
 
-      // The eyes glance toward the cursor. Track its canvas-local position (the
-      // viewport for the fixed backdrop, the card box otherwise) and smooth the
-      // engage/disengage so pupils ease back to center when the pointer leaves.
+      // The eyes glance toward the cursor. ptrX/ptrY are already canvas-local, so
+      // there's no per-frame layout read; smooth the engage/disengage (dt-corrected
+      // like the drift) so pupils ease back to center when the pointer leaves.
       let target = 0;
-      if (ptrIn) {
-        let lx = ptrClientX;
-        let ly = ptrClientY;
-        if (!fixed) {
-          const r = canvas.getBoundingClientRect();
-          lx -= r.left;
-          ly -= r.top;
-        }
-        if (lx >= 0 && lx <= w && ly >= 0 && ly <= h) {
-          target = 1;
-          gtx = lx;
-          gty = ly;
-        }
+      if (ptrIn && ptrX >= 0 && ptrX <= w && ptrY >= 0 && ptrY <= h) {
+        target = 1;
+        gtx = ptrX;
+        gty = ptrY;
       }
-      glance += (target - glance) * 0.12;
+      glance += (target - glance) * Math.min(1, dt * 8);
 
       let idx = 0;
       for (let gy = 0; gy <= rows; gy++) {
@@ -204,8 +210,13 @@
     return () => {
       cancelAnimationFrame(raf);
       if (onResize) window.removeEventListener("resize", onResize);
-      window.removeEventListener("pointermove", onPointerMove);
-      document.removeEventListener("pointerleave", onPointerLeaveWin);
+      moveTarget.removeEventListener("pointermove", onPointerMove as EventListener);
+      if (fixed) {
+        document.removeEventListener("pointerleave", onPointerGone);
+        window.removeEventListener("blur", onPointerGone);
+      } else {
+        canvas.removeEventListener("pointerleave", onPointerGone);
+      }
       ro?.disconnect();
     };
   });

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -24,6 +24,11 @@
   };
   $effect(() => {
     onScroll(); // initial state (e.g. a short page starts with the bottom scrim off)
+    // Recompute as the page height settles — covers/posters and the web font load
+    // after mount and can change scrollHeight without a scroll or resize event.
+    const ro = new ResizeObserver(onScroll);
+    ro.observe(document.body);
+    return () => ro.disconnect();
   });
 
   const url = (p: string) => base + p; // manifest path → R2 origin (prod) / static (dev)

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -14,6 +14,18 @@
     if (audioEl) attach(audioEl);
   });
 
+  // Scroll-aware edge fades: the top scrim fades in once scrolled off the top;
+  // the bottom scrim fades out once you reach the end — so neither edge clips
+  // content at rest.
+  let scrollY = $state(0);
+  let atBottom = $state(false);
+  const onScroll = () => {
+    atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 4;
+  };
+  $effect(() => {
+    onScroll(); // initial state (e.g. a short page starts with the bottom scrim off)
+  });
+
   const url = (p: string) => base + p; // manifest path → R2 origin (prod) / static (dev)
 
   // Hide a cover/poster that fails to load so the "?" placeholder behind it shows
@@ -92,9 +104,19 @@
   schema={collectionPageNode({ path: "/sounds", name: "sounds — threesam" })}
 />
 
+<svelte:window bind:scrollY onscroll={onScroll} onresize={onScroll} />
+
 <EyeOcean />
-<div class="scrim scrim-top" aria-hidden="true"></div>
+<div class="scrim scrim-top" class:show={scrollY > 8} aria-hidden="true"></div>
 <h1 class="brand">sounds</h1>
+
+{#snippet glyph(playing: boolean)}
+  {#if playing}
+    <span class="g-pause" aria-hidden="true"><span></span><span></span></span>
+  {:else}
+    <span class="g-play" aria-hidden="true"></span>
+  {/if}
+{/snippet}
 
 {#snippet tile(t: Tile, featured: boolean)}
   {@const song = t.song}
@@ -115,7 +137,7 @@
         aria-label={active ? `pause ${song.title}` : `play ${song.title}`}
         onclick={() => play(song)}
       >
-        {#if active}❚❚{:else}▶{/if}
+        {@render glyph(active)}
       </button>
     </div>
     <figcaption>
@@ -155,11 +177,11 @@
   </section>
 </main>
 
-<div class="scrim scrim-bottom" aria-hidden="true"></div>
+<div class="scrim scrim-bottom" class:hide={atBottom} aria-hidden="true"></div>
 
 <footer class="transport">
   <button class="tp-play" aria-label={player.playing ? "pause" : "play"} onclick={toggle} disabled={!player.track}>
-    {#if player.playing}❚❚{:else}▶{/if}
+    {@render glyph(player.playing)}
   </button>
   <div class="np">
     {#if player.track}
@@ -322,7 +344,7 @@
     border-radius: 50%;
     background: var(--coin);
     color: var(--black);
-    font-size: 0.95rem;
+    font-size: 1.4rem; /* drives the glyph size (in em) — larger arrow in the disc */
     display: grid;
     place-items: center;
     cursor: pointer;
@@ -338,8 +360,32 @@
     transform: scale(1);
   }
 
+  /* play / pause glyphs — sized in em to the coin disc's font-size, centered by
+     the disc's grid. The pause is the nav coin's bars, vertical (its hamburger
+     glyph rotated 90°). */
+  .g-play {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0.6em 0 0.6em 1em;
+    border-color: transparent transparent transparent currentColor;
+    margin-left: 0.16em; /* optical centering of the triangle */
+  }
+  .g-pause {
+    display: flex;
+    gap: 0.24em;
+  }
+  .g-pause span {
+    width: 0.2em;
+    height: 0.92em;
+    background: currentColor;
+    border-radius: 1px;
+  }
+
   figcaption {
     margin-top: 0.9rem;
+    position: relative;
+    z-index: 60; /* keep titles above neighbouring tiles' fanned/hovered cards */
   }
   /* Titles read as headings. They sit over the reactive eye-ocean (black→cream),
      so a dark backing that hugs the text guarantees WCAG contrast regardless of
@@ -484,11 +530,20 @@
     top: 0;
     height: 20vh;
     background: linear-gradient(to bottom, #000 12%, transparent);
+    opacity: 0; /* hidden at rest so the first row isn't faded; fades in on scroll */
+    transition: opacity 0.35s ease;
+  }
+  .scrim-top.show {
+    opacity: 1;
   }
   .scrim-bottom {
     bottom: 0; /* runs under the transport — no gap above the player */
     height: 30vh;
     background: linear-gradient(to top, #000 70px, transparent);
+    transition: opacity 0.35s ease;
+  }
+  .scrim-bottom.hide {
+    opacity: 0; /* fades out at the end so the last row isn't clipped */
   }
 
   /* fixed transport */
@@ -516,7 +571,9 @@
     border-radius: 50%;
     background: var(--coin);
     color: var(--black);
-    font-size: 0.8rem;
+    font-size: 1.1rem; /* drives the glyph size (in em) */
+    display: grid;
+    place-items: center;
     cursor: pointer;
   }
   .tp-play:disabled {


### PR DESCRIPTION
Five /sounds polish items: (1) play arrow centered + larger in the coin disc; (2) pause = the nav-coin hamburger glyph rotated 90° (two vertical bars); (3) titles raised above neighbouring stacked cards (z-index); (4) eye-ocean pupils glance toward the cursor on hover (homepage card + fullscreen backdrop — per-eye math is trivial); (5) scroll-aware edge fades (top scrim fades in once scrolled, bottom fades out at the end) so neither edge clips content at rest. check 0 / build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)