### PR TITLE
fix: voronoi edges transparent + ABA fades use --black token

### DIFF
--- a/src/lib/components/art/ArtGallery.svelte
+++ b/src/lib/components/art/ArtGallery.svelte
@@ -69,12 +69,12 @@
 		class="relative h-dvh w-full snap-start overflow-hidden"
 		style="content-visibility: auto; contain-intrinsic-size: 100dvh;"
 	>
-		<SketchHost slug={s.slug} {active} bgClass="bg-[#000]" />
+		<SketchHost slug={s.slug} {active} bgClass="bg-black" />
 		<!-- True-black overlay over each sketch: fades both ways (transition:fade)
 		     so scrolling back and forth smoothly reveals / hides the sketch. -->
 		{#if !active}
 			<div
-				class="pointer-events-none absolute inset-0 z-[5] bg-[#000]"
+				class="pointer-events-none absolute inset-0 z-[5] bg-black"
 				transition:fade={{ duration: 1000 }}
 			></div>
 		{/if}

--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -229,17 +229,17 @@ const FRAGMENT_SHADER = `
     float edgeLine = (1.0 - smoothstep(0.05 - strokeW, 0.05 + strokeW, strokeD)) * (1.0 - focus);
     base = mix(base, vec3(0.0), edgeLine);
 
-    // Blend toward --black (#1a1a14) at the canvas edges so the voronoi
-    // is its own dark frame — no external fade overlay needed, and the
-    // warm brand dark matches the rest of the palette (pure black
-    // looked too chill against the coin/cream surroundings).
+    // Edges fade to transparent so whatever's behind the canvas (page
+    // bg, card bg, etc.) shows through — voronoi instances pick up
+    // their surroundings instead of imposing a fixed dark frame.
+    // Premultiplied alpha output: rgb already multiplied by alpha so
+    // the canvas composites correctly under premultipliedAlpha:true.
     float edgeFade = smoothstep(0.0, 0.08, uv.x)
                    * smoothstep(0.0, 0.08, 1.0 - uv.x)
                    * smoothstep(0.0, 0.08, uv.y)
                    * smoothstep(0.0, 0.08, 1.0 - uv.y);
-    base = mix(vec3(0.1020, 0.1020, 0.0784), base, edgeFade);
 
-    gl_FragColor = vec4(base, 1.0);
+    gl_FragColor = vec4(base * edgeFade, edgeFade);
   }
 `;
 
@@ -268,7 +268,10 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
   const activeImageSrc =
     mobileImageSrc && window.innerWidth < MOBILE_BREAK ? mobileImageSrc : imageSrc;
 
-  const glRaw = node.getContext('webgl', { antialias: false, alpha: false });
+  // alpha: true so the shader's edge fade renders as transparency and
+  // the underlying DOM bg shows through (instead of compositing onto
+  // an opaque canvas backdrop).
+  const glRaw = node.getContext('webgl', { antialias: false, alpha: true, premultipliedAlpha: true });
   if (!glRaw) return {};
   // Narrowed alias so closures (resize, render) don't see the nullable type.
   const gl: WebGLRenderingContext = glRaw;

--- a/src/routes/anything-but-analog/+page.svelte
+++ b/src/routes/anything-but-analog/+page.svelte
@@ -26,7 +26,7 @@
 
 <main
   id="art-scroller"
-  class="h-dvh snap-y snap-mandatory overflow-y-scroll bg-[#000]"
+  class="h-dvh snap-y snap-mandatory overflow-y-scroll bg-black"
 >
   <ArtScrollSync />
   <section


### PR DESCRIPTION
## Summary
- **Voronoi shader** — edges fade to *alpha* instead of mixing toward a hard-coded color. Outer 8% of every voronoi instance becomes transparent so the underlying card/page bg shows through. WebGL context promoted to \`alpha: true\` + \`premultipliedAlpha: true\` and the shader output is now \`vec4(base * edgeFade, edgeFade)\` so the canvas composites correctly.
- **ABA scroll tour + /anything-but-analog bg** — \`bg-[#000]\` → \`bg-black\` (three spots). \`bg-black\` resolves to \`--black\` (#1a1a14) via \`@theme inline\`, matching the rest of the dark palette.

## Test plan
- [x] HP gallery SELF voronoi: edges fade transparently, cream image area shows through
- [x] /self hero: edges transparent over the page bg
- [x] AnythingButAnalogBanner + in-essay banner voronoi instances: same
- [x] /anything-but-analog scroll tour: sketch fade-out overlay lands on \`--black\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)