### PR TITLE
fix(voronoi): --black backdrop behind every VoronoiCanvas instance

### DIFF
--- a/src/lib/components/canvas/VoronoiCanvas.svelte
+++ b/src/lib/components/canvas/VoronoiCanvas.svelte
@@ -25,4 +25,10 @@
   });
 </script>
 
-<canvas class="absolute inset-0 h-full w-full" use:voronoi={params}></canvas>
+<!-- `bg-black` (--black) sits behind the canvas so any uncovered area
+     during mount/load shows the warm brand dark instead of whatever
+     the container happens to be — voronoi instances always read as
+     "on dark". -->
+<div class="absolute inset-0 bg-black">
+  <canvas class="absolute inset-0 h-full w-full" use:voronoi={params}></canvas>
+</div>


### PR DESCRIPTION
## Summary
Wrap the \`<canvas>\` in a \`bg-black\` div inside \`VoronoiCanvas.svelte\` so a warm-brand-dark backdrop sits behind every voronoi instance (HP gallery SELF card, /self hero, \`AnythingButAnalogBanner\`, the in-essay banner instances). Any pixels not yet rendered by the WebGL pipeline now show \`--black\` instead of whatever the parent container's bg happens to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)