### PR TITLE
fix(sounds): clip horizontal overflow from the fanned dub-stack cards

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -350,6 +350,10 @@
     padding: 7rem 1.5rem calc(var(--player-h) + 6rem);
     color: var(--white);
     font-family: "Recursive Mono", ui-monospace, monospace;
+    /* the fanned dub-stack cards rotate past the edge columns; clip that off-screen
+       overhang so it can't spawn a horizontal scrollbar. `clip` (not `hidden`) so
+       main doesn't become a scroll container — overflow-y stays visible. */
+    overflow-x: clip;
   }
   /* title pinned top-left, inline with the nav coin, above the top scrim */
   .brand {


### PR DESCRIPTION
Rotated version-stack cards in the edge columns poked ~10–19px past the viewport → horizontal scrollbar on desktop and mobile. Fixed with `overflow-x: clip` on `main` (not `hidden` — keeps overflow-y visible, no scroll container). Off-screen overhang only, nothing visible lost.

Verified in-browser: 0px document overflow at 1280 and 390.

Note: removing the overflow changes the captured page width, so I'll refresh the /sounds visual baselines after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)