### PR TITLE
style(hp gallery): softer, more diffused card shadow

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -306,7 +306,7 @@
 				draggable="false"
 				data-sveltekit-preload-data="off"
 				onclick={(e) => handleClick(e, item)}
-				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-xl transition-[transform,box-shadow] duration-700 hover:shadow-sm hover:[transform:rotate(-1.3deg)]"
+				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-[0_30px_60px_-15px_rgba(0,0,0,0.18),0_8px_20px_-8px_rgba(0,0,0,0.08)] transition-[transform,box-shadow] duration-700 hover:shadow-[0_10px_24px_-12px_rgba(0,0,0,0.12)] hover:[transform:rotate(-1.3deg)]"
 				style="aspect-ratio: 4 / 5;"
 			>
 				<!-- image area: takes remaining space above the label. Cream by


### PR DESCRIPTION
## Summary
\`shadow-xl\` was reading as harsh and clean-edged on the gold homepage backdrop — its negative spread cuts a visible right-side stripe. Swap to a custom two-layer shadow:

- \`0 30px 60px -15px rgba(0,0,0,0.18)\` — long soft cast
- \`0 8px 20px -8px rgba(0,0,0,0.08)\` — close-in ambient cushion

Hover state keeps the inversion (smaller closer shadow = "lifted" feel), also custom for clean transition between states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)