### PR TITLE
style(hp gallery): card shadow-sm at rest, none on hover

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -306,7 +306,7 @@
 				draggable="false"
 				data-sveltekit-preload-data="off"
 				onclick={(e) => handleClick(e, item)}
-				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-[0_30px_60px_-15px_rgba(0,0,0,0.18),0_8px_20px_-8px_rgba(0,0,0,0.08)] transition-[transform,box-shadow] duration-700 hover:shadow-[0_10px_24px_-12px_rgba(0,0,0,0.12)] hover:[transform:rotate(-1.3deg)]"
+				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-sm transition-[transform,box-shadow] duration-700 hover:shadow-none hover:[transform:rotate(-1.3deg)]"
 				style="aspect-ratio: 20 / 29;"
 			>
 				<!-- image area: locked to 4:5 so canvases that bake at that


### PR DESCRIPTION
## Summary
Custom two-layer shadow read harsh (long elongated stripe under each card) on mobile. Switch to Tailwind \`shadow-sm\` at rest, \`shadow-none\` on hover — quieter, card "settles flat" when focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)