### PR TITLE
fix(day30): hover actually slows the bodies, not just tints them

### DIFF
--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -119,15 +119,16 @@ export const day30: Sketch = {
       }
     }
 
-    // Color mode: opt-in via `sketchMode.active`. The /thoughts route
-    // flips it on; the homepage gallery leaves it off so its day30 card
-    // keeps the original neutral grays.
+    // Color + speed mode: opt-in via `sketchMode.active`. The /thoughts
+    // route flips it on; the homepage gallery leaves it off so its day30
+    // card keeps the original neutral grays and full-speed walkers.
     //
     // When active, hover sets `sketchMode.slow` to 1 and we ramp
     // `currentSlow` linearly at 1/180 per frame (exactly 3s at 60fps —
     // the same timeline as the card back face's `duration-[3000ms]`).
-    // Walker color lerps coin → --white over the same 3s. Speed is
-    // unchanged in both modes; only the tint moves.
+    // Walker color lerps coin → --white over the same 3s AND their
+    // per-frame motion scales down to ~15% so the field settles instead
+    // of churning. Match: hover slows the bodies.
     let currentSlow = 0;
     let active = false;
     const SLOW_RATE = 1 / 180;
@@ -348,8 +349,14 @@ export const day30: Sketch = {
             }
           }
 
-          wk.x += Math.cos(moveAngle) * wk.speed + repelX * SEPARATION_GAIN + orbitX;
-          wk.y += Math.sin(moveAngle) * wk.speed + repelY * SEPARATION_GAIN + orbitY;
+          // currentSlow=0 → full speed; currentSlow=1 → ~15% speed. The
+          // ramp lives in the tick (3 s linear), so motion settles in
+          // lockstep with the card flip and the color shift. Cursor
+          // orbit (only on routes that pass interactive=true) is
+          // unaffected — it stays a deliberate, attention-grabbing pull.
+          const speedScale = 1 - currentSlow * 0.85;
+          wk.x += (Math.cos(moveAngle) * wk.speed + repelX * SEPARATION_GAIN) * speedScale + orbitX;
+          wk.y += (Math.sin(moveAngle) * wk.speed + repelY * SEPARATION_GAIN) * speedScale + orbitY;
 
           // Asteroids wrap. Exit right → enter left at same y. Exit top
           // → enter bottom at same x. And vice versa. Uses the extended


### PR DESCRIPTION
## Summary
\`sketchMode.slow\` was wired only into the color lerp (coin → cream over 3s) — walker motion was untouched. Hovering a /thoughts card brightened the walkers (which made them visually punch harder against the dark bg) but pixel velocity was identical, so it read as "speed up" instead of the intended slowdown.

Scale walker motion by \`(1 - currentSlow * 0.85)\` so currentSlow=0 keeps full speed and currentSlow=1 slows to ~15%. Same 3 s ramp; motion settles in lockstep with the card flip and color shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)