### PR TITLE
feat(sounds): hide playing card's pause button until hover (desktop)

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -509,6 +509,15 @@
     opacity: 1;
     transform: scale(1);
   }
+  /* On desktop, the playing card's pause button hides until you hover it — the
+     modal stays a clean cover (+ coin ring). The loading swirl still shows (it's
+     not yet `.playing`, or is also `.loading` mid auto-advance), and touch devices
+     keep the button visible since there's no hover to summon it. */
+  @media (hover: hover) {
+    .stack.playing:not(.loading):not(:hover) .play {
+      opacity: 0;
+    }
+  }
 
   figcaption {
     margin-top: 0.9rem;


### PR DESCRIPTION
While a grid song plays, the focused card now stays a clean cover + coin ring on desktop — the pause glyph only appears on hover.

- `@media (hover: hover)` so touch devices keep the pause button visible (no hover to summon it).
- `:not(.loading)` so the auto-advance loading swirl still shows even though the card is also `.playing` mid-load.
- Click-anywhere-to-pause (the full-screen catcher) is unchanged.

CSS-only, presentational. svelte-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)