### PR TITLE
fix(sounds): start dim/ring fade on click, not after audio loads

### DIFF
--- a/src/lib/sounds/player.svelte.ts
+++ b/src/lib/sounds/player.svelte.ts
@@ -58,16 +58,20 @@ function loop() {
 async function start() {
   if (!el) return;
   const myGen = ++gen; // claim this start; a newer playTrack/toggle supersedes it
-  try {
-    await el.play();
-  } catch {
-    if (myGen === gen) player.playing = false; // only the latest attempt reflects failure
-    return;
-  }
-  if (myGen !== gen) return; // a newer track took over while we awaited play()
+  // Flip to playing optimistically — BEFORE awaiting play() — so the grid's
+  // dim/ring opacity transitions begin on the click, not when the audio finishes
+  // loading. On a cold track the play() promise can stay pending for hundreds of
+  // ms (R2 fetch); resolving it there made the fade-out start late and snap,
+  // while the synchronous pause faded cleanly (the in/out asymmetry). Starting
+  // the fade now lets it run during the load and complete before playback begins.
   player.playing = true;
   lastUi = 0; // first loop tick writes time/duration immediately (no stale flash on track switch)
   if (!raf) loop();
+  try {
+    await el.play();
+  } catch {
+    if (myGen === gen) player.playing = false; // blocked/interrupted, and still the latest attempt
+  }
 }
 
 export async function playTrack(t: Track) {


### PR DESCRIPTION
The grid's dim-out (playing a song fades its siblings to 0.13) **snapped** instead of transitioning, while the fade back in on pause was smooth — the recurring in/out asymmetry.

**Cause:** `player.playing` flipped `true` only *after* `await el.play()` resolved. On a cold R2 track that promise stays pending for hundreds of ms, so the opacity transition started late and got dropped at the busy load-complete instant. Pause flips `playing` synchronously, which is why the fade *in* always looked clean.

**Fix:** set `playing` optimistically at the top of `start()` (before awaiting `play()`), so the transition begins on the click and runs during the load. The generation guard + `catch` still revert it if the latest `play()` is blocked/interrupted.

Scope: one function in `src/lib/sounds/player.svelte.ts`. No at-rest visual change (the dim only applies during playback), so the prod visual baselines are unaffected.

- svelte-check + svelte autofixer: clean
- `/rl`: clean — 2 rounds, 0 findings (Round 0 security 0; the rapid-switch / toggle-during-load / remount races and a "ghost audio" desync were all traced and refuted — single `<audio>` element + spec-compliant `pause()` aborting a pending `play()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)