### PR TITLE
fix(voronoi): restore tight edge fade to --black wrapper

### DIFF
--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -232,7 +232,11 @@ const FRAGMENT_SHADER = `
     // Grayscale (luminance) output — voronoi reads as black-and-white
     // mosaic regardless of the source image's color palette.
     float gray = dot(base, vec3(0.2126, 0.7152, 0.0722));
-    gl_FragColor = vec4(vec3(gray), 1.0);
+    // Tight edge fade to the --black wrapper: fully on within ~4% of the
+    // canvas, so the body is clean and only the outermost rim softens.
+    vec2 distToEdge = min(vUv, 1.0 - vUv);
+    float edgeFade = smoothstep(0.0, 0.04, min(distToEdge.x, distToEdge.y));
+    gl_FragColor = vec4(vec3(gray * edgeFade), 1.0);
   }
 `;
 


### PR DESCRIPTION
## Summary
Re-introduces a tight edge fade on the voronoi shader. Smoothstep over the inner ~4% of the canvas darkens the rim to black, leaving the body crisp. Sits on top of the existing \`bg-black\` wrapper so the fade resolves into the brand dark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)