### PR TITLE
fix(perf): don't defer the LCP candidate (above-the-fold ascii heroes)

### DIFF
--- a/src/lib/components/messages/AsciiImageSection.svelte
+++ b/src/lib/components/messages/AsciiImageSection.svelte
@@ -7,9 +7,14 @@
 		src: string;
 		/** Optional secondary src for crossfade cycling. */
 		altSrcs?: string[];
+		/** Defer mount to requestIdleCallback so the canvas first-frame
+		 *  paint lands in an idle slot rather than competing with scroll.
+		 *  Leave OFF (default) for the first/above-the-fold section — the
+		 *  rIC delay pushes LCP back. Turn ON for off-screen sections. */
+		useIdle?: boolean;
 	}
 
-	let { src, altSrcs }: Props = $props();
+	let { src, altSrcs, useIdle = false }: Props = $props();
 
 	const srcs = $derived(altSrcs?.length ? [src, ...altSrcs] : [src]);
 </script>
@@ -18,11 +23,10 @@
 	class="relative h-dvh w-full overflow-hidden bg-white"
 	style="content-visibility: auto; contain-intrinsic-size: 100vw 100dvh;"
 >
-	<!-- rootMargin tightened 400 -> 200 and mount deferred to idle so the
-	     ascii canvas setup + first-frame paint don't compete with scroll.
-	     content-visibility: auto on the parent already keeps off-screen
-	     sections cheap; this keeps the on-mount work calm. -->
-	<LazyMount class="absolute inset-0" rootMargin="200px" useIdle>
+	<!-- rootMargin tightened 400 -> 200 in either case. useIdle only when
+	     the section isn't the hero — for above-the-fold the rIC wait
+	     would push LCP back instead of saving TBT. -->
+	<LazyMount class="absolute inset-0" rootMargin="200px" {useIdle}>
 		<AsciiImage {srcs} class="h-full w-full" />
 	</LazyMount>
 	<span

--- a/src/routes/dad/+page.svelte
+++ b/src/routes/dad/+page.svelte
@@ -26,7 +26,9 @@
 
 <main class="min-h-screen bg-black text-white">
   <section class="relative h-dvh w-full overflow-hidden bg-black">
-    <LazyMount class="absolute inset-0" rootMargin="200px" useIdle>
+    <!-- Above-the-fold hero: tighten rootMargin but DON'T defer to idle —
+         the canvas is the LCP candidate, the rIC wait pushed LCP back. -->
+    <LazyMount class="absolute inset-0" rootMargin="200px">
       <AsciiImage srcs={["/assets/dad-1.webp"]} class="h-full w-full" inverted />
     </LazyMount>
     <h1

--- a/src/routes/deana/+page.svelte
+++ b/src/routes/deana/+page.svelte
@@ -57,7 +57,7 @@
     </div>
   </section>
 
-  <AsciiImageSection src={DEANA_PHOTOS[1]} />
+  <AsciiImageSection src={DEANA_PHOTOS[1]} useIdle />
 
   <section class="w-full bg-white px-3 py-12 md:px-6 md:py-24">
     <div class="mx-auto w-full max-w-7xl flex flex-col {g}">
@@ -72,7 +72,7 @@
     </div>
   </section>
 
-  <AsciiImageSection src={DEANA_PHOTOS[2]} />
+  <AsciiImageSection src={DEANA_PHOTOS[2]} useIdle />
 
   <section class="w-full bg-white px-3 py-12 md:px-6 md:py-24">
     <div class="mx-auto w-full max-w-7xl flex flex-col {g}">
@@ -109,7 +109,7 @@
     </div>
   </section>
 
-  <AsciiImageSection src={DEANA_PHOTOS[3]} />
+  <AsciiImageSection src={DEANA_PHOTOS[3]} useIdle />
 
   <section class="w-full bg-white px-3 py-12 md:px-6 md:py-24">
     <div class="mx-auto w-full max-w-7xl flex flex-col {g}">


### PR DESCRIPTION
## Symptom
After #166, /dad LCP regressed from 1.7s → 2.7s. The rIC wait pushed the canvas first-frame paint past the LCP window.

## Cause
#166 baked \`useIdle\` into \`AsciiImageSection\` unconditionally. But for /dad and /deana the FIRST section IS the LCP candidate (the hero canvas). Deferring it = delaying LCP.

## Fix
- \`AsciiImageSection.useIdle\` becomes a prop, default false. Only off-screen sections opt in.
- /deana: sections 2-4 → \`useIdle\`; section 1 (hero) eager.
- /dad: revert \`useIdle\` on its inline LazyMount; the rootMargin tightening (400 → 200) stays — only the rIC wrap hurt LCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)