### PR TITLE
feat(thoughts): full 4/5 image + symmetric strip padding

### DIFF
--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -55,9 +55,9 @@
     {#each cards as card (card.href)}
       <a
         href={card.href}
-        class="group relative block aspect-[4/5] border-2 border-[var(--black)] transition-[border-color,transform] duration-700 hover:border-[var(--coin)] hover:[transform:rotate(-1.3deg)]"
+        class="group relative block border-2 border-[var(--black)] transition-[border-color,transform] duration-700 hover:border-[var(--coin)] hover:[transform:rotate(-1.3deg)]"
       >
-        <div class="absolute inset-x-0 top-0 h-[70%] overflow-hidden">
+        <div class="aspect-[4/5] overflow-hidden">
           <img
             src={card.img}
             alt=""
@@ -65,7 +65,7 @@
             class="h-full w-full object-cover [image-rendering:pixelated]"
           />
         </div>
-        <div class="absolute inset-x-0 bottom-0 h-[30%] bg-black/70 p-4 md:p-5">
+        <div class="bg-black/70 px-4 py-4 md:px-5 md:py-5">
           <span
             class="block font-mono text-xl font-bold uppercase tracking-[0.3em] text-[var(--white)] transition-colors duration-300 group-hover:text-[var(--coin)] md:text-2xl"
           >


### PR DESCRIPTION
## Summary
Two tweaks to the card layout:
- **Image at full 4/5 aspect**: dropped the 70%/30% absolute split that was cropping the source. Image area now \`aspect-[4/5]\` (matches the bake) → no crop, full source visible.
- **Symmetric strip padding**: strip is content-driven now (\`py-4 md:py-5\` instead of \`h-[30%]\`), so the space above the title and below the description are equal.

## Test plan
- [x] dev server: image fills its area at full 4/5; strip's title + description sit centered vertically with equal padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)