### PR TITLE
feat(thoughts): reverse speed map + transitionend-gated drain

### DIFF
--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -125,9 +125,11 @@ export const day30: Sketch = {
     // per frame so the full traversal lasts ~2s at 60fps — the "drain
     // color from bodies into card" tween the design calls for. At
     // currentSlow=0 walkers are coin-tinted (per-walker brightness
-    // wk.color/255 scales the coin channels — keeps the gold textured).
-    // At currentSlow=1 they go to the brand --white and move at half
-    // speed.
+    // wk.color/255 scales the coin channels — keeps the gold textured)
+    // and crawl at 25% of their base speed: idle reads as a sluggish
+    // drift. At currentSlow=1 they snap to the brand --white and burst
+    // to 3× base — bodies "release" their color and accelerate as the
+    // card absorbs it.
     let currentSlow = 0;
     const SLOW_RATE = 1 / 120;
     // --coin = #e8a317
@@ -233,7 +235,7 @@ export const day30: Sketch = {
         } else if (sketchMode.slow < currentSlow) {
           currentSlow = Math.max(sketchMode.slow, currentSlow - SLOW_RATE);
         }
-        const speedMul = 1 - 0.5 * currentSlow;
+        const speedMul = 0.25 + 2.75 * currentSlow;
 
         // Full-canvas alpha-blended fill is the single most expensive
         // op in this sketch (measured ~2ms on a desktop 2880×1800 DPR-2

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -4,26 +4,18 @@
   import { sketchMode } from "$lib/art/sketch-mode";
   import { blogNode } from "$lib/seo";
 
-  // The card's 3D flip takes 700ms (transition-transform duration-700).
-  // The color drain only begins once that flip lands — page schedules
-  // sketchMode.slow=1 700ms after the first card hover. day30 then
-  // linearly tweens its currentSlow over 2s.
+  // The drain only begins after the card's 3D flip is fully painted.
+  // Instead of guessing the duration we listen for the actual
+  // `transitionend` of the flip's transform — guarantees we never start
+  // mid-flip, even if the browser delays the first frame.
   //
   // hoverCount survives mouseleave-A → mouseenter-B; the microtask
   // deferral on leave catches the same handoff so we don't tear the
   // pending drain down between adjacent cards.
-  const FLIP_MS = 700;
   let hoverCount = 0;
-  let drainTimer: ReturnType<typeof setTimeout> | null = null;
 
   function enterCard() {
     hoverCount++;
-    if (hoverCount === 1 && drainTimer === null && sketchMode.slow === 0) {
-      drainTimer = setTimeout(() => {
-        sketchMode.slow = 1;
-        drainTimer = null;
-      }, FLIP_MS);
-    }
   }
   function leaveCard() {
     hoverCount--;
@@ -31,13 +23,17 @@
       hoverCount = 0;
       queueMicrotask(() => {
         if (hoverCount > 0) return;
-        if (drainTimer !== null) {
-          clearTimeout(drainTimer);
-          drainTimer = null;
-        }
         sketchMode.slow = 0;
       });
     }
+  }
+  function onSectionTransitionEnd(e: TransitionEvent) {
+    // Only the card outer + inner flip transition `transform`. Both end
+    // at the same paint; the first one to fire is enough.
+    if (e.propertyName !== "transform") return;
+    if (hoverCount === 0) return;
+    if (sketchMode.slow === 1) return;
+    sketchMode.slow = 1;
   }
 
   const cards = [
@@ -87,6 +83,7 @@
     </h1>
   </header>
   <section
+    ontransitionend={onSectionTransitionEnd}
     class="relative z-10 mx-auto grid max-w-7xl grid-cols-1 gap-6 md:grid-cols-3 md:gap-9"
   >
     {#each cards as card (card.href)}


### PR DESCRIPTION
## Summary
- **Speed**: walkers idle at \`0.25×\` their base speed (drifty crawl) and burst to \`3.0×\` during the drain — bodies "exhale" color into the card and accelerate away. Linear map: \`speedMul = 0.25 + 2.75 · currentSlow\`.
- **Drain trigger**: drop the \`setTimeout(700)\` and listen to the section's \`transitionend\`. The drain now starts on the exact frame the flip's transform settles, gated on \`hoverCount > 0 && slow === 0\` so the flip-back's transitionend is a no-op.

## Test plan
- [x] idle: walkers visibly slow + gold, trails very short
- [x] hover: flip 700ms → drain begins exactly when flip lands → walkers accelerate to 3× and fade to \`--white\` over 2s, leaving dramatic long trails
- [x] unhover: walkers recover to gold + slow over 2s in parallel with the CSS flip-back

🤖 Generated with [Claude Code](https://claude.com/claude-code)