### PR TITLE
perf(self): defer inline voronoi banners to requestIdleCallback

### DIFF
--- a/src/routes/self/+page.svelte
+++ b/src/routes/self/+page.svelte
@@ -58,18 +58,44 @@
             render: () => `<div data-voronoi-slot="${id}" class="my-12 -mx-6 md:-mx-9"></div>`,
             setup(node: Element) {
               let instance: ReturnType<typeof mount> | null = null;
+              let idleHandle: number | null = null;
+              const ric =
+                typeof requestIdleCallback === 'function'
+                  ? requestIdleCallback
+                  : (cb: () => void) => setTimeout(cb, 1) as unknown as number;
+              const cancelRic =
+                typeof cancelIdleCallback === 'function'
+                  ? cancelIdleCallback
+                  : (h: number) => clearTimeout(h);
+              // rootMargin 400px -> 200px keeps the prefetch buffer just
+              // outside the viewport (one slot at a time during normal
+              // scroll instead of 2-3 simultaneously) and the mount goes
+              // through requestIdleCallback so the WebGL shader compile
+              // (~80-150 ms each) lands in an idle slot between scroll
+              // frames rather than stacking into a long task.
               const io = new IntersectionObserver(
                 (entries) => {
                   if (entries[0].isIntersecting && !instance) {
-                    instance = mount(VoronoiImage, { target: node, props: { src, alt } });
                     io.disconnect();
+                    idleHandle = ric(
+                      () => {
+                        idleHandle = null;
+                        if (instance) return;
+                        instance = mount(VoronoiImage, { target: node, props: { src, alt } });
+                      },
+                      // 2 s upper bound so banners always mount even on a
+                      // device that never goes truly idle (busy main
+                      // thread during long scrolls).
+                      { timeout: 2000 } as IdleRequestOptions,
+                    );
                   }
                 },
-                { rootMargin: '400px' }
+                { rootMargin: '200px' }
               );
               io.observe(node);
               return () => {
                 io.disconnect();
+                if (idleHandle != null) cancelRic(idleHandle);
                 if (instance) unmount(instance);
               };
             },


### PR DESCRIPTION
## Symptom
\`/self\` LH perf=70, TBT 727 ms. Inline voronoi banners (6 of them in self.md) mount via IO with \`rootMargin: 400 px\`, so 2–3 can be inside the prefetch buffer simultaneously during fast scroll. Each mount is a WebGL shader compile (~80–150 ms); they stack into a ~600 ms long task.

## Fix
- \`rootMargin\` 400 px → 200 px: prefetch one slot at a time during normal scroll.
- Wrap \`mount()\` in \`requestIdleCallback\` with a 2 s timeout fallback: shader compile lands in idle gaps between scroll frames, not competing with scroll.
- \`cancelIdleCallback\` on teardown.
- Graceful degrade for Safari < 17 / others via \`setTimeout\` shim.

## Tradeoff
On a fast scroll, banners may pop in ~100–300 ms later than before. No visual change at rest. Better INP / scroll smoothness in exchange for tiny perceived load delay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)