### PR TITLE
feat(thoughts): extend bg-black/70 to whole bottom strip

### DIFF
--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -65,14 +65,14 @@
             class="h-full w-full object-cover [image-rendering:pixelated]"
           />
         </div>
-        <div class="absolute inset-x-0 bottom-0 h-[30%] px-3 py-3">
+        <div class="absolute inset-x-0 bottom-0 h-[30%] bg-black/70 p-4 md:p-5">
           <span
-            class="inline-block bg-black/70 p-3 font-mono text-xl font-bold uppercase tracking-[0.3em] text-[var(--white)] transition-colors duration-300 group-hover:text-[var(--coin)] md:text-2xl"
+            class="block font-mono text-xl font-bold uppercase tracking-[0.3em] text-[var(--white)] transition-colors duration-300 group-hover:text-[var(--coin)] md:text-2xl"
           >
             {card.title}
           </span>
           <p
-            class="mt-3 font-mono text-xs uppercase tracking-[0.15em] text-zinc-300 md:text-sm"
+            class="mt-2 font-mono text-xs uppercase tracking-[0.15em] text-zinc-300 md:text-sm"
           >
             {card.description}
           </p>


### PR DESCRIPTION
## Summary
The bottom 30% strip of each card now has a single full-width \`bg-black/70\` band that holds both the title and the description — previously the tint was only behind the title pill, leaving the description sitting transparently on the walkers.

## Test plan
- [x] dev server: continuous 70%-black band across the whole bottom strip; walkers still pass behind it

🤖 Generated with [Claude Code](https://claude.com/claude-code)