### PR TITLE
feat(sounds): backdrop eyes watch the playing song; other cards recede

### DIFF
--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -20,8 +20,11 @@
     reactive?: boolean;
     /** true = fullscreen fixed backdrop; false = absolute, sized to the parent element. */
     fixed?: boolean;
+    /** Fixed backdrop only: a viewport point the pupils gaze toward (the playing
+     *  song's card center). null = idle drift. Ignored in card mode. */
+    gaze?: { x: number; y: number } | null;
   }
-  let { reactive = true, fixed = true }: Props = $props();
+  let { reactive = true, fixed = true, gaze = null }: Props = $props();
 
   let canvas: HTMLCanvasElement;
 
@@ -33,8 +36,9 @@
     let raf = 0;
     let flow = 0; // accumulated drift distance (noise units); persists across pauses
     let last = 0;
-    // pointer glance — the pupils lean toward the cursor (card mode only; see the
-    // listener block). Canvas-local coords, smoothed engage/disengage in draw().
+    // glance — the pupils lean toward a target: the cursor in card mode (see the
+    // listener block), or the `gaze` prop in fixed mode (the playing song's card).
+    // gtx/gty hold the target point; glance is the smoothed 0..1 engage strength.
     let ptrX = 0;
     let ptrY = 0;
     let ptrIn = false;
@@ -142,11 +146,15 @@
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
 
-      // The eyes glance toward the cursor. ptrX/ptrY are already canvas-local, so
-      // there's no per-frame layout read; smooth the engage/disengage (dt-corrected
-      // like the drift) so pupils ease back to center when the pointer leaves.
+      // Aim the glance: the fixed backdrop follows the `gaze` prop (the playing
+      // card); card mode follows the in-bounds cursor. dt-corrected easing (like
+      // the drift) eases the pupils in, and back to center when the target clears.
       let target = 0;
-      if (ptrIn && ptrX >= 0 && ptrX <= w && ptrY >= 0 && ptrY <= h) {
+      if (fixed && gaze) {
+        target = 1;
+        gtx = gaze.x;
+        gty = gaze.y;
+      } else if (!fixed && ptrIn && ptrX >= 0 && ptrX <= w && ptrY >= 0 && ptrY <= h) {
         target = 1;
         gtx = ptrX;
         gty = ptrY;
@@ -178,7 +186,7 @@
           if (glance > 0.01) {
             const ddx = gtx - cx;
             const ddy = gty - cy;
-            const dd = Math.hypot(ddx, ddy) || 1;
+            const dd = Math.sqrt(ddx * ddx + ddy * ddy) || 1; // cheaper than hypot, runs per eye
             const reach = ((size - pupil) / 2) * 0.8 * glance; // pupil stays within the eye
             ppx = cx + (ddx / dd) * reach;
             ppy = cy + (ddy / dd) * reach;

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -55,6 +55,8 @@
     let blobScale = 0;
     const jitterX: number[] = [];
     const jitterY: number[] = [];
+    const restX: number[] = []; // per-eye idle gaze direction (unit vector)
+    const restY: number[] = [];
 
     function applySize(width: number, height: number) {
       w = Math.max(1, Math.floor(width));
@@ -73,12 +75,18 @@
       // stable per-cell jitter so the grid doesn't read as a rigid grid
       jitterX.length = 0;
       jitterY.length = 0;
+      restX.length = 0;
+      restY.length = 0;
       for (let gy = 0; gy <= rows; gy++) {
         for (let gx = 0; gx <= cols; gx++) {
           const px = gx * cell;
           const py = gy * cell;
           jitterX.push((noise(px * 0.05, py * 0.05, 5.3) - 0.5) * cell * 0.45);
           jitterY.push((noise(py * 0.05, px * 0.05, 8.7) - 0.5) * cell * 0.45);
+          // each eye rests looking in its own stable random direction
+          const ang = noise(px * 0.07, py * 0.07, 13.1) * Math.PI * 2;
+          restX.push(Math.cos(ang));
+          restY.push(Math.sin(ang));
         }
       }
     }
@@ -146,20 +154,33 @@
       ctx.fillStyle = "#000";
       ctx.fillRect(0, 0, w, h);
 
-      // Aim the glance: the fixed backdrop follows the `gaze` prop (the playing
-      // card); card mode follows the in-bounds cursor. dt-corrected easing (like
-      // the drift) eases the pupils in, and back to center when the target clears.
-      let target = 0;
+      // Desired aim + engage strength this frame: the fixed backdrop follows the
+      // `gaze` prop (the playing card); card mode follows the in-bounds cursor.
+      let dtx = gtx;
+      let dty = gty;
+      let strength = 0;
       if (fixed && gaze) {
-        target = 1;
-        gtx = gaze.x;
-        gty = gaze.y;
+        dtx = gaze.x;
+        dty = gaze.y;
+        strength = 1;
       } else if (!fixed && ptrIn && ptrX >= 0 && ptrX <= w && ptrY >= 0 && ptrY <= h) {
-        target = 1;
-        gtx = ptrX;
-        gty = ptrY;
+        dtx = ptrX;
+        dty = ptrY;
+        strength = 1;
       }
-      glance += (target - glance) * Math.min(1, dt * 8);
+      // Ease the aim point so the gaze glides between targets (song→song, or as the
+      // card scrolls) rather than snapping; snap only while disengaged so the next
+      // engage starts aimed right (the pupils are centered then anyway, via glance).
+      if (glance < 0.01) {
+        gtx = dtx;
+        gty = dty;
+      } else {
+        gtx += (dtx - gtx) * Math.min(1, dt * 5);
+        gty += (dty - gty) * Math.min(1, dt * 5);
+      }
+      // dt-corrected like the drift: ease the pupils toward the target, and back to
+      // each eye's idle direction when it clears.
+      glance += (strength - glance) * Math.min(1, dt * 8);
 
       let idx = 0;
       for (let gy = 0; gy <= rows; gy++) {
@@ -169,9 +190,10 @@
           // the drifting field value at this cell — a blob slides through as it rises
           const n = noise(px * blobScale + driftX, py * blobScale + driftY, 0);
           // precomputed per-cell jitter + a gentle lean that follows the current
-          const cx = px + jitterX[idx] + (n - 0.5) * cell * 0.3 * (1 + bass * 0.6);
-          const cy = py + jitterY[idx] + (n - 0.5) * cell * 0.2;
+          const ci = idx; // this cell's index into the precomputed arrays
           idx++;
+          const cx = px + jitterX[ci] + (n - 0.5) * cell * 0.3 * (1 + bass * 0.6);
+          const cy = py + jitterY[ci] + (n - 0.5) * cell * 0.2;
           const size = base * (0.32 + n * 1.0) * (1 + bass * 1.15);
           if (size < 1) continue;
 
@@ -181,16 +203,23 @@
           ctx.fill();
 
           const pupil = Math.max(1.5, size * 0.3 * (1 + amp * 0.6));
-          let ppx = cx;
-          let ppy = cy;
-          if (glance > 0.01) {
+          const maxReach = ((size - pupil) / 2) * 0.8; // keeps the pupil inside the eye
+          // idle: this eye looks in its own stable random direction
+          const rox = restX[ci] * maxReach * 0.7;
+          const roy = restY[ci] * maxReach * 0.7;
+          // engaged: aim toward the eased gaze/cursor point
+          let tox = rox;
+          let toy = roy;
+          if (glance > 0.001) {
             const ddx = gtx - cx;
             const ddy = gty - cy;
-            const dd = Math.sqrt(ddx * ddx + ddy * ddy) || 1; // cheaper than hypot, runs per eye
-            const reach = ((size - pupil) / 2) * 0.8 * glance; // pupil stays within the eye
-            ppx = cx + (ddx / dd) * reach;
-            ppy = cy + (ddy / dd) * reach;
+            const dd = Math.sqrt(ddx * ddx + ddy * ddy) || 1; // cheaper than hypot, per eye
+            tox = (ddx / dd) * maxReach;
+            toy = (ddy / dd) * maxReach;
           }
+          // blend idle → target by glance: eyes swing to the song, then ease home
+          const ppx = cx + rox + (tox - rox) * glance;
+          const ppy = cy + roy + (toy - roy) * glance;
           ctx.fillStyle = "#000";
           ctx.beginPath();
           ctx.arc(ppx, ppy, pupil / 2, 0, Math.PI * 2);

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -99,6 +99,10 @@
 
   const isCurrent = (song: Song) => player.track?.slug === song.slug;
 
+  // a grid card (not an HMBM cue) is actively playing → eyes gaze + the rest recede.
+  // Pure derived so the fade reliably clears on pause/stop, independent of updateGaze.
+  const anyPlaying = $derived(player.playing && tiles.some((t) => isCurrent(t.song)));
+
   // The fullscreen eyes gaze toward the playing song's card. Recompute its viewport
   // center on play/pause/track-change and on scroll/resize — one layout read, not
   // per animation frame. null when nothing in the grid is playing (a paused track,
@@ -179,7 +183,7 @@
 {/snippet}
 
 <main>
-  <section class="grid" class:dimmed={!!gaze}>
+  <section class="grid" class:dimmed={anyPlaying}>
     {#each tiles as t, i (t.song.slug)}{@render tile(t, i < 3)}{/each}
   </section>
 
@@ -284,7 +288,7 @@
   /* while a song plays, the other cards recede so the playing one — and the eyes
      watching it — stand out */
   .grid.dimmed > :global(.stack:not(.playing)) {
-    opacity: 0.22;
+    opacity: 0.13;
   }
 
   /* dub-stack tile */

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -19,8 +19,11 @@
   // content at rest.
   let scrollY = $state(0);
   let atBottom = $state(false);
+  // viewport point the backdrop eyes gaze toward — the playing song's card center
+  let gaze = $state<{ x: number; y: number } | null>(null);
   const onScroll = () => {
     atBottom = window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 4;
+    updateGaze(); // the playing card moves under the viewport as you scroll
   };
   $effect(() => {
     onScroll(); // initial state (e.g. a short page starts with the bottom scrim off)
@@ -96,6 +99,26 @@
 
   const isCurrent = (song: Song) => player.track?.slug === song.slug;
 
+  // The fullscreen eyes gaze toward the playing song's card. Recompute its viewport
+  // center on play/pause/track-change and on scroll/resize — one layout read, not
+  // per animation frame. null when nothing in the grid is playing (a paused track,
+  // or an HMBM cue, which has no card), so the eyes relax to idle drift.
+  const updateGaze = () => {
+    const slug = player.playing ? player.track?.slug : undefined;
+    const el = slug ? document.querySelector<HTMLElement>(`[data-slug="${CSS.escape(slug)}"]`) : null;
+    if (!el) {
+      gaze = null;
+      return;
+    }
+    const r = el.getBoundingClientRect();
+    gaze = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+  };
+  $effect(() => {
+    void player.track?.slug; // re-aim when the track or play state changes
+    void player.playing;
+    updateGaze();
+  });
+
   const fmt = (s: number) => {
     if (!s || !Number.isFinite(s)) return "0:00";
     return `${Math.floor(s / 60)}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
@@ -111,7 +134,7 @@
 
 <svelte:window bind:scrollY onscroll={onScroll} onresize={onScroll} />
 
-<EyeOcean />
+<EyeOcean {gaze} />
 <div class="scrim scrim-top" class:show={scrollY > 8} aria-hidden="true"></div>
 <h1 class="brand">sounds</h1>
 
@@ -126,7 +149,7 @@
 {#snippet tile(t: Tile, featured: boolean)}
   {@const song = t.song}
   {@const active = isCurrent(song) && player.playing}
-  <figure class="stack" class:playing={active}>
+  <figure class="stack" class:playing={active} data-slug={song.slug}>
     <div class="deck">
       {#each song.versions as v, i (v.src)}
         <div class="card" style="--rot:{fan(i)}deg; z-index:{40 - i};">
@@ -156,7 +179,7 @@
 {/snippet}
 
 <main>
-  <section class="grid">
+  <section class="grid" class:dimmed={!!gaze}>
     {#each tiles as t, i (t.song.slug)}{@render tile(t, i < 3)}{/each}
   </section>
 
@@ -253,9 +276,15 @@
   }
   .grid > :global(.stack) {
     grid-column: span 3;
+    transition: opacity 0.45s ease;
   }
   .grid > :global(.stack:nth-child(-n + 3)) {
     grid-column: span 4;
+  }
+  /* while a song plays, the other cards recede so the playing one — and the eyes
+     watching it — stand out */
+  .grid.dimmed > :global(.stack:not(.playing)) {
+    opacity: 0.22;
   }
 
   /* dub-stack tile */


### PR DESCRIPTION
## What
When a grid song is playing, the fullscreen EyeOcean pupils **gaze toward that song's card**, and the **other cards fade back** (opacity 0.22) — the playing one, and the eyes watching it, stand out.

## How
- **`EyeOcean` gains a `gaze` prop** (a viewport point, or null). In fixed mode the pupils aim at `gaze` instead of the cursor. This is the perf-friendly counterpart to the cursor-chase dropped in #49: the target only moves on track-change / scroll, not every mouse-move. Per-eye distance now uses `sqrt` instead of `Math.hypot`.
- **`+page.svelte`** computes the playing card's viewport center (`getBoundingClientRect` on play/pause/track-change + scroll/resize — one layout read, not per animation frame) and passes it as `gaze`. `null` for a paused track or an HMBM cue (which has no card) → eyes relax to idle drift.
- The grid carries a `dimmed` class while a card is playing; non-playing stacks fade.

## Notes
- Homepage card EyeOcean is unaffected (still cursor-tracked).
- Interactive/visual — best felt on a preview. `/rl` to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)