### PR TITLE
perf(sounds): preload the first featured tile's cover

### DIFF
--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -117,6 +117,12 @@
     return [...pinnedTiles, ...singles, ...otherEps, ...scores];
   });
 
+  // First featured tile's cover is the LCP candidate (it's eager +
+  // fetchpriority=high on the <img>; we add a preload from the head so
+  // the fetch starts before the body parses). Falls through to undefined
+  // when the manifest has no tiles or no cover on the first one.
+  const lcpCoverPreload = $derived(tiles[0]?.cover ? coverUrl(tiles[0].cover) : undefined);
+
   // Pause/resume the current track (logs the umami event). A fresh play of a
   // different track goes through play/playCue below.
   const toggleCurrent = async () => {
@@ -231,6 +237,7 @@
   title="sounds"
   description="music — demos and scores."
   canonical="/sounds"
+  preloadImage={lcpCoverPreload}
   schema={collectionPageNode({ path: "/sounds", name: "sounds — threesam" })}
 />
 


### PR DESCRIPTION
PR #131 made the first 3 featured covers eager + \`fetchpriority=high\` on the \`<img>\`, but they weren't preloaded from the head — browser only discovered them after parsing the body. LCP sat at ~3.8 s.

Add a \`<link rel="preload" as="image">\` for \`tiles[0].cover\` routed through the same \`coverUrl()\` rewrite the \`<img>\` uses (so the preloaded response is reused, not double-fetched). Falls through to \`undefined\` when there's no first tile.

**Visual diff vs prod**: lazy-loading timing variability only (covers loaded vs \`?\` placeholders differ between captures — both have identical layout). Preload tag has zero visual impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)