### PR TITLE
fix(voronoi): edge blend lands on --black (#1a1a14) instead of pure black

### DIFF
--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -229,15 +229,15 @@ const FRAGMENT_SHADER = `
     float edgeLine = (1.0 - smoothstep(0.05 - strokeW, 0.05 + strokeW, strokeD)) * (1.0 - focus);
     base = mix(base, vec3(0.0), edgeLine);
 
-    // Multiply down to pure black at the canvas edges instead of mixing
-    // toward the theme bg — cards no longer need a separate vignette /
-    // fade overlay; the voronoi itself darkens into the surrounding
-    // dark frame.
+    // Blend toward --black (#1a1a14) at the canvas edges so the voronoi
+    // is its own dark frame — no external fade overlay needed, and the
+    // warm brand dark matches the rest of the palette (pure black
+    // looked too chill against the coin/cream surroundings).
     float edgeFade = smoothstep(0.0, 0.08, uv.x)
                    * smoothstep(0.0, 0.08, 1.0 - uv.x)
                    * smoothstep(0.0, 0.08, uv.y)
                    * smoothstep(0.0, 0.08, 1.0 - uv.y);
-    base *= edgeFade;
+    base = mix(vec3(0.1020, 0.1020, 0.0784), base, edgeFade);
 
     gl_FragColor = vec4(base, 1.0);
   }


### PR DESCRIPTION
## Summary
Pure-black multiply (PR #118) read as too chill against the warm coin/cream palette. Switch back to a \`mix()\` but target \`#1a1a14\` (\`--black\` token) directly instead of \`uTopColor\`/\`uBotColor\`. Cells still darken into a frame at the edges, just in the warm brand dark — no external fade overlay needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)