### PR TITLE
fix(sounds): bg crossfade duration 2s → 600ms

### DIFF
--- a/src/lib/sounds/EyeOcean.svelte
+++ b/src/lib/sounds/EyeOcean.svelte
@@ -56,10 +56,10 @@
 
     // Playing-state crossfade: a single 0..1 value lerps every per-frame
     // color (bg, eye sclera, pupil) between the cream/dark-eye idle look and
-    // the black/cream-eye playing look. Linear ramp at 1/120 per frame =
-    // ~2s at 60fps, matching the user-perceived "fade" duration.
+    // the black/cream-eye playing look. Linear ramp at 1/36 per frame =
+    // 600ms at 60fps, matching the CSS transitions on the brand + transport.
     let currentP = 0;
-    const PLAYING_RATE = 1 / 120;
+    const PLAYING_RATE = 1 / 36;
     // Idle palette: cream bg (--white), dark eye sclera (--black tint),
     // cream pupils. Playing palette: --black bg, cream sclera, dark pupils.
     // --white #f5f4f0, --black #1a1a14, cream sclera rgb(255,250,200).
@@ -183,7 +183,7 @@
         nextBlink = now + 1000;
       }
 
-      // Ramp the playing crossfade by ~1/120 per frame (~2s at 60fps).
+      // Ramp the playing crossfade by 1/36 per frame (~600ms at 60fps).
       const target = playing ? 1 : 0;
       if (target > currentP) currentP = Math.min(target, currentP + PLAYING_RATE);
       else if (target < currentP) currentP = Math.max(target, currentP - PLAYING_RATE);

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -354,7 +354,7 @@
   }
   /* title pinned top-left, inline with the nav coin. Color crossfades
      with the EyeOcean's cream<->black bg: dark text at idle, cream text
-     while playing — same 2s ramp as the bg lerp inside EyeOcean. */
+     while playing — same 600ms ramp as the bg lerp inside EyeOcean. */
   .brand {
     position: fixed;
     top: 1.25rem;
@@ -370,7 +370,7 @@
     text-transform: uppercase;
     letter-spacing: 0.35em;
     color: var(--black);
-    transition: color 2s linear;
+    transition: color 600ms linear;
   }
   .brand.playing {
     color: var(--white);
@@ -701,7 +701,7 @@
 
   /* fixed transport. Background + text colors crossfade with the bg —
      cream-tinted scrim + dark text at idle, black scrim + cream text
-     while playing. Same 2s ramp as the EyeOcean bg lerp. */
+     while playing. Same 600ms ramp as the EyeOcean bg lerp. */
   .transport {
     position: fixed;
     left: 0;
@@ -718,8 +718,8 @@
     color: var(--black);
     font-family: "Recursive Mono", ui-monospace, monospace;
     transition:
-      background 2s linear,
-      color 2s linear;
+      background 600ms linear,
+      color 600ms linear;
   }
   .transport.playing {
     background: rgba(0, 0, 0, 0.66);


### PR DESCRIPTION
## Summary
Shortens the EyeOcean playing crossfade + the brand/transport CSS transitions from 2s to 600ms so the swap snaps with playback rather than easing in slowly.

- \`EyeOcean.svelte\`: \`PLAYING_RATE\` 1/120 → 1/36 per frame (600ms @ 60fps).
- \`/sounds\` CSS: \`.brand\` color transition + \`.transport\` background/color transitions 2s → 600ms.

## Test plan
- [x] Idle → playing flips bg + eye + pupil + brand + transport in ~600ms in unison

🤖 Generated with [Claude Code](https://claude.com/claude-code)