### PR TITLE
chore(home): reorder gallery cards — self→analog→sounds→shelf→deana→thoughts

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -16,8 +16,8 @@
 		{ label: 'self', handle: 'self', href: '/self' },
 		{ label: 'analog', handle: 'anything-but-analog', href: '/anything-but-analog' },
 		{ label: 'sounds', handle: 'sounds', href: '/sounds' },
-		{ label: 'D-ANA', handle: 'deana', href: '/deana' },
 		{ label: 'shelf', handle: 'shelf', href: '/shelf' },
+		{ label: 'D-ANA', handle: 'deana', href: '/deana' },
 		{ label: 'thoughts', handle: 'thoughts', href: '/thoughts' },
 	];
 


### PR DESCRIPTION
One-off: swaps the order of the homepage gallery cards so `shelf` comes before `deana`. The strip is masked in the visual-parity test, so no baseline change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)