### PR TITLE
fix(voronoi): edge fade → pure-black multiply

### DIFF
--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -229,12 +229,15 @@ const FRAGMENT_SHADER = `
     float edgeLine = (1.0 - smoothstep(0.05 - strokeW, 0.05 + strokeW, strokeD)) * (1.0 - focus);
     base = mix(base, vec3(0.0), edgeLine);
 
+    // Multiply down to pure black at the canvas edges instead of mixing
+    // toward the theme bg — cards no longer need a separate vignette /
+    // fade overlay; the voronoi itself darkens into the surrounding
+    // dark frame.
     float edgeFade = smoothstep(0.0, 0.08, uv.x)
                    * smoothstep(0.0, 0.08, 1.0 - uv.x)
                    * smoothstep(0.0, 0.08, uv.y)
                    * smoothstep(0.0, 0.08, 1.0 - uv.y);
-    vec3 bg = uInvert > 0.5 ? uTopColor : uBotColor;
-    base = mix(bg, base, edgeFade);
+    base *= edgeFade;
 
     gl_FragColor = vec4(base, 1.0);
   }


### PR DESCRIPTION
## Summary
The shader was mixing cells toward the theme bg (\`--black\` / \`--white\`) in the outer 8% of the canvas — a soft vignette around every voronoi instance. The card design no longer wants the soft tone; switch from \`mix(bg, base, edgeFade)\` to \`base *= edgeFade\` so cells multiply down to **pure black** at the edges. The voronoi becomes its own dark frame and no external fade overlay is needed.

## Test plan
- [x] HP gallery SELF card: edges fade to true black; voronoi mosaic in the middle
- [x] /self hero: same
- [x] AnythingButAnalogBanner and the in-essay banner voronoi instances: edges go dark too (consistent across all VoronoiCanvas instances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)