### PR TITLE
chore(hp): reorder gallery — self, sounds, thoughts, deana, shelf, analog

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -14,11 +14,11 @@
 
 	const UNIQUE_ITEMS: { label: string; handle: ItemHandle; href: string }[] = [
 		{ label: 'self', handle: 'self', href: '/self' },
-		{ label: 'analog', handle: 'anything-but-analog', href: '/anything-but-analog' },
 		{ label: 'sounds', handle: 'sounds', href: '/sounds' },
-		{ label: 'shelf', handle: 'shelf', href: '/shelf' },
-		{ label: 'D-ANA', handle: 'deana', href: '/deana' },
 		{ label: 'thoughts', handle: 'thoughts', href: '/thoughts' },
+		{ label: 'D-ANA', handle: 'deana', href: '/deana' },
+		{ label: 'shelf', handle: 'shelf', href: '/shelf' },
+		{ label: 'analog', handle: 'anything-but-analog', href: '/anything-but-analog' },
 	];
 
 	const UNIQUE_COUNT = UNIQUE_ITEMS.length;


### PR DESCRIPTION
## Summary
Reorder the homepage gallery's \`UNIQUE_ITEMS\` to: \`self → sounds → thoughts → deana → shelf → analog\`.

## Test plan
- [x] / shows cards in new order

🤖 Generated with [Claude Code](https://claude.com/claude-code)