### PR TITLE
feat(thoughts): rounded corners + mobile fade overlay

### DIFF
--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -97,32 +97,33 @@
         onmouseleave={leaveCard}
         class="group relative block transition-transform duration-700 hover:[transform:rotate(-1.3deg)]"
       >
-        <!-- mobile: polaroid (cream card, image padded matching the text padding below) -->
-        <div class="bg-white p-4 md:hidden">
-          <div class="aspect-[4/5] overflow-hidden">
-            <img
-              src={card.img}
-              alt=""
-              loading="lazy"
-              class="h-full w-full object-cover [image-rendering:pixelated]"
-            />
-          </div>
-          <div class="mt-4">
+        <!-- mobile: image-fills card, bottom-left white title + description over a dark→transparent fade -->
+        <div class="relative aspect-[4/5] overflow-hidden rounded-2xl md:hidden">
+          <img
+            src={card.img}
+            alt=""
+            loading="lazy"
+            class="absolute inset-0 h-full w-full object-cover [image-rendering:pixelated]"
+          />
+          <div
+            class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/85 via-black/30 to-transparent"
+          ></div>
+          <div class="absolute right-4 bottom-4 left-4">
             <span
-              class="block font-mono text-xl font-bold uppercase tracking-[0.3em] text-black"
+              class="block font-mono text-xl font-bold uppercase tracking-[0.3em] text-white"
             >
               {card.title}
             </span>
             <p
-              class="mt-2 font-mono text-xs uppercase tracking-[0.15em] text-black"
+              class="mt-1.5 font-mono text-xs uppercase tracking-[0.15em] text-white"
             >
               {card.description}
             </p>
           </div>
         </div>
 
-        <!-- desktop: image-only front; hover flips to a coin back with title + description -->
-        <div class="hidden aspect-[4/5] [perspective:1200px] md:block">
+        <!-- desktop: image-only front; hover flips to a (white→coin) back with title + description -->
+        <div class="hidden aspect-[4/5] overflow-hidden rounded-2xl [perspective:1200px] md:block">
           <div
             class="relative h-full w-full transition-transform duration-700 [transform-style:preserve-3d] group-hover:[transform:rotateY(180deg)]"
           >


### PR DESCRIPTION
## Summary
- **Mobile**: drop the polaroid layout (cream bg + padded image + text below) for an image-fills-card variant. Dark→transparent gradient at the bottom; \`text-white\` title + description sit bottom-left over the fade. Rounded corners (\`rounded-2xl\`).
- **Desktop**: add \`rounded-2xl\` to the flip card. The outer \`overflow-hidden\` clips both faces during the 3D rotation; flip + drain tween still work.

## Test plan
- [x] mobile: image fills the rounded card, white title + description over a dark fade bottom-left
- [x] desktop: rounded corners visible on the image front, the white→coin back, and during the flip
- [x] hover drain (bodies coin→white, card white→coin) still runs across the 3s timeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)