### PR TITLE
fix(hp gallery): drop border-2 for ring-inset to kill iOS edge leak

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -284,7 +284,7 @@
 				draggable="false"
 				data-sveltekit-preload-data="off"
 				onclick={(e) => handleClick(e, item)}
-				class="gallery-card group relative block h-full shrink-0 overflow-hidden rounded-2xl border-2 border-black transition-[border-color,transform] duration-700 hover:border-coin hover:[transform:rotate(-1.3deg)]"
+				class="gallery-card group relative block h-full shrink-0 overflow-hidden rounded-2xl ring-2 ring-inset ring-black transition-[box-shadow,transform] duration-700 hover:ring-coin hover:[transform:rotate(-1.3deg)]"
 				style="aspect-ratio: 4 / 5; background-color: {BG_MAP[item.handle as ItemHandle] ?? 'var(--black)'};"
 			>
 				{#if visible}


### PR DESCRIPTION
## Summary
On the homepage gallery cards the \`border-2 border-black\` was leaking ~1-2px past the rounded \`overflow-hidden\` clip on the bottom + right edges in mobile Safari — a known antialiasing quirk when a border meets a border-radius + overflow-hidden parent.

Swap the border for \`ring-2 ring-inset ring-black hover:ring-coin\`. \`ring\` is an inset box-shadow under the hood, which clips cleanly inside the rounded corner across browsers. The transition selector moves from \`[border-color,transform]\` to \`[box-shadow,transform]\` so the hover crossfade to coin stays smooth.

## Test plan
- [x] Homepage gallery: all four corners read as a clean rounded outline; no extra darkness on the bottom-right

🤖 Generated with [Claude Code](https://claude.com/claude-code)