### PR TITLE
feat(thoughts): card + bodies on one 3s drain timeline

### DIFF
--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -120,18 +120,17 @@ export const day30: Sketch = {
     }
 
     // Slow/color mode: when a /thoughts card is hovered, `sketchMode.slow`
-    // flips to 1 *after* the card flip finishes (page schedules it). We
-    // ramp `currentSlow` linearly toward the target at a rate of 1/120
-    // per frame so the full traversal lasts ~2s at 60fps — the "drain
-    // color from bodies into card" tween the design calls for. At
-    // currentSlow=0 walkers are coin-tinted (per-walker brightness
-    // wk.color/255 scales the coin channels — keeps the gold textured)
-    // and crawl at 25% of their base speed: idle reads as a sluggish
-    // drift. At currentSlow=1 they snap to the brand --white and burst
-    // to 3× base — bodies "release" their color and accelerate as the
-    // card absorbs it.
+    // flips to 1. We ramp `currentSlow` linearly at 1/180 per frame so
+    // the full traversal lasts exactly 3s at 60fps — the same timeline
+    // as the card back face's `transition-colors duration-[3000ms]`.
+    // The two run in parallel: bodies fade gold → --white while the
+    // card fades white → coin. At currentSlow=0 walkers are coin-tinted
+    // (per-walker brightness wk.color/255 scales the channels — keeps
+    // the gold textured) and crawl at 25% of base speed: idle reads as
+    // a sluggish drift. At currentSlow=1 they snap to brand --white and
+    // burst to 2× base.
     let currentSlow = 0;
-    const SLOW_RATE = 1 / 120;
+    const SLOW_RATE = 1 / 180;
     // --coin = #e8a317
     const COIN_R = 232;
     const COIN_G = 163;
@@ -235,7 +234,7 @@ export const day30: Sketch = {
         } else if (sketchMode.slow < currentSlow) {
           currentSlow = Math.max(sketchMode.slow, currentSlow - SLOW_RATE);
         }
-        const speedMul = 0.25 + 2.75 * currentSlow;
+        const speedMul = 0.25 + 1.75 * currentSlow;
 
         // Full-canvas alpha-blended fill is the single most expensive
         // op in this sketch (measured ~2ms on a desktop 2880×1800 DPR-2

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -4,18 +4,21 @@
   import { sketchMode } from "$lib/art/sketch-mode";
   import { blogNode } from "$lib/seo";
 
-  // The drain only begins after the card's 3D flip is fully painted.
-  // Instead of guessing the duration we listen for the actual
-  // `transitionend` of the flip's transform — guarantees we never start
-  // mid-flip, even if the browser delays the first frame.
+  // Hover triggers two parallel 3s transitions:
+  //   - the card back face fades bg-white -> bg-coin via group-hover CSS
+  //   - the sketch's currentSlow ramps 0 -> 1 (day30 lerps at 1/180 per
+  //     frame, also 3s at 60fps)
+  // Net effect: bodies release color and accelerate while the card
+  // absorbs it, both on the same timeline.
   //
-  // hoverCount survives mouseleave-A → mouseenter-B; the microtask
-  // deferral on leave catches the same handoff so we don't tear the
-  // pending drain down between adjacent cards.
+  // hoverCount survives mouseleave-A → mouseenter-B between adjacent
+  // cards; the microtask deferral on leave catches the same handoff so
+  // we don't tear sketchMode.slow down for one frame.
   let hoverCount = 0;
 
   function enterCard() {
     hoverCount++;
+    sketchMode.slow = 1;
   }
   function leaveCard() {
     hoverCount--;
@@ -26,14 +29,6 @@
         sketchMode.slow = 0;
       });
     }
-  }
-  function onSectionTransitionEnd(e: TransitionEvent) {
-    // Only the card outer + inner flip transition `transform`. Both end
-    // at the same paint; the first one to fire is enough.
-    if (e.propertyName !== "transform") return;
-    if (hoverCount === 0) return;
-    if (sketchMode.slow === 1) return;
-    sketchMode.slow = 1;
   }
 
   const cards = [
@@ -83,7 +78,6 @@
     </h1>
   </header>
   <section
-    ontransitionend={onSectionTransitionEnd}
     class="relative z-10 mx-auto grid max-w-7xl grid-cols-1 gap-6 md:grid-cols-3 md:gap-9"
   >
     {#each cards as card (card.href)}
@@ -131,7 +125,7 @@
               />
             </div>
             <div
-              class="absolute inset-0 flex flex-col justify-center bg-coin p-6 [backface-visibility:hidden] [transform:rotateY(180deg)]"
+              class="absolute inset-0 flex flex-col justify-center bg-white p-6 transition-colors duration-[3000ms] group-hover:bg-coin [backface-visibility:hidden] [transform:rotateY(180deg)]"
             >
               <span
                 class="block font-mono text-2xl font-bold uppercase tracking-[0.3em] text-black"


### PR DESCRIPTION
## Summary
Two synchronized 3s tweens on hover, no JS coordination:
- Card back face: \`bg-white group-hover:bg-coin transition-colors duration-[3000ms]\`.
- day30: \`SLOW_RATE = 1/180\` per frame (exactly 3s at 60fps).

Drops the prior \`drainOn\` \`$state\` and \`transitionend\` listener — CSS handles the card side, the sketch handles the body side, both run on the same wall clock. \`hoverCount\` + the microtask deferral remain for adjacent-card handoffs.

## Test plan
- [x] hover any card: card tweens white → coin over 3s; bodies simultaneously tween coin → \`--white\` and 0.25× → 2× speed over the same 3s
- [x] unhover: both reverse in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)