### PR TITLE
fix(thoughts): scope tint to /thoughts (active flag); drop speed mod

### DIFF
--- a/src/lib/art/sketch-mode.ts
+++ b/src/lib/art/sketch-mode.ts
@@ -1,5 +1,6 @@
-// Shared signal for the /thoughts hover → bg-sketch coordination.
-// Pages set `slow` to 1 when a hover should slow/gold the sketch, 0 to
-// release. Sketches read it each tick and lerp toward it internally so
-// the page side stays a single assignment per event.
-export const sketchMode = { slow: 0 };
+// Shared signal between routes and the day30 sketch. Only the
+// /thoughts route opts in via `active = true`; the homepage gallery's
+// day30 sees `active = false` and renders its original look (full
+// speed, neutral grays). When active, day30 reads `slow` (0..1) and
+// ramps its internal currentSlow toward it for the drain effect.
+export const sketchMode = { slow: 0, active: false };

--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -119,17 +119,17 @@ export const day30: Sketch = {
       }
     }
 
-    // Slow/color mode: when a /thoughts card is hovered, `sketchMode.slow`
-    // flips to 1. We ramp `currentSlow` linearly at 1/180 per frame so
-    // the full traversal lasts exactly 3s at 60fps — the same timeline
-    // as the card back face's `transition-colors duration-[3000ms]`.
-    // The two run in parallel: bodies fade gold → --white while the
-    // card fades white → coin. At currentSlow=0 walkers are coin-tinted
-    // (per-walker brightness wk.color/255 scales the channels — keeps
-    // the gold textured) and crawl at 25% of base speed: idle reads as
-    // a sluggish drift. At currentSlow=1 they fade to brand --white and
-    // drop further to 5% of base — drained of color *and* energy.
+    // Color mode: opt-in via `sketchMode.active`. The /thoughts route
+    // flips it on; the homepage gallery leaves it off so its day30 card
+    // keeps the original neutral grays.
+    //
+    // When active, hover sets `sketchMode.slow` to 1 and we ramp
+    // `currentSlow` linearly at 1/180 per frame (exactly 3s at 60fps —
+    // the same timeline as the card back face's `duration-[3000ms]`).
+    // Walker color lerps coin → --white over the same 3s. Speed is
+    // unchanged in both modes; only the tint moves.
     let currentSlow = 0;
+    let active = false;
     const SLOW_RATE = 1 / 180;
     // --coin = #e8a317
     const COIN_R = 232;
@@ -152,14 +152,18 @@ export const day30: Sketch = {
       const ll = wk.limbLength;
       const minPossible = 0.025;
 
-      const k = wk.color / 255;
-      const idleR = COIN_R * k;
-      const idleG = COIN_G * k;
-      const idleB = COIN_B * k;
-      const r = Math.round(idleR + (WHITE_R - idleR) * currentSlow);
-      const g = Math.round(idleG + (WHITE_G - idleG) * currentSlow);
-      const b = Math.round(idleB + (WHITE_B - idleB) * currentSlow);
-      ctx.strokeStyle = `rgb(${r},${g},${b})`;
+      if (active) {
+        const k = wk.color / 255;
+        const idleR = COIN_R * k;
+        const idleG = COIN_G * k;
+        const idleB = COIN_B * k;
+        const r = Math.round(idleR + (WHITE_R - idleR) * currentSlow);
+        const g = Math.round(idleG + (WHITE_G - idleG) * currentSlow);
+        const b = Math.round(idleB + (WHITE_B - idleB) * currentSlow);
+        ctx.strokeStyle = `rgb(${r},${g},${b})`;
+      } else {
+        ctx.strokeStyle = `rgb(${wk.color},${wk.color},${wk.color})`;
+      }
 
       // Draw calls are deterministic per-figure (no per-frame randomness)
       // so the same walker looks consistent as it moves. We reuse rng()
@@ -229,12 +233,13 @@ export const day30: Sketch = {
 
     return {
       tick() {
-        if (sketchMode.slow > currentSlow) {
-          currentSlow = Math.min(sketchMode.slow, currentSlow + SLOW_RATE);
-        } else if (sketchMode.slow < currentSlow) {
-          currentSlow = Math.max(sketchMode.slow, currentSlow - SLOW_RATE);
+        active = sketchMode.active;
+        const target = active ? sketchMode.slow : 0;
+        if (target > currentSlow) {
+          currentSlow = Math.min(target, currentSlow + SLOW_RATE);
+        } else if (target < currentSlow) {
+          currentSlow = Math.max(target, currentSlow - SLOW_RATE);
         }
-        const speedMul = 0.25 - 0.2 * currentSlow;
 
         // Full-canvas alpha-blended fill is the single most expensive
         // op in this sketch (measured ~2ms on a desktop 2880×1800 DPR-2
@@ -343,8 +348,8 @@ export const day30: Sketch = {
             }
           }
 
-          wk.x += (Math.cos(moveAngle) * wk.speed + repelX * SEPARATION_GAIN + orbitX) * speedMul;
-          wk.y += (Math.sin(moveAngle) * wk.speed + repelY * SEPARATION_GAIN + orbitY) * speedMul;
+          wk.x += Math.cos(moveAngle) * wk.speed + repelX * SEPARATION_GAIN + orbitX;
+          wk.y += Math.sin(moveAngle) * wk.speed + repelY * SEPARATION_GAIN + orbitY;
 
           // Asteroids wrap. Exit right → enter left at same y. Exit top
           // → enter bottom at same x. And vice versa. Uses the extended

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -4,17 +4,27 @@
   import { sketchMode } from "$lib/art/sketch-mode";
   import { blogNode } from "$lib/seo";
 
+  // /thoughts opts the bg sketch into its tinted mode for the duration
+  // of this route. The homepage gallery leaves `active` off so its
+  // day30 card keeps the original neutral grays.
+  //
   // Hover triggers two parallel 3s transitions:
   //   - the card back face fades bg-white -> bg-coin via group-hover CSS
   //   - the sketch's currentSlow ramps 0 -> 1 (day30 lerps at 1/180 per
   //     frame, also 3s at 60fps)
-  // Net effect: bodies release color and accelerate while the card
-  // absorbs it, both on the same timeline.
   //
   // hoverCount survives mouseleave-A → mouseenter-B between adjacent
   // cards; the microtask deferral on leave catches the same handoff so
   // we don't tear sketchMode.slow down for one frame.
   let hoverCount = 0;
+
+  $effect(() => {
+    sketchMode.active = true;
+    return () => {
+      sketchMode.active = false;
+      sketchMode.slow = 0;
+    };
+  });
 
   function enterCard() {
     hoverCount++;


### PR DESCRIPTION
## Summary
\`sketchMode\` is a shared signal — the homepage gallery card and the /thoughts background both read it. Without scoping, the gold/white tint and the slowdown bled onto the homepage thoughts card.

- Add \`sketchMode.active\` (default \`false\`). /thoughts flips it on via a \`\$effect\` on mount and back off on cleanup (also clearing \`slow\`).
- day30 reads \`active\`. When off → original neutral-gray walkers at full speed (homepage look). When on → coin tint at rest, \`--white\` after the 3s drain.
- Speed modifier dropped. Walkers always move at their base speed; only the tint crossfades on hover.

## Test plan
- [x] homepage: thoughts card has full-speed gray walkers (original look)
- [x] /thoughts idle: full-speed walkers, coin tint
- [x] /thoughts hover: walkers tween coin → \`--white\` over 3s, no speed change
- [x] navigate away mid-hover: cleanup clears \`active\` + \`slow\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)