### PR TITLE
fix(hp gallery): swap border palette — even=cream, odd=black

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -334,13 +334,13 @@
 				</div>
 				<!-- Border overlay: positioned above the canvas + label so the
 				     inset ring paints crisply on top instead of being covered by
-				     canvas pixels. Color contrasts the label palette — odd
-				     (dark-label) cards get a cream ring, even (cream-label) cards
-				     get a dark ring. Coin on hover. -->
+				     canvas pixels. Even (cream-label) cards get a cream ring,
+				     odd (dark-label) cards get a dark ring — matches the band
+				     so each card reads as a single tone. Coin on hover. -->
 				<div
 					class="pointer-events-none absolute inset-0 rounded-2xl ring-2 ring-inset transition-shadow duration-700 group-hover:ring-coin {cream
-						? 'ring-black'
-						: 'ring-white'}"
+						? 'ring-white'
+						: 'ring-black'}"
 				></div>
 			</a>
 		{/each}


### PR DESCRIPTION
## Summary
Flip the border palette per the user's latest spec — even-index (cream-label) cards now get a cream ring; odd-index (dark-label) cards get a black ring. Border matches the label band so each card reads as a single tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)