### PR TITLE
perf(shelf): preload the featured book cover

### DIFF
--- a/src/routes/shelf/+page.svelte
+++ b/src/routes/shelf/+page.svelte
@@ -7,12 +7,21 @@
 
   let { data }: { data: PageData } = $props();
   let { sorted, featured, featuredLabel } = $derived(data);
+
+  // Featured book cover is the LCP element. Preload it from the head so
+  // the browser starts the fetch before parsing the body. URL must match
+  // the <img> src in ShelfHero exactly (same proxyImg width) so the
+  // preloaded response gets reused instead of a second fetch firing.
+  const featuredCoverPreload = $derived(
+    featured?.coverUrl ? proxyImg(featured.coverUrl, 400) : undefined,
+  );
 </script>
 
 <SeoHead
   title="shelf"
   description="Books, media, and the things that shape how I think."
   canonical="/shelf"
+  preloadImage={featuredCoverPreload}
   schema={collectionPageNode({
     path: "/shelf",
     name: "shelf — threesam",


### PR DESCRIPTION
LCP candidate on /shelf is the featured book cover. \`<img>\` had \`fetchpriority=high\` already but no preload — browser only discovered it after parsing the body. Adding a \`<link rel="preload" as="image">\` from the head so the fetch starts immediately.

URL is computed via \`proxyImg(featured.coverUrl, 400)\` — same call ShelfHero uses for the \`<img>\` src, so the preloaded response is reused (no double fetch).

**Baseline**: perf 86–87, LCP 3.1–3.4 s.
**Visual diff vs prod**: 9.5 % — entirely dynamic data drift (Goodreads "currently reading" updated since prod build; featured book + ordering changed, metaballs are noise-driven). My change is a head-only preload tag, zero visual impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)