### PR TITLE
fix(voronoi): add object-cover to canvas element

### DIFF
--- a/src/lib/components/canvas/VoronoiCanvas.svelte
+++ b/src/lib/components/canvas/VoronoiCanvas.svelte
@@ -28,7 +28,8 @@
 <!-- `bg-black` (--black) sits behind the canvas so any uncovered area
      during mount/load shows the warm brand dark instead of whatever
      the container happens to be — voronoi instances always read as
-     "on dark". -->
+     "on dark". `object-cover` lets the canvas crop-fill the container
+     when the pixel buffer aspect ratio doesn't match. -->
 <div class="absolute inset-0 bg-black">
-  <canvas class="absolute inset-0 h-full w-full" use:voronoi={params}></canvas>
+  <canvas class="absolute inset-0 h-full w-full object-cover" use:voronoi={params}></canvas>
 </div>


### PR DESCRIPTION
## Summary
Add \`object-cover\` to the \`<canvas>\` inside \`VoronoiCanvas.svelte\`. Lets the canvas crop-fill its container when the pixel-buffer aspect doesn't match the display box's, so cells stay proportional instead of stretching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)