### PR TITLE
fix(thoughts): cache-bust the pixel cards (?v=2)

### DIFF
--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -41,24 +41,28 @@
     }
   }
 
+  // ?v=N busts the immutable 1-year cache when we re-bake the source
+  // (covers iOS Safari, which won't even check the server otherwise).
+  // Bump the version every time you change generate-thoughts-pixel.mjs.
+  const PIXEL_V = 2;
   const cards = [
     {
       href: "/self",
       title: "self",
       description: "growing up in trenton.",
-      img: "/assets/thoughts-pixel/self.webp",
+      img: `/assets/thoughts-pixel/self.webp?v=${PIXEL_V}`,
     },
     {
       href: "/benny",
       title: "benny",
       description: "remembering 102 jackson street.",
-      img: "/assets/thoughts-pixel/benny.webp",
+      img: `/assets/thoughts-pixel/benny.webp?v=${PIXEL_V}`,
     },
     {
       href: "/dad",
       title: "dad",
       description: "stories about my dad.",
-      img: "/assets/thoughts-pixel/dad.webp",
+      img: `/assets/thoughts-pixel/dad.webp?v=${PIXEL_V}`,
     },
   ];
 </script>


### PR DESCRIPTION
## Summary
PR #90 re-baked \`self.webp\` from \`self-hero.webp\` (chunkier blocks) but devices that already visited /thoughts hold the old \`self.webp\` in their browser cache for **a year** (Vercel static-asset header is \`max-age=31536000, immutable\`). Even with prod and local hashes matching now, the iOS screenshot still showed the old soft bake.

Append a \`?v=N\` query string to the three pixel card URLs to make them distinct from the browser's perspective. The constant \`PIXEL_V\` lives next to the card list — bump on future re-bakes.

## Test plan
- [x] /thoughts loads the cards with \`?v=2\` URLs
- [x] phones that previously cached the old self.webp will now fetch the new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)