### PR TITLE
fix(sounds): cap edge-scrim height at nav height on desktop

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -727,6 +727,14 @@
     bottom: 0;
     height: 12rem;
   }
+  /* Desktop: cap the fades at nav height — the long gradient tails
+     read as too heavy at wider viewports. */
+  @media (min-width: 768px) {
+    .scrim-top,
+    .scrim-bottom {
+      height: 2.5rem;
+    }
+  }
   .scrim-cream.scrim-top {
     background: linear-gradient(to bottom, var(--white) 2.5rem, transparent);
     opacity: 1;


### PR DESCRIPTION
## Summary
The top/bottom edge scrims on /sounds were 7rem and 12rem tall — their gradient tails read as way too heavy at desktop widths. Add a \`@media (min-width: 768px)\` clamp to 2.5rem (nav height) for both edges. Mobile keeps its original heights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)