### PR TITLE
style(shelf): cream metaballs, regardless of cover

### DIFF
--- a/src/lib/components/ShelfHero.svelte
+++ b/src/lib/components/ShelfHero.svelte
@@ -5,8 +5,14 @@
 	import { proxyImg } from '$lib/img';
 	import type { Book } from '$lib/goodreads';
 
-	// --black #1a1a14 as normalized RGB
+	// --black #1a1a14 as normalized RGB — fallback for the dominant-color
+	// extraction that drives the shadow + repeating text pattern.
 	const BG_COLOR: [number, number, number] = [26 / 255, 26 / 255, 20 / 255];
+	// --white #f5f4f0 as normalized RGB. The metaballs always read cream
+	// against the black backdrop regardless of the book cover; only the
+	// shadow + pattern still pick up the per-book dominant color so each
+	// hero stays a touch personalised without the blobs going off-brand.
+	const CREAM: [number, number, number] = [245 / 255, 244 / 255, 240 / 255];
 
 	interface Props {
 		featured: Book | null;
@@ -97,7 +103,7 @@
 		class="pointer-events-none absolute inset-0 transition-opacity duration-1000 ease-out"
 		style="z-index: 2; opacity: {metaballsHidden ? 0 : 1};"
 	>
-		<MetaballCanvas {color} trackCursor={false} {target} />
+		<MetaballCanvas color={CREAM} trackCursor={false} {target} />
 	</div>
 
 	<h1 class="sr-only">what's on my shelf?</h1>


### PR DESCRIPTION
## Summary
The /shelf hero's metaballs previously inherited the featured book's dominant cover color, so they drifted across the palette. Lock the blob color to \`--white\` (cream) — blooming blobs now read consistently on the black backdrop.

Shadow + repeating text pattern still pick up the dominant color, so each book retains its tint on the trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)