### PR TITLE
seo: homepage WebPage + ItemList of SITE_PAGES

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -244,6 +244,24 @@ export function musicPlaylistNode(opts: {
   };
 }
 
+/**
+ * WebPage anchor for the homepage. Pairs with itemListNode (over SITE_PAGES)
+ * so search engines + answer engines pick up the site index in structured
+ * form alongside the natural-language llms.txt and the sitemap.
+ */
+export function homePageNode(): object {
+  return {
+    "@type": "WebPage",
+    "@id": `${SITE_URL}/#webpage`,
+    url: `${SITE_URL}/`,
+    name: "threesam",
+    isPartOf: { "@id": WEBSITE_ID },
+    about: { "@id": PERSON_ID },
+    primaryImageOfPage: `${SITE_URL}/og/home.png`,
+    inLanguage: "en",
+  };
+}
+
 /** A curated list of items on a CollectionPage (e.g. /shelf). Generic
  * ItemList so the same helper works for books, links, anything. */
 export function itemListNode(opts: {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,9 +2,22 @@
   import SeoHead from '$lib/components/SeoHead.svelte';
   import Gallery from '$lib/components/gallery/Gallery.svelte';
   import BrandSignoff from '$lib/components/frame/BrandSignoff.svelte';
+  import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
+
+  // Structured site index for search + answer engines. Mirrors the
+  // natural-language /llms.txt and the sitemap so the same SITE_PAGES
+  // source feeds all three crawl surfaces.
+  const homeSchema = [
+    homePageNode(),
+    itemListNode({
+      path: '/',
+      name: 'threesam — site index',
+      items: SITE_PAGES.map((p) => ({ url: `${SITE_URL}${p.path}`, name: p.label })),
+    }),
+  ];
 </script>
 
-<SeoHead canonical="/" ogImage="/og/home.png" />
+<SeoHead canonical="/" ogImage="/og/home.png" schema={homeSchema} />
 
 <!--
   Single-viewport homepage on a flat --coin field: a 50dvh gallery strip


### PR DESCRIPTION
Homepage was emitting only the shared Person + WebSite JSON-LD nodes. Add an explicit \`WebPage\` anchor + an \`ItemList\` of \`SITE_PAGES\` so search / answer engines pick up the site index in structured form alongside \`llms.txt\` (natural language) and the sitemap (raw URLs). Single source (\`SITE_PAGES\`) feeds all three.

- \`$lib/seo.ts\`: new \`homePageNode()\` helper.
- \`routes/+page.svelte\`: pass \`[homePageNode(), itemListNode(...)]\` as schema.

Zero visual impact (head-only \`<script type="application/ld+json">\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)