### PR TITLE
fix(shelf): flip metaball palette — card cream, page dynamic

### DIFF
--- a/src/lib/components/ShelfHero.svelte
+++ b/src/lib/components/ShelfHero.svelte
@@ -5,14 +5,8 @@
 	import { proxyImg } from '$lib/img';
 	import type { Book } from '$lib/goodreads';
 
-	// --black #1a1a14 as normalized RGB — fallback for the dominant-color
-	// extraction that drives the shadow + repeating text pattern.
+	// --black #1a1a14 as normalized RGB
 	const BG_COLOR: [number, number, number] = [26 / 255, 26 / 255, 20 / 255];
-	// --white #f5f4f0 as normalized RGB. The metaballs always read cream
-	// against the black backdrop regardless of the book cover; only the
-	// shadow + pattern still pick up the per-book dominant color so each
-	// hero stays a touch personalised without the blobs going off-brand.
-	const CREAM: [number, number, number] = [245 / 255, 244 / 255, 240 / 255];
 
 	interface Props {
 		featured: Book | null;
@@ -103,7 +97,7 @@
 		class="pointer-events-none absolute inset-0 transition-opacity duration-1000 ease-out"
 		style="z-index: 2; opacity: {metaballsHidden ? 0 : 1};"
 	>
-		<MetaballCanvas color={CREAM} trackCursor={false} {target} />
+		<MetaballCanvas {color} trackCursor={false} {target} />
 	</div>
 
 	<h1 class="sr-only">what's on my shelf?</h1>

--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -312,7 +312,9 @@
 								{:else if item.handle === 'deana'}
 									<CanvasComp />
 								{:else if item.handle === 'shelf'}
-									<CanvasComp color={[0.91, 0.64, 0.09]} />
+									<!-- Cream (--white) blobs on the dark card background — read as
+									     bright glowing forms regardless of which book is featured. -->
+									<CanvasComp color={[245 / 255, 244 / 255, 240 / 255]} />
 								{:else if item.handle === 'anything-but-analog'}
 									<CanvasComp countOverride={4000} hideText pointSize={2} repelRadius={50} lowDpr />
 								{:else if item.handle === 'thoughts'}


### PR DESCRIPTION
## Summary
PR #135 had it backwards.

- **Gallery shelf card**: coin gold → cream (\`--white\`) blobs against the dark card. Always-glow, regardless of which book is featured.
- **/shelf hero**: cream → revert to \`{color}\` (dominant from the book cover, what it was before #135).

🤖 Generated with [Claude Code](https://claude.com/claude-code)