### PR TITLE
fix(day31): tune colors closer to the reference image

### DIFF
--- a/src/lib/art/sketches/day31.ts
+++ b/src/lib/art/sketches/day31.ts
@@ -29,10 +29,10 @@ export const day31: Sketch = {
         for (let z = start; z < end; z += space) {
           const d = Math.hypot(x, y, z);
           if (d <= 0) continue;
-          // Dark bursts on a light field: 0 (black) at the center,
-          // ramping to ~150 (medium gray) at the edge so the spikes
-          // fade into the bg rather than ending in a hard line.
-          const color = map(d, 0, end, 0, 150);
+          // Dark bursts on a light field. Solid near-black across the
+          // depth range; the visual gradient at the edges comes from
+          // line density (sparse spikes) rather than lighter strokes.
+          const color = map(d, 0, end, 0, 30);
           const size = map(rng(), 0, 1, 0, space);
           flowers.push({
             x: x + map(rng(), 0, 1, -10, 10),
@@ -58,9 +58,9 @@ export const day31: Sketch = {
       }))
       .sort((a, b) => a.z - b.z);
 
-    // Light gray backdrop — the dark spiky bursts read against a
-    // neutral field instead of the dark theme bg.
-    ctx.fillStyle = "rgb(200,200,198)";
+    // Neutral mid-gray backdrop sampled from the reference — light
+    // enough to keep the black spikes legible.
+    ctx.fillStyle = "rgb(192,192,192)";
     ctx.fillRect(0, 0, w, h);
     ctx.save();
     ctx.translate(w / 2, h / 2);


### PR DESCRIPTION
## Summary
Refine day31's palette to match the reference image more faithfully:
- **Strokes**: ramp \`0 → 30\` (instead of \`0 → 150\`) so spikes stay near-black at every depth. The lighter look at the edges in the reference comes from line density (fewer spikes radiating outward), not lighter strokes.
- **Bg**: \`rgb(192,192,192)\` — a neutral mid-gray sampled from the reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)