### PR TITLE
style(deana): fade ASCII canvas in on first paint

### DIFF
--- a/src/lib/components/messages/AsciiImage.svelte
+++ b/src/lib/components/messages/AsciiImage.svelte
@@ -9,8 +9,21 @@
 	}
 
 	let { srcs, class: className = '', inverted = false }: Props = $props();
+
+	// Fade the canvas in from 0 -> 1 the moment the first frame actually
+	// paints. LazyMount can mount this several hundred ms before the image
+	// loads; without the fade the section sits blank and then snaps to ASCII.
+	let ready = $state(false);
+	const onReady = () => {
+		ready = true;
+	};
 </script>
 
 <div class={className}>
-	<canvas use:asciiImage={{ srcs, inverted }} style="display:block;width:100%;height:100%;"></canvas>
+	<canvas
+		use:asciiImage={{ srcs, inverted, onReady }}
+		style="display:block;width:100%;height:100%;opacity:{ready
+			? 1
+			: 0};transition:opacity 700ms ease-out;"
+	></canvas>
 </div>

--- a/src/lib/components/messages/actions/asciiImage.ts
+++ b/src/lib/components/messages/actions/asciiImage.ts
@@ -7,10 +7,15 @@ const CYCLE_MS = 3000;
 export interface AsciiImageConfig {
 	srcs: string[];
 	inverted?: boolean;
+	/** Fires exactly once, after the first frame is actually painted to the
+	 * canvas (not just on action mount). Consumers use this to fade the
+	 * canvas in from opacity 0 so the lazy-mount doesn't pop. */
+	onReady?: () => void;
 }
 
 export const asciiImage: Action<HTMLCanvasElement, AsciiImageConfig> = (canvas, config) => {
-	let { srcs, inverted = false } = config;
+	let { srcs, inverted = false, onReady } = config;
+	let firstFramePainted = false;
 
 	const container = canvas.parentElement as HTMLDivElement;
 	const sample = document.createElement('canvas');
@@ -103,6 +108,11 @@ export const asciiImage: Action<HTMLCanvasElement, AsciiImageConfig> = (canvas, 
 					: `rgba(20, 20, 20, ${alpha})`;
 				ctx.fillText(glyph, x * cellW, y * cellH);
 			}
+		}
+
+		if (!firstFramePainted) {
+			firstFramePainted = true;
+			onReady?.();
 		}
 	}
 


### PR DESCRIPTION
## Summary
LazyMount on /deana sections mounts \`AsciiImage\` as the section nears the viewport, but the actual image fetch + first render lands 200–800ms later. Section was sitting blank then snapping to ASCII — a jarring pop.

Threads an \`onReady\` callback through the \`asciiImage\` action; it fires exactly once after the first frame actually paints (not just on action mount, which is too early). \`AsciiImage.svelte\` uses it to flip a \`ready\` flag → CSS opacity 0 → 1 over 700ms ease-out.

Every consumer of \`AsciiImage\` benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)