### PR TITLE
feat: coin-bg eye-ocean + matching SVG favicon

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%sveltekit.assets%/favicon.ico" />
+    <!-- SVG favicon scales for any tab/bookmark size; .ico stays as a fallback
+         for older browsers that don't support SVG favicons yet. -->
+    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg" />
+    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>

--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -159,7 +159,8 @@
         nextBlink = now + 1000;
       }
 
-      ctx.fillStyle = "#000";
+      // Backdrop in --coin (#e8a317) — eyes are cream blobs floating on gold.
+      ctx.fillStyle = "#e8a317";
       ctx.fillRect(0, 0, w, h);
 
       // Desired aim + engage strength this frame: the fixed backdrop follows the

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="threesam">
+  <!-- One eye from the EyeOcean (see /sounds): cream sclera on a --coin field with a --black pupil. -->
+  <rect width="64" height="64" fill="#e8a317"/>
+  <ellipse cx="32" cy="32" rx="24" ry="20" fill="#fffac8"/>
+  <circle cx="32" cy="32" r="9" fill="#1a1a14"/>
+</svg>


### PR DESCRIPTION
## Summary
- **/sounds EyeOcean** backdrop fills with \`--coin\` (#e8a317) instead of \`#000\`. Cream eyes float as glowing blobs on the gold field; black pupils still carry the contrast. Fixed scrims at top + bottom keep their black-to-transparent fades so the brand title and transport stay legible.
- **Favicon**: new \`static/favicon.svg\` — one cream-on-coin eye with a \`--black\` pupil, evoking a single EyeOcean cell. Registered as \`type="image/svg+xml"\` in \`app.html\` with the existing \`.ico\` as a fallback for browsers that don't yet support SVG favicons.

## Test plan
- [x] /sounds: eye-ocean fills with coin, eyes visible as cream blobs, scrims still fade at top + bottom
- [x] favicon: \`/favicon.svg\` renders the eye-on-coin design at all sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)