### PR TITLE
fix(hp gallery): border overlay above canvas; image area always cream

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -281,13 +281,13 @@
 				draggable="false"
 				data-sveltekit-preload-data="off"
 				onclick={(e) => handleClick(e, item)}
-				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl ring-2 ring-inset transition-[box-shadow,transform] duration-700 hover:ring-coin hover:[transform:rotate(-1.3deg)] {cream
-					? 'bg-white ring-black'
-					: 'bg-black ring-white'}"
+				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl transition-transform duration-700 hover:[transform:rotate(-1.3deg)]"
 				style="aspect-ratio: 4 / 5;"
 			>
-				<!-- image area: takes remaining space above the label -->
-				<div class="relative flex-1 overflow-hidden">
+				<!-- image area: takes remaining space above the label. Always cream so
+				     the canvas fades in over a matching backdrop (the deana particle
+				     bitmap and the EyeOcean idle bg are both cream). -->
+				<div class="relative flex-1 overflow-hidden bg-white">
 					{#if visible}
 						<div class="absolute inset-0">
 							{#await getCanvasModule(item.handle) then CanvasComp}
@@ -318,8 +318,8 @@
 				<div
 					data-card-label
 					class="shrink-0 px-3 py-3 text-center font-mono text-xl font-bold uppercase tracking-pill transition-colors duration-300 group-hover:text-coin lg:text-2xl {cream
-						? 'text-black'
-						: 'text-white'}"
+						? 'bg-white text-black'
+						: 'bg-black text-white'}"
 				>
 					{#if item.handle === 'deana'}
 						<DanaLabel />
@@ -327,6 +327,14 @@
 						{item.label}
 					{/if}
 				</div>
+				<!-- Border overlay: positioned above the canvas + label so the inset
+				     ring paints crisply on top instead of being covered by canvas
+				     pixels. Color alternates per card; coin on hover. -->
+				<div
+					class="pointer-events-none absolute inset-0 rounded-2xl ring-2 ring-inset transition-shadow duration-700 group-hover:ring-coin {cream
+						? 'ring-black'
+						: 'ring-white'}"
+				></div>
 			</a>
 		{/each}
 	</div>


### PR DESCRIPTION
## Summary
Two issues with the previous card structure:

1. **Border under the canvas** — \`ring-2 ring-inset\` on the card root painted as a box-shadow, which renders below child content. The canvas overlapped the inset shadow and effectively hid the border. Move the ring onto a \`pointer-events-none absolute inset-0\` overlay above the image + label so it paints crisply on top.

2. **Deana (and other cream canvases) invisible on dark cards** — the previous PR alternated the outer \`<a>\` bg between \`bg-white\` and \`bg-black\`. On the dark cards (sounds, deana, analog) the dark bg showed through any time the canvas hadn't yet mounted or wasn't currently \`isActive\`. Move the alternation onto the label only; set the image area to \`bg-white\` unconditionally so every sketch composites over a matching cream backdrop.

### Net layout per card
- image area: \`bg-white\`, \`flex-1\`
- label area: \`shrink-0\`, alternating bg/text
- border overlay: \`absolute inset-0\`, alternating ring color, \`group-hover:ring-coin\`

## Test plan
- [x] All six cards' canvases visible at all scroll positions (incl. edge/half-clipped cards)
- [x] Black/cream ring overlay visible above each canvas; coin on hover
- [x] Alternation still self/sounds/thoughts/deana/shelf/analog → cream/dark/cream/dark/cream/dark labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)