### PR TITLE
feat(sounds): multi-step play button (loading swirl) + click-anywhere-to-pause modal

### DIFF
--- a/src/lib/sounds/PlayGlyph.svelte
+++ b/src/lib/sounds/PlayGlyph.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  // Three-state transport glyph, sized in `em` to its host button's font-size.
+  //   play     — equilateral triangle (circumcenter = centroid, so it's optically
+  //              centred AND its 3 vertices sit at 0°/120°/240° for a symmetric spin)
+  //   loading  — those 3 vertices become comet heads orbiting with a trailing arc
+  //              (a loading swirl) while el.play() is still pending
+  //   playing  — snaps to the two pause bars
+  // The vertices and the comet heads share the same circumradius (34), so the
+  // triangle dissolving into the swirl is continuous.
+  interface Props {
+    state: "play" | "loading" | "playing";
+  }
+  let { state }: Props = $props();
+</script>
+
+<span class="glyph" data-state={state} aria-hidden="true">
+  <svg viewBox="0 0 100 100">
+    <!-- play: equilateral triangle pointing right -->
+    <polygon class="tri" points="84,50 33,79.44 33,20.56" />
+
+    <!-- loading: 3 comets (trailing arc + head dot) at 120° apart, group spins -->
+    <g class="swirl" fill="currentColor">
+      {#each [0, 120, 240] as a (a)}
+        <g transform="rotate({a} 50 50)">
+          <path
+            d="M61.63,18.05 A34,34 0 0 1 84,50"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="9"
+            stroke-linecap="round"
+            stroke-opacity="0.4"
+          />
+          <circle cx="84" cy="50" r="7" />
+        </g>
+      {/each}
+    </g>
+
+    <!-- playing: pause bars -->
+    <g class="bars" fill="currentColor">
+      <rect x="35" y="27" width="11" height="46" rx="3" />
+      <rect x="54" y="27" width="11" height="46" rx="3" />
+    </g>
+  </svg>
+</span>
+
+<style>
+  .glyph {
+    display: inline-grid;
+    place-items: center;
+    line-height: 0;
+  }
+  .glyph svg {
+    display: block;
+    width: 1em;
+    height: 1em;
+  }
+
+  .tri,
+  .swirl,
+  .bars {
+    opacity: 0;
+    transition: opacity 0.22s ease;
+  }
+  /* spin around the viewBox centre regardless of how the SVG is scaled */
+  .swirl {
+    transform-box: view-box;
+    transform-origin: 50% 50%;
+  }
+
+  [data-state="play"] .tri {
+    opacity: 1;
+  }
+  [data-state="loading"] .swirl {
+    opacity: 1;
+    animation: pg-spin 0.8s linear infinite;
+  }
+  /* "snaps immediately to the pause button" — no fade in/out at playback start */
+  [data-state="playing"] .bars {
+    opacity: 1;
+    transition: none;
+  }
+  [data-state="playing"] .swirl {
+    opacity: 0;
+    transition: none;
+  }
+
+  @keyframes pg-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    [data-state="loading"] .swirl {
+      animation: none; /* show the 3 static points instead of spinning them */
+    }
+  }
+</style>

--- a/src/lib/sounds/player.svelte.ts
+++ b/src/lib/sounds/player.svelte.ts
@@ -14,7 +14,8 @@ export interface Track {
 
 export const player = $state({
   track: null as Track | null,
-  playing: false,
+  playing: false, // audio has actually begun (el.play() resolved) — drives pause glyph + grid recede
+  loading: false, // asked to play, awaiting playback start — drives the loading swirl
   currentTime: 0,
   duration: 0,
 });
@@ -37,6 +38,7 @@ export function attach(node: HTMLAudioElement) {
     gen++; // invalidate any in-flight start() from the outgoing element
     el.pause(); // stop the outgoing element before we drop our reference to it
     player.playing = false;
+    player.loading = false;
     player.currentTime = 0;
     player.duration = 0;
   }
@@ -58,20 +60,28 @@ function loop() {
 async function start() {
   if (!el) return;
   const myGen = ++gen; // claim this start; a newer playTrack/toggle supersedes it
-  // Flip to playing optimistically — BEFORE awaiting play() — so the grid's
-  // dim/ring opacity transitions begin on the click, not when the audio finishes
-  // loading. On a cold track the play() promise can stay pending for hundreds of
-  // ms (R2 fetch); resolving it there made the fade-out start late and snap,
-  // while the synchronous pause faded cleanly (the in/out asymmetry). Starting
-  // the fade now lets it run during the load and complete before playback begins.
-  player.playing = true;
+  // Two-step UI. Show the loading swirl the instant we're asked to play —
+  // el.play() can stay pending for hundreds of ms on a cold R2 track — then flip
+  // to actually-playing only once playback has begun. That second flip is the cue
+  // for the pause glyph and for the grid receding to just the playing card.
+  // Leave `playing` as-is meanwhile: false from idle (the other cards stay visible
+  // behind the swirl), but still-true when auto-advancing/switching from a playing
+  // track, so the grid stays receded through the load instead of flashing back in.
+  player.loading = true;
   lastUi = 0; // first loop tick writes time/duration immediately (no stale flash on track switch)
-  if (!raf) loop();
   try {
     await el.play();
   } catch {
-    if (myGen === gen) player.playing = false; // blocked/interrupted, and still the latest attempt
+    if (myGen === gen) {
+      player.loading = false;
+      player.playing = false; // blocked/interrupted, and still the latest attempt
+    }
+    return;
   }
+  if (myGen !== gen) return; // a newer track took over while we awaited play()
+  player.loading = false;
+  player.playing = true; // playback has begun
+  if (!raf) loop();
 }
 
 export async function playTrack(t: Track) {
@@ -87,9 +97,10 @@ export async function playTrack(t: Track) {
 
 export async function toggle() {
   if (!el || !player.track) return;
-  if (player.playing) {
-    el.pause();
+  if (player.playing || player.loading) {
+    el.pause(); // also aborts an in-flight load (rejects the pending play())
     player.playing = false;
+    player.loading = false;
   } else {
     await start();
   }

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -173,6 +173,7 @@
       }
     }
     player.playing = false; // reached the end of the list
+    player.loading = false;
   };
 
   const isCurrent = (song: Song) => player.track?.slug === song.slug;
@@ -239,7 +240,7 @@
   {@const active = isCurrent(song) && player.playing}
   {@const loading = isCurrent(song) && player.loading}
   {@const dimmed = modal && !active}
-  <figure class="stack" class:playing={active} class:loading class:dimmed data-slug={song.slug}>
+  <figure class="stack" class:playing={active} class:loading class:dimmed inert={dimmed} data-slug={song.slug}>
     <div class="deck">
       {#each song.versions as v, i (v.src)}
         <div class="card" style="--rot:{fan(i)}deg; z-index:{40 - i};">
@@ -273,7 +274,7 @@
     {#each tiles as t, i (t.song.slug)}{@render tile(t, i < 3)}{/each}
   </section>
 
-  <section class="hmbm" class:hushed={modal}>
+  <section class="hmbm" class:hushed={modal} inert={modal}>
     <h2 class="hmbm-title">{HMBM_FILM.title}</h2>
     <p class="hmbm-meta">sk+w · film score · {HMBM_FILM.year} · {manifest.scores.hmbm.length} cues</p>
     <div class="hmbm-poster">

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -2,6 +2,7 @@
   import SeoHead from "$lib/components/SeoHead.svelte";
   import { collectionPageNode } from "$lib/seo";
   import EyeOcean from "$lib/sounds/EyeOcean.svelte";
+  import PlayGlyph from "$lib/sounds/PlayGlyph.svelte";
   import { player, attach, playTrack, toggle, seek, setScrubbing } from "$lib/sounds/player.svelte";
   import type { PageData } from "./$types";
   import type { Cue, Song } from "$lib/sounds/types";
@@ -176,6 +177,17 @@
 
   const isCurrent = (song: Song) => player.track?.slug === song.slug;
 
+  // "Modal" = a grid song is playing → the other cards recede to nothing and a
+  // full-screen catcher lets a click anywhere pause. Cues (no card) don't engage it.
+  const modal = $derived(player.playing && player.track?.variant !== "cue");
+  // Resolve the three-state glyph. Only the active track shows loading/pause.
+  const status = (): "play" | "loading" | "playing" => {
+    if (player.loading) return "loading";
+    if (player.playing) return "playing";
+    return "play";
+  };
+  const tileStatus = (slug: string) => (player.track?.slug === slug ? status() : "play");
+
 
   // The fullscreen eyes gaze toward the playing song's card. Recompute its viewport
   // center on play/pause/track-change and on scroll/resize — one layout read, not
@@ -223,19 +235,12 @@
 <div class="scrim scrim-top" aria-hidden="true"></div>
 <h1 class="brand">sounds</h1>
 
-{#snippet glyph(playing: boolean)}
-  {#if playing}
-    <span class="g-pause" aria-hidden="true"><span></span><span></span></span>
-  {:else}
-    <span class="g-play" aria-hidden="true"></span>
-  {/if}
-{/snippet}
-
 {#snippet tile(t: Tile, featured: boolean)}
   {@const song = t.song}
   {@const active = isCurrent(song) && player.playing}
-  {@const dimmed = player.playing && player.track?.variant !== "cue" && !active}
-  <figure class="stack" class:playing={active} class:dimmed data-slug={song.slug}>
+  {@const loading = isCurrent(song) && player.loading}
+  {@const dimmed = modal && !active}
+  <figure class="stack" class:playing={active} class:loading class:dimmed data-slug={song.slug}>
     <div class="deck">
       {#each song.versions as v, i (v.src)}
         <div class="card" style="--rot:{fan(i)}deg; z-index:{40 - i};">
@@ -251,7 +256,7 @@
         aria-label={active ? `pause ${song.title}` : `play ${song.title}`}
         onclick={() => play(song)}
       >
-        {@render glyph(active)}
+        <PlayGlyph state={tileStatus(song.slug)} />
       </button>
     </div>
     <figcaption>
@@ -269,7 +274,7 @@
     {#each tiles as t, i (t.song.slug)}{@render tile(t, i < 3)}{/each}
   </section>
 
-  <section class="hmbm">
+  <section class="hmbm" class:hushed={modal}>
     <h2 class="hmbm-title">{HMBM_FILM.title}</h2>
     <p class="hmbm-meta">sk+w · film score · {HMBM_FILM.year} · {manifest.scores.hmbm.length} cues</p>
     <div class="hmbm-poster">
@@ -289,13 +294,19 @@
       </div>
     </div>
   </section>
+
+  <!-- while a grid song plays, a click anywhere pauses it (and brings the cards
+       back); the playing card + transport sit above this catcher and keep working -->
+  {#if modal}
+    <button class="pause-catch" aria-label="pause and show all tracks" onclick={toggleCurrent}></button>
+  {/if}
 </main>
 
 <div class="scrim scrim-bottom" aria-hidden="true"></div>
 
 <footer class="transport">
   <button class="tp-play" aria-label={player.playing ? "pause" : "play"} onclick={toggleCurrent} disabled={!player.track}>
-    {@render glyph(player.playing)}
+    <PlayGlyph state={status()} />
   </button>
   <div class="np">
     {#if player.track}
@@ -378,11 +389,18 @@
   .grid > :global(.stack:nth-child(-n + 3)) {
     grid-column: span 4;
   }
-  /* while a grid song plays, the other cards recede to a dim — the playing one (and
-     the eyes watching it) stand out; they stay in the grid + clickable to switch.
-     Computed per-tile so it updates the instant you click. */
+  /* once a grid song is actually playing, every other card recedes to nothing so
+     only the playing one (and the eyes watching it) remain. Computed per-tile so
+     it tracks playback start; a click anywhere then pauses + brings them back. */
   .grid > :global(.stack.dimmed) {
-    opacity: 0.13;
+    opacity: 0;
+    pointer-events: none;
+  }
+  /* lift the playing card above the full-screen pause-catcher so it stays crisp
+     and its own pause button keeps working */
+  .grid > :global(.stack.playing) {
+    position: relative;
+    z-index: 25;
   }
 
   /* dub-stack tile */
@@ -428,8 +446,9 @@
   .stack:hover .card {
     transform: rotate(calc(var(--rot) * 1.85)) translateY(-3px);
   }
-  /* covers sit in grayscale, bloom to color on hover (and while playing) */
+  /* covers sit in grayscale, bloom to color on hover (and while loading/playing) */
   .stack:hover .card img,
+  .stack.loading .card img,
   .stack.playing .card img {
     filter: grayscale(0);
   }
@@ -485,31 +504,10 @@
     z-index: 50;
   }
   .stack:hover .play,
+  .stack.loading .play,
   .stack.playing .play {
     opacity: 1;
     transform: scale(1);
-  }
-
-  /* play / pause glyphs — sized in em to the coin disc's font-size, centered by
-     the disc's grid. The pause is the nav coin's bars, vertical (its hamburger
-     glyph rotated 90°). */
-  .g-play {
-    width: 0;
-    height: 0;
-    border-style: solid;
-    border-width: 0.6em 0 0.6em 1em;
-    border-color: transparent transparent transparent currentColor;
-    margin-left: 0.16em; /* optical centering of the triangle */
-  }
-  .g-pause {
-    display: flex;
-    gap: 0.24em;
-  }
-  .g-pause span {
-    width: 0.2em;
-    height: 0.92em;
-    background: currentColor;
-    border-radius: 1px;
   }
 
   figcaption {
@@ -568,6 +566,27 @@
     margin-top: 4.5rem;
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     padding-top: 2rem;
+    transition: opacity 0.45s ease;
+  }
+  /* recede with the grid while a song plays — focus stays on the one playing card */
+  .hmbm.hushed {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* full-screen click target shown while a grid song plays: a click anywhere
+     pauses (and the cards return). Inside <main> (z-index 1) so the playing card
+     (z-index 25) sits above it; the transport (z-index 30, outside main) stays
+     clickable so the scrubber doesn't trigger a pause. */
+  .pause-catch {
+    position: fixed;
+    inset: 0;
+    z-index: 20;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
   }
   .hmbm-poster {
     position: relative;

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -188,7 +188,6 @@
   };
   const tileStatus = (slug: string) => (player.track?.slug === slug ? status() : "play");
 
-
   // The fullscreen eyes gaze toward the playing song's card. Recompute its viewport
   // center on play/pause/track-change and on scroll/resize — one layout read, not
   // per animation frame. null when nothing in the grid is playing (a paused track,


### PR DESCRIPTION
The /sounds play control is now a **three-state morphing glyph** (`PlayGlyph.svelte`, an SVG sized in `em` to its host disc):

- **play** — an equilateral triangle (circumcentre = centroid, so it's optically centred *and* its 3 vertices sit at 0°/120°/240° for a symmetric spin)
- **loading** — on click, the triangle dissolves into those 3 vertices, which orbit with a trailing swirl while `el.play()` is pending
- **playing** — snaps to the pause bars the instant playback begins

**Engine:** split `loading` (asked to play, awaiting start) from `playing` (`el.play()` resolved) in the player store. `start()` flips `loading` on immediately, then `playing` once `play()` resolves; it no longer forces `playing=false`, so auto-advancing from a playing track keeps the grid receded through the next load instead of flashing the cards back in.

**Modal:** once a grid song actually plays, the other cards (and the HMBM section) fade to opacity 0 and a full-screen catcher lets a click anywhere pause — which brings the cards back and snaps the glyph to play. The playing card (z-index 25) and the transport (z-index 30) stay above the catcher; receded/hushed regions are `inert` so they leave the keyboard tab order.

Supersedes the optimistic-playing flip from #69: the dim now waits for real playback, with the loading swirl bridging the click→playback gap.

Verified live by Sam.

- svelte-check + svelte autofixer: clean
- `/rl`: clean — 3 rounds, 3 findings addressed (R1: a stray blank line; the keyboard-reachable receded-cards a11y gap → `inert`; explicit `loading` reset at end-of-list). Security 0. Stacking/state-machine/SVG traced and verified across R1–R3.

Note: the transport's play glyph changes (CSS-border triangle → SVG equilateral); I'll refresh the /sounds visual baselines after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)