### PR TITLE
style(hp gallery): label bg goes coin on hover, matching ring

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -349,10 +349,13 @@
 						</div>
 					{/if}
 				</div>
-				<!-- label: below the image, full width, centered. Palette alternates per card. -->
+				<!-- label: below the image, full width, centered. Palette alternates
+				     per card. On hover the label bg matches the border ring
+				     (coin) so the card "lights up" as a single unit; text
+				     goes black so it stays legible on the gold. -->
 				<div
 					data-card-label
-					class="flex flex-1 items-center justify-center px-3 text-center font-mono text-xl font-bold uppercase tracking-pill lg:text-2xl {cream
+					class="flex flex-1 items-center justify-center px-3 text-center font-mono text-xl font-bold uppercase tracking-pill transition-colors duration-700 group-hover:bg-coin group-hover:text-black lg:text-2xl {cream
 						? 'bg-white text-black'
 						: 'bg-black text-white'}"
 				>


### PR DESCRIPTION
## Summary
On hover, card already gets a coin ring (border overlay). Push the label bg + text to match: \`bg-coin\` + \`text-black\` so the gold border and label read as one unit, with text staying legible against the gold. \`transition-colors duration-700\` matches the ring's animation timing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)