### PR TITLE
fix(sounds): restore playing-card ring, concentric with the cover

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -329,6 +329,16 @@
   .stack.playing .card img {
     filter: grayscale(0);
   }
+  /* coin ring around the playing card — radius is concentric with the cover
+     (.card 8px + 5px inset = 13px) so the corners track the cover's curve */
+  .stack.playing .deck::after {
+    content: "";
+    position: absolute;
+    inset: -5px;
+    border-radius: 13px;
+    border: 2px solid var(--coin);
+    pointer-events: none;
+  }
   /* demo / score badge, pinned over the top-left of the cover */
   .badge {
     position: absolute;


### PR DESCRIPTION
"outline is off" = misaligned, not unwanted (earlier removal reverted). The coin ring used `border-radius: 11px` at `inset: -5px` over an 8px cover, so the corners pinched off the cover's curve. Now `13px` (8 + 5) — concentric. Only shows while a card is playing (no visual-baseline impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)