### PR TITLE
feat(thoughts): stage the drain — flip first, then 2s tween

### DIFF
--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -120,14 +120,16 @@ export const day30: Sketch = {
     }
 
     // Slow/color mode: when a /thoughts card is hovered, `sketchMode.slow`
-    // flips to 1. We lerp `currentSlow` toward it each tick so the page
-    // side just sets a target and the sketch handles the easing. At
+    // flips to 1 *after* the card flip finishes (page schedules it). We
+    // ramp `currentSlow` linearly toward the target at a rate of 1/120
+    // per frame so the full traversal lasts ~2s at 60fps — the "drain
+    // color from bodies into card" tween the design calls for. At
     // currentSlow=0 walkers are coin-tinted (per-walker brightness
     // wk.color/255 scales the coin channels — keeps the gold textured).
     // At currentSlow=1 they go to the brand --white and move at half
     // speed.
     let currentSlow = 0;
-    const SLOW_LERP = 0.05; // ~600ms to reach 95% of the target
+    const SLOW_RATE = 1 / 120;
     // --coin = #e8a317
     const COIN_R = 232;
     const COIN_G = 163;
@@ -226,7 +228,11 @@ export const day30: Sketch = {
 
     return {
       tick() {
-        currentSlow += (sketchMode.slow - currentSlow) * SLOW_LERP;
+        if (sketchMode.slow > currentSlow) {
+          currentSlow = Math.min(sketchMode.slow, currentSlow + SLOW_RATE);
+        } else if (sketchMode.slow < currentSlow) {
+          currentSlow = Math.max(sketchMode.slow, currentSlow - SLOW_RATE);
+        }
         const speedMul = 1 - 0.5 * currentSlow;
 
         // Full-canvas alpha-blended fill is the single most expensive

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -4,19 +4,39 @@
   import { sketchMode } from "$lib/art/sketch-mode";
   import { blogNode } from "$lib/seo";
 
-  // Counter (not boolean) so the brief mouseleave-A → mouseenter-B
-  // transition between adjacent cards doesn't flicker the sketch back to
-  // fast for a frame.
+  // The card's 3D flip takes 700ms (transition-transform duration-700).
+  // The color drain only begins once that flip lands — page schedules
+  // sketchMode.slow=1 700ms after the first card hover. day30 then
+  // linearly tweens its currentSlow over 2s.
+  //
+  // hoverCount survives mouseleave-A → mouseenter-B; the microtask
+  // deferral on leave catches the same handoff so we don't tear the
+  // pending drain down between adjacent cards.
+  const FLIP_MS = 700;
   let hoverCount = 0;
+  let drainTimer: ReturnType<typeof setTimeout> | null = null;
+
   function enterCard() {
     hoverCount++;
-    sketchMode.slow = 1;
+    if (hoverCount === 1 && drainTimer === null && sketchMode.slow === 0) {
+      drainTimer = setTimeout(() => {
+        sketchMode.slow = 1;
+        drainTimer = null;
+      }, FLIP_MS);
+    }
   }
   function leaveCard() {
     hoverCount--;
     if (hoverCount <= 0) {
       hoverCount = 0;
-      sketchMode.slow = 0;
+      queueMicrotask(() => {
+        if (hoverCount > 0) return;
+        if (drainTimer !== null) {
+          clearTimeout(drainTimer);
+          drainTimer = null;
+        }
+        sketchMode.slow = 0;
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
The flip and the walker color drain now happen sequentially, not in parallel:

1. Hover → CSS flip animation (700ms).
2. Page setTimeout fires → \`sketchMode.slow = 1\`.
3. day30 linearly ramps \`currentSlow\` 0 → 1 at \`1/120\` per frame — exactly 2s @ 60fps. Walkers shift from \`--coin\` (per-walker brightness preserved) to \`--white\` and halve speed in unison.

Unhover mirrors: \`slow = 0\` immediately + CSS flip-back run in parallel.

Adjacent-card handoff is preserved via \`queueMicrotask\` — if mouseenter-B fires synchronously after mouseleave-A, the pending drain isn't torn down for one frame.

## Test plan
- [x] hover any card: flip 700ms → walkers begin draining → fully white at ~2.7s from hover
- [x] unhover: flip-back + walkers recovering to gold simultaneously (~2s recovery)
- [x] move A→B between adjacent cards: drain keeps progressing, no reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)