### PR TITLE
chore(security): add basic security headers globally

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,15 @@
   ],
   "headers": [
     {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), interest-cohort=(), browsing-topics=()" },
+        { "key": "X-Frame-Options", "value": "DENY" }
+      ]
+    },
+    {
       "source": "/_app/immutable/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
Vercel only ships HSTS by default. Adds 4 conservative headers globally that don't change functionality:

- \`X-Content-Type-Options: nosniff\`
- \`Referrer-Policy: strict-origin-when-cross-origin\`
- \`Permissions-Policy: camera=(), microphone=(), geolocation=(), interest-cohort=(), browsing-topics=()\` — features the site doesn't use
- \`X-Frame-Options: DENY\` — prevent clickjacking

Skipped CSP — inline analytics script + Tailwind inline styles would require a permissive policy that adds friction without real gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)