### PR TITLE
fix(hp gallery): gray bg + black spiky walkers for thoughts preview

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -318,7 +318,14 @@
 								{:else if item.handle === 'anything-but-analog'}
 									<CanvasComp countOverride={4000} hideText pointSize={2} repelRadius={50} lowDpr />
 								{:else if item.handle === 'thoughts'}
-									<CanvasComp slug="30" active interactive={false} />
+									<!-- Invert + dim + boost contrast so the day30 walkers
+									     read as bold black spikes on a gray field instead of
+									     thin white spikes on true black. -->
+									<div
+										class="absolute inset-0 [filter:invert(1)_brightness(0.65)_contrast(1.6)]"
+									>
+										<CanvasComp slug="30" active interactive={false} />
+									</div>
 								{:else if item.handle === 'sounds'}
 									<CanvasComp fixed={false} />
 								{/if}


### PR DESCRIPTION
## Summary
The day30 preview on the homepage gallery was painting white walkers on #000 — should read as the "gray with black spiky thing" the user described. Wrap the \`CanvasComp\` in a div with \`filter: invert(1) brightness(0.65) contrast(1.6)\` so:
- the #000 backdrop lands on a middle-gray after invert+dim,
- the light-gray walkers land on bold black after invert+contrast.

Scoped to the gallery card only — \`/thoughts\` itself is untouched.

## Test plan
- [x] HP gallery THOUGHTS card: gray field with black spiky walkers
- [x] /thoughts route bg unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)