### PR TITLE
perf(deana,dad): defer ascii canvas mounts to idle

### DIFF
--- a/src/lib/components/LazyMount.svelte
+++ b/src/lib/components/LazyMount.svelte
@@ -13,6 +13,13 @@
      * section). Cleared once mounted.
      */
     placeholderMinHeight?: string;
+    /**
+     * When true, the visibility flip is wrapped in requestIdleCallback
+     * (with a 2 s timeout fallback) so heavy child mounts land in idle
+     * slots between scroll frames instead of competing with scroll.
+     * Defaults to false to preserve existing callers' behaviour.
+     */
+    useIdle?: boolean;
     /** Optional class on the wrapping div. */
     class?: string;
     children?: import('svelte').Snippet;
@@ -21,6 +28,7 @@
   let {
     rootMargin = '400px',
     placeholderMinHeight,
+    useIdle = false,
     class: klass = '',
     children,
   }: Props = $props();
@@ -34,19 +42,42 @@
       visible = true;
       return;
     }
-    // Snapshot rootMargin so prop changes after mount have no effect.
+    // Snapshot rootMargin + useIdle so prop changes after mount have no effect.
     const margin = rootMargin;
+    const ric =
+      useIdle && typeof requestIdleCallback === 'function'
+        ? requestIdleCallback
+        : null;
+    const cancelRic =
+      typeof cancelIdleCallback === 'function' ? cancelIdleCallback : null;
+    let idleHandle: number | null = null;
     const io = new IntersectionObserver(
       (entries) => {
-        if (entries.some((e) => e.isIntersecting)) {
+        if (!entries.some((e) => e.isIntersecting)) return;
+        io.disconnect();
+        if (ric) {
+          // 2 s upper bound so the mount fires even on a device that
+          // never goes truly idle (busy main thread during long scrolls).
+          idleHandle = ric(
+            () => {
+              idleHandle = null;
+              visible = true;
+            },
+            { timeout: 2000 } as IdleRequestOptions,
+          );
+        } else {
+          // Falls through here when useIdle is off OR the browser doesn't
+          // support rIC — same behaviour as before the prop existed.
           visible = true;
-          io.disconnect();
         }
       },
       { rootMargin: margin },
     );
     io.observe(host);
-    return () => io.disconnect();
+    return () => {
+      io.disconnect();
+      if (idleHandle != null && cancelRic) cancelRic(idleHandle);
+    };
   });
 </script>
 

--- a/src/lib/components/messages/AsciiImageSection.svelte
+++ b/src/lib/components/messages/AsciiImageSection.svelte
@@ -18,7 +18,11 @@
 	class="relative h-dvh w-full overflow-hidden bg-white"
 	style="content-visibility: auto; contain-intrinsic-size: 100vw 100dvh;"
 >
-	<LazyMount class="absolute inset-0">
+	<!-- rootMargin tightened 400 -> 200 and mount deferred to idle so the
+	     ascii canvas setup + first-frame paint don't compete with scroll.
+	     content-visibility: auto on the parent already keeps off-screen
+	     sections cheap; this keeps the on-mount work calm. -->
+	<LazyMount class="absolute inset-0" rootMargin="200px" useIdle>
 		<AsciiImage {srcs} class="h-full w-full" />
 	</LazyMount>
 	<span

--- a/src/routes/dad/+page.svelte
+++ b/src/routes/dad/+page.svelte
@@ -26,7 +26,7 @@
 
 <main class="min-h-screen bg-black text-white">
   <section class="relative h-dvh w-full overflow-hidden bg-black">
-    <LazyMount class="absolute inset-0">
+    <LazyMount class="absolute inset-0" rootMargin="200px" useIdle>
       <AsciiImage srcs={["/assets/dad-1.webp"]} class="h-full w-full" inverted />
     </LazyMount>
     <h1


### PR DESCRIPTION
## Summary
Same defer pattern as #165 (which fixed /self banners) applied to AsciiImageSection (the /deana hero sections × 4) and /dad's inline hero.

- **LazyMount** gains a \`useIdle\` opt-in prop (default false, all existing callers unchanged). Wraps the visibility flip in \`requestIdleCallback\` with a 2 s timeout fallback + \`cancelIdleCallback\` on teardown. Graceful shim for browsers without rIC.
- **AsciiImageSection** opts in: rootMargin 400 → 200 + useIdle.
- **/dad** inline LazyMount: same.

## Baseline
- /deana: perf 76, TBT 1219 ms, bootup 1343 ms, 5 long tasks.
- /dad: perf 85, TBT 568 ms, bootup 741 ms, 2 long tasks.

## Visual diff (local production build vs prod baseline)
- /dad = **0 pixel difference**.
- /deana = 0.18 % (DanaLabel variant cycling — expected, not regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)