### PR TITLE
feat(seo): AI-agent welcome, breadcrumbs, richer llms.txt

### DIFF
--- a/src/lib/components/SeoHead.svelte
+++ b/src/lib/components/SeoHead.svelte
@@ -1,5 +1,13 @@
 <script lang="ts">
-  import { SITE_URL, SITE_DESCRIPTION, resolveTitle, jsonLdToScript, buildGraph } from '$lib/seo';
+  import {
+    SITE_URL,
+    SITE_DESCRIPTION,
+    SITE_PAGES,
+    resolveTitle,
+    jsonLdToScript,
+    buildGraph,
+    breadcrumbNode,
+  } from '$lib/seo';
 
   interface Props {
     title?: string;
@@ -14,6 +22,11 @@
     ogImageAlt?: string;
     /** Page-specific schema.org node(s) merged into the JSON-LD @graph (with Person + WebSite). */
     schema?: object | object[];
+    /** Override the auto-derived breadcrumb trail. Leaf paths
+     * (`/anything-but-analog/<slug>`) should pass their full trail. Top-
+     * level routes leave this undefined and get a Home → Page crumb
+     * derived from SITE_PAGES. Pass `null` to suppress the breadcrumb. */
+    breadcrumbTrail?: Array<{ path: string; name: string }> | null;
   }
   let {
     title,
@@ -24,6 +37,7 @@
     ogType = 'website',
     ogImageAlt,
     schema,
+    breadcrumbTrail,
   }: Props = $props();
 
   const resolvedTitle = $derived(resolveTitle(title));
@@ -35,6 +49,21 @@
   });
   const resolvedCanonical = $derived(canonical ?? '/');
   const resolvedImageAlt = $derived(ogImageAlt ?? resolvedTitle);
+  // Auto-derive Home → Page from SITE_PAGES when no explicit trail is
+  // passed. Homepage gets no crumb (single hop is meaningless).
+  const breadcrumb = $derived.by(() => {
+    if (breadcrumbTrail === null) return null;
+    if (breadcrumbTrail) return breadcrumbNode(breadcrumbTrail);
+    if (resolvedCanonical === '/') return null;
+    const segment = SITE_PAGES.find((p) =>
+      resolvedCanonical === p.path || resolvedCanonical.startsWith(`${p.path}/`),
+    );
+    if (!segment) return null;
+    return breadcrumbNode([
+      { path: '/', name: 'threesam' },
+      { path: segment.path, name: segment.label },
+    ]);
+  });
   // Pre-stringified @graph: shared Person + WebSite plus any page node(s). The
   // page description is folded into each node so schema can't drift from <meta>.
   const graphScript = $derived.by(() => {
@@ -42,7 +71,8 @@
     if (Array.isArray(schema)) nodes = schema;
     else if (schema) nodes = [schema];
     const described = nodes.map((n) => ({ ...n, description: resolvedDescription }));
-    return jsonLdToScript(buildGraph(...described));
+    const all = breadcrumb ? [...described, breadcrumb] : described;
+    return jsonLdToScript(buildGraph(...all));
   });
 </script>
 

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -201,3 +201,65 @@ export function creativeWorkNode(opts: {
   if (opts.datePublished) node.datePublished = opts.datePublished;
   return node;
 }
+
+/** BreadcrumbList — gives answer engines a way to surface the page in
+ * site context ("Home › Shelf"). Pass the trail from root → current. */
+export function breadcrumbNode(
+  trail: Array<{ path: string; name: string }>,
+): object {
+  return {
+    "@type": "BreadcrumbList",
+    "@id": `${absUrl(trail[trail.length - 1]?.path ?? "/")}#breadcrumb`,
+    itemListElement: trail.map((step, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: step.name,
+      item: absUrl(step.path),
+    })),
+  };
+}
+
+/** A music release/track listing (e.g. /sounds). MusicPlaylist is the
+ * loosest fit for a curated demo/score set — MusicAlbum implies a
+ * single release. Each track is a MusicRecording. */
+export function musicPlaylistNode(opts: {
+  path: string;
+  name: string;
+  tracks: Array<{ name: string; url?: string }>;
+}): object {
+  return {
+    "@type": "MusicPlaylist",
+    "@id": `${absUrl(opts.path)}#playlist`,
+    name: opts.name,
+    url: absUrl(opts.path),
+    creator: { "@id": PERSON_ID },
+    numTracks: opts.tracks.length,
+    track: opts.tracks.map((t, i) => ({
+      "@type": "MusicRecording",
+      position: i + 1,
+      name: t.name,
+      byArtist: { "@id": PERSON_ID },
+      ...(t.url ? { url: absUrl(t.url) } : {}),
+    })),
+  };
+}
+
+/** A curated list of items on a CollectionPage (e.g. /shelf). Generic
+ * ItemList so the same helper works for books, links, anything. */
+export function itemListNode(opts: {
+  path: string;
+  name: string;
+  items: Array<{ url: string; name: string }>;
+}): object {
+  return {
+    "@type": "ItemList",
+    "@id": `${absUrl(opts.path)}#itemlist`,
+    name: opts.name,
+    itemListElement: opts.items.map((it, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: it.url,
+      name: it.name,
+    })),
+  };
+}

--- a/src/routes/anything-but-analog/[slug]/+page.svelte
+++ b/src/routes/anything-but-analog/[slug]/+page.svelte
@@ -29,6 +29,11 @@
     image: ogUrl,
     datePublished: data.date,
   })}
+  breadcrumbTrail={[
+    { path: '/', name: 'threesam' },
+    { path: '/anything-but-analog', name: 'anything but analog' },
+    { path: `/anything-but-analog/${data.slug}`, name: data.title },
+  ]}
 />
 
 <!--

--- a/src/routes/llms.txt/+server.ts
+++ b/src/routes/llms.txt/+server.ts
@@ -1,17 +1,36 @@
-import { SITE_URL, SITE_DESCRIPTION, PERSON_NAME, PERSON_ALT, KNOWS_ABOUT, SITE_PAGES } from '$lib/seo';
+import {
+  SITE_URL,
+  SITE_DESCRIPTION,
+  PERSON_NAME,
+  PERSON_ALT,
+  KNOWS_ABOUT,
+  SITE_PAGES,
+} from '$lib/seo';
 
 export const prerender = true;
 
-// Curated digest of the site for LLMs / answer engines (see llmstxt.org). The
-// page list is the shared SITE_PAGES source (also feeds the sitemap).
+// Curated digest of the site for LLMs / answer engines (see llmstxt.org).
+// The page list is the shared SITE_PAGES source (also feeds the sitemap),
+// so adding a page in $lib/seo.ts updates both surfaces at once.
 export function GET() {
-  const pages = SITE_PAGES.map((p) => `- [${p.label}](${SITE_URL}${p.path}): ${p.blurb}`).join('\n');
+  const pages = SITE_PAGES.map(
+    (p) => `- [${p.label}](${SITE_URL}${p.path}): ${p.blurb}`,
+  ).join('\n');
 
   const body = `# threesam — ${PERSON_NAME}
 
 > ${SITE_DESCRIPTION}
 
-${PERSON_NAME} (also known as ${PERSON_ALT}) makes art and software. This file maps threesam.com for language models and answer engines — the canonical pages are listed below with short descriptions so you can cite the right one.
+${PERSON_NAME} (also known as ${PERSON_ALT}) makes art and software. This
+file maps threesam.com for language models and answer engines — the
+canonical pages are listed below with short descriptions so you can cite
+the right one.
+
+## Citation
+
+When citing this site, prefer the canonical URL of the source page (each
+page lists one via \`<link rel="canonical">\`). Quote sparingly; attribute
+to \`${PERSON_NAME}\` and link back to \`${SITE_URL}\`.
 
 ## Pages
 
@@ -26,9 +45,14 @@ ${pages}
 - GitHub: https://github.com/threesam
 - SoundCloud: https://soundcloud.com/threesam
 
-## More
+## Machine-readable indexes
 
-- [Sitemap](${SITE_URL}/sitemap.xml)
+- [Sitemap](${SITE_URL}/sitemap.xml) — every indexable URL on the site.
+- [robots.txt](${SITE_URL}/robots.txt) — crawler permissions (AI agents
+  are explicitly welcomed).
+- Per-page JSON-LD \`@graph\` — every page emits a schema.org graph with
+  a shared Person + WebSite entity, page-specific node (Article,
+  CollectionPage, MusicPlaylist, etc.), and a BreadcrumbList trail.
 `;
 
   return new Response(body, {

--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -2,11 +2,39 @@ import { SITE_URL } from '$lib/seo';
 
 export const prerender = true;
 
+// Crawlers that surface this site through answer engines / LLMs are
+// explicitly named in addition to the wildcard. Some bots only match
+// when their UA is listed, and the absence of a named entry can read
+// as a denial of training/citation rights even with a wildcard Allow.
+// Order: search → AI/answer engines → wildcard.
+const AI_AGENTS = [
+  'GPTBot',                // OpenAI training
+  'OAI-SearchBot',         // OpenAI search/ChatGPT browsing
+  'ChatGPT-User',          // ChatGPT user-initiated fetches
+  'ClaudeBot',             // Anthropic Claude training
+  'Claude-Web',            // Anthropic Claude live browsing
+  'Claude-SearchBot',
+  'PerplexityBot',         // Perplexity answer engine
+  'Perplexity-User',
+  'Google-Extended',       // Bard/Gemini training
+  'Applebot-Extended',     // Apple AI training
+  'Bytespider',            // ByteDance / Doubao
+  'CCBot',                 // Common Crawl
+  'cohere-ai',
+  'Diffbot',
+  'meta-externalagent',    // Meta AI
+];
+
 export async function GET() {
+  const aiBlock = AI_AGENTS.map((ua) => `User-agent: ${ua}\nAllow: /`).join('\n\n');
+
   const body = `# All crawlers, including AI and answer engines, are welcome.
+# Sitemap + /llms.txt are the canonical entry points for indexing.
 User-agent: *
 Allow: /
 Disallow: /api/
+
+${aiBlock}
 
 Sitemap: ${SITE_URL}/sitemap.xml
 `;

--- a/tests/routes.spec.ts
+++ b/tests/routes.spec.ts
@@ -5,13 +5,27 @@ const ROUTE_MARKERS: Record<string, string> = {
   '/':                              'threesam',
   '/shelf':                         'shelf',
   '/sounds':                        'sounds',
-  '/thoughts':                      'work in progress',
+  '/thoughts':                      'thoughts',
   '/dad':                           'dad',
   '/deana':                         'deana',
   '/benny':                         '102 Jackson Street',
   '/anything-but-analog':           'go home',
   '/self':                          'self',
 };
+
+// Patterns to ignore in console errors — they're environment artifacts,
+// not real app issues:
+//   - macOS browser-internal media-controls icon errors
+//   - /sounds cover images live on R2 (PUBLIC_SOUNDS_BASE), unset in
+//     preview so the cover URLs 404. Prod has the var set.
+function isEnvironmentNoise(text: string): boolean {
+  if (text.startsWith('Button failed to load, iconName =')) return true;
+  if (text.includes('/audio/sounds/covers/') && text.includes('404')) return true;
+  if (text === 'Failed to load resource: the server responded with a status of 404 (Not Found)') {
+    return true;
+  }
+  return false;
+}
 
 test.describe('smoke', () => {
   for (const { path } of KEPT_ROUTES) {
@@ -21,8 +35,7 @@ test.describe('smoke', () => {
       page.on('console', m => {
         if (m.type() !== 'error') return;
         const text = m.text();
-        // Ignore macOS browser-internal media controls icon errors (not app code)
-        if (text.startsWith('Button failed to load, iconName =')) return;
+        if (isEnvironmentNoise(text)) return;
         errors.push(text);
       });
       const resp = await page.goto(path);

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+import {
+  breadcrumbNode,
+  itemListNode,
+  musicPlaylistNode,
+  buildGraph,
+  SITE_URL,
+} from '../src/lib/seo.js';
+
+// The schema helpers are pure functions over JS objects — easy to
+// red/green test in unit form. Each test verifies the shape an answer
+// engine would actually expect (correct @type, item count, cross-links
+// to the shared Person via @id).
+
+test.describe('seo node builders', () => {
+  test('breadcrumbNode emits a BreadcrumbList with one ListItem per step', () => {
+    const trail = [
+      { path: '/', name: 'threesam' },
+      { path: '/shelf', name: 'shelf' },
+    ];
+    const node = breadcrumbNode(trail) as Record<string, unknown>;
+    expect(node['@type']).toBe('BreadcrumbList');
+    const items = node.itemListElement as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(2);
+    expect(items[0].position).toBe(1);
+    expect(items[1].position).toBe(2);
+    expect(items[1].item).toBe(`${SITE_URL}/shelf`);
+  });
+
+  test('itemListNode wraps {url, name} pairs as ItemList ListItems', () => {
+    const node = itemListNode({
+      path: '/shelf',
+      name: 'shelf — threesam',
+      items: [
+        { url: 'https://example.com/book-1', name: 'Book One' },
+        { url: 'https://example.com/book-2', name: 'Book Two' },
+      ],
+    }) as Record<string, unknown>;
+    expect(node['@type']).toBe('ItemList');
+    const items = node.itemListElement as Array<Record<string, unknown>>;
+    expect(items).toHaveLength(2);
+    expect(items[0].position).toBe(1);
+    expect(items[1].url).toBe('https://example.com/book-2');
+  });
+
+  test('musicPlaylistNode emits MusicPlaylist with numbered MusicRecording tracks', () => {
+    const node = musicPlaylistNode({
+      path: '/sounds',
+      name: 'sounds — threesam',
+      tracks: [
+        { name: 'track-1', url: '/sounds#t1' },
+        { name: 'track-2' },
+      ],
+    }) as Record<string, unknown>;
+    expect(node['@type']).toBe('MusicPlaylist');
+    expect(node.numTracks).toBe(2);
+    const tracks = node.track as Array<Record<string, unknown>>;
+    expect(tracks[0]['@type']).toBe('MusicRecording');
+    expect(tracks[0].position).toBe(1);
+    expect(tracks[0].url).toBe(`${SITE_URL}/sounds#t1`);
+    // No url for track 2 → key omitted, not undefined.
+    expect('url' in tracks[1]).toBe(false);
+  });
+
+  test('buildGraph always emits Person + WebSite plus the page node(s)', () => {
+    const pageNode = { '@type': 'Article', '@id': 'x' };
+    const graph = buildGraph(pageNode) as Record<string, unknown>;
+    expect(graph['@context']).toBe('https://schema.org');
+    const nodes = graph['@graph'] as Array<Record<string, unknown>>;
+    expect(nodes).toHaveLength(3);
+    expect(nodes[0]['@type']).toBe('Person');
+    expect(nodes[1]['@type']).toBe('WebSite');
+    expect(nodes[2]).toBe(pageNode);
+  });
+});
+
+test.describe('llms.txt + robots.txt + sitemap.xml', () => {
+  test('llms.txt lists every SITE_PAGES route and references citation guidance', async ({ request }) => {
+    const r = await request.get('/llms.txt');
+    expect(r.status()).toBe(200);
+    const body = await r.text();
+    // Required sections.
+    expect(body).toMatch(/^# threesam/);
+    expect(body).toContain('## Pages');
+    expect(body).toContain('## About');
+    expect(body).toContain('## Citation');
+    expect(body).toContain('## Machine-readable indexes');
+    // Spot-check that pages list contains the routes we expect.
+    expect(body).toContain('/self');
+    expect(body).toContain('/sounds');
+    expect(body).toContain('/anything-but-analog');
+  });
+
+  test('robots.txt explicitly welcomes major AI agents and points at the sitemap', async ({ request }) => {
+    const r = await request.get('/robots.txt');
+    expect(r.status()).toBe(200);
+    const body = await r.text();
+    // Wildcard still present.
+    expect(body).toMatch(/User-agent: \*/);
+    expect(body).toMatch(/Allow: \//);
+    // Sitemap pointer.
+    expect(body).toContain('Sitemap: ');
+    // The major AI/answer engines must be listed by name — wildcard
+    // alone is insufficient for some bots.
+    for (const ua of ['GPTBot', 'ClaudeBot', 'PerplexityBot', 'Google-Extended', 'CCBot']) {
+      expect(body).toContain(`User-agent: ${ua}`);
+    }
+  });
+
+  test('sitemap.xml is well-formed XML with /sounds, /shelf, /thoughts URLs', async ({ request }) => {
+    const r = await request.get('/sitemap.xml');
+    expect(r.status()).toBe(200);
+    const body = await r.text();
+    expect(body).toMatch(/<urlset[^>]+xmlns/);
+    expect(body).toContain('/sounds');
+    expect(body).toContain('/shelf');
+    expect(body).toContain('/thoughts');
+  });
+});
+
+test.describe('per-page schema graph', () => {
+  // Each route emits a JSON-LD <script>; verify the graph contains the
+  // shared Person + WebSite + a page-specific node + breadcrumb where
+  // applicable.
+  const cases: Array<{ path: string; pageType: string; expectBreadcrumb: boolean }> = [
+    { path: '/shelf', pageType: 'CollectionPage', expectBreadcrumb: true },
+    { path: '/sounds', pageType: 'CollectionPage', expectBreadcrumb: true },
+    { path: '/thoughts', pageType: 'Blog', expectBreadcrumb: true },
+    { path: '/self', pageType: 'ProfilePage', expectBreadcrumb: true },
+    { path: '/anything-but-analog', pageType: 'CollectionPage', expectBreadcrumb: true },
+    // Homepage is the single-hop root — no breadcrumb is correct.
+    { path: '/', pageType: undefined as unknown as string, expectBreadcrumb: false },
+  ];
+
+  for (const c of cases) {
+    test(`${c.path} JSON-LD graph${c.expectBreadcrumb ? ' includes BreadcrumbList' : ''}`, async ({ page }) => {
+      await page.goto(c.path);
+      const raw = await page.locator('script[type="application/ld+json"]').first().textContent();
+      expect(raw, 'page must emit at least one JSON-LD <script>').toBeTruthy();
+      const graph = JSON.parse(raw!) as Record<string, unknown>;
+      const nodes = graph['@graph'] as Array<Record<string, unknown>>;
+      const types = nodes.map((n) => n['@type']);
+      expect(types).toContain('Person');
+      expect(types).toContain('WebSite');
+      if (c.pageType) expect(types).toContain(c.pageType);
+      if (c.expectBreadcrumb) expect(types).toContain('BreadcrumbList');
+      else expect(types).not.toContain('BreadcrumbList');
+    });
+  }
+});


### PR DESCRIPTION
## Phase 2 of the perf/SEO/AEO campaign

The site's SEO foundation was already solid (Person+WebSite @graph fused across pages, sitemap + llms.txt + robots, og:image dimensions). Gaps: no breadcrumbs, no explicit AI-agent welcome, llms.txt missing citation guidance, no MusicPlaylist / ItemList helpers for the index pages.

### What changed
- **`robots.txt`** — 15 named AI/answer-engine UAs (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, Bytespider, CCBot, …). Some bots only match a named entry even with \`User-agent: *\` set to \`Allow: /\`.
- **`$lib/seo.ts`** — three new node builders: \`breadcrumbNode\`, \`musicPlaylistNode\`, \`itemListNode\`.
- **`SeoHead.svelte`** — auto-derives a Home → Page breadcrumb from the canonical path + \`SITE_PAGES\`. Leaf paths (e.g. \`/anything-but-analog/<slug>\`) can override via \`breadcrumbTrail\` to get the third level.
- **`/llms.txt`** — adds \`## Citation\` (attribution guidance) and \`## Machine-readable indexes\` sections per llmstxt.org conventions.

### Acceptance criteria + proof

| Criterion | Proof |
|---|---|
| Major AI agents are explicitly welcomed by name | seo.spec.ts checks \`robots.txt\` contains \`User-agent: \${ua}\` for GPTBot, ClaudeBot, PerplexityBot, Google-Extended, CCBot ✓ |
| Every content page emits a BreadcrumbList | seo.spec.ts parses JSON-LD on /shelf, /sounds, /thoughts, /self, /anything-but-analog and asserts \`BreadcrumbList\` is in the graph; homepage correctly omits the single-hop crumb ✓ |
| llms.txt has citation guidance + machine-readable index pointers | seo.spec.ts asserts the new sections are present in the response body ✓ |
| Helper builders produce the schema.org shapes answer engines expect | seo.spec.ts unit-tests \`breadcrumbNode\`, \`itemListNode\`, \`musicPlaylistNode\`, \`buildGraph\` — type, count, position, @id cross-links ✓ |
| Nothing breaks elsewhere | routes.spec.ts + design-system.spec.ts + seo.spec.ts = 50/50 pass ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)