### PR TITLE
fix(sounds): fade cards out smoothly on play (always-mounted overlay)

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -290,10 +290,10 @@
   </section>
 </main>
 
-{#if anyPlaying}
-  <!-- pointer-only dismiss backdrop; keyboard/AT users pause via the transport -->
-  <button class="play-overlay" tabindex="-1" aria-hidden="true" onclick={toggleCurrent}></button>
-{/if}
+<!-- pointer-only dismiss backdrop, always mounted (toggle pointer-events, don't
+     insert it, so inserting a fixed layer mid-play doesn't interrupt the cards'
+     opacity transition); keyboard/AT users pause via the transport -->
+<button class="play-overlay" class:on={anyPlaying} tabindex="-1" aria-hidden="true" onclick={toggleCurrent}></button>
 
 <div class="scrim scrim-bottom" aria-hidden="true"></div>
 
@@ -399,6 +399,10 @@
     padding: 0;
     background: transparent;
     cursor: pointer;
+    pointer-events: none; /* click-through until a track plays */
+  }
+  .play-overlay.on {
+    pointer-events: auto; /* catch taps to pause while playing */
   }
 
   /* dub-stack tile */


### PR DESCRIPTION
Non-playing cards snapped to hidden on play but faded back in on pause. Cause: the `{#if anyPlaying}` overlay was *inserted* in the same frame the cards went opacity:0 — inserting a full-screen fixed layer forces a composite that skips the cards' transition (on pause the overlay is removed, so fade-in was fine → out-abrupt/in-smooth). Now the overlay is always mounted and toggles `pointer-events` via `.on`, so the 0.45s opacity transition runs cleanly both ways. At-rest look unchanged (overlay is transparent + click-through when off) — no baseline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)