### PR TITLE
chore: cream replaces residual pure-white literals

### DIFF
--- a/src/lib/components/canvas/actions/particle-text.ts
+++ b/src/lib/components/canvas/actions/particle-text.ts
@@ -440,7 +440,7 @@ export const particleText: Action<HTMLCanvasElement, ParticleTextParams> = (node
 
     if (!hideText) {
       const whiteColor =
-        getComputedStyle(container).getPropertyValue('--white').trim() || '#ffffff';
+        getComputedStyle(container).getPropertyValue('--white').trim() || '#f5f4f0';
 
       const stacked = w < 768;
 

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -432,7 +432,7 @@
     border-radius: 8px;
     overflow: hidden;
     background: var(--black);
-    border: 1px solid rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(245, 244, 240, 0.16);
     box-shadow: 0 8px 22px rgba(0, 0, 0, 0.55);
     transform: rotate(var(--rot));
     transform-origin: 50% 90%;
@@ -489,7 +489,7 @@
   .badge-demo {
     color: var(--white);
     background: rgba(0, 0, 0, 0.55);
-    border: 1px solid rgba(255, 255, 255, 0.4);
+    border: 1px solid rgba(245, 244, 240, 0.4);
   }
   .badge-score {
     color: var(--black);
@@ -594,7 +594,7 @@
   /* HMBM film score — heading, then the poster with the cue slider over its base */
   .hmbm {
     margin-top: 4.5rem;
-    border-top: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 1px solid rgba(245, 244, 240, 0.12);
     padding-top: 2rem;
     transition: opacity 0.45s ease;
   }
@@ -626,7 +626,7 @@
     border-radius: 10px;
     overflow: hidden;
     margin: 0.4rem 0 0;
-    border: 1px solid rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(245, 244, 240, 0.16);
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
     background: var(--black);
   }


### PR DESCRIPTION
## Summary
\`bg-white\`/\`text-white\`/etc. already resolve to \`--white\` (#f5f4f0) cream via \`@theme inline\`, but two pockets of pure-white literals were still lurking and would have leaked if anything bypassed the token system:

- \`particle-text.ts\`: the \`getPropertyValue('--white')\` lookup's fallback was \`'#ffffff'\` (pure white) → swap to \`'#f5f4f0'\` so a missing CSS var still lands on cream.
- \`sounds/+page.svelte\`: four \`rgba(255,255,255, X)\` borders (tile + transport hairlines) → \`rgba(245,244,240, X)\` cream-tinted. Visible on the black playing-state bg; previously read as a slightly chill blue-ish white against the rest of the warm palette.

## Test plan
- [x] \`grep -rE 'rgba?\\(\\s*255,\\s*255,\\s*255'\` against \`src/routes/sounds\` and \`src/lib/components/canvas\` returns nothing
- [x] Site still renders identically (cream-cream swap is sub-pixel-perceptible at most)

🤖 Generated with [Claude Code](https://claude.com/claude-code)