### PR TITLE
chore(agentic): Content-Signal + agent-useful Link headers

### DIFF
--- a/src/routes/robots.txt/+server.ts
+++ b/src/routes/robots.txt/+server.ts
@@ -25,12 +25,25 @@ const AI_AGENTS = [
   'meta-externalagent',    // Meta AI
 ];
 
+// Content-Signal directive (Cloudflare proposal — blog.cloudflare.com/content-signals/)
+// tells AI agents what THIS site permits even when allowed via robots. We opt
+// into search indexing, AI training, and live answer-engine input. Listing
+// these explicitly is the agentic equivalent of a content-licence stamp.
+const CONTENT_SIGNAL = 'search=yes, ai-train=yes, ai-input=yes';
+
 export async function GET() {
-  const aiBlock = AI_AGENTS.map((ua) => `User-agent: ${ua}\nAllow: /`).join('\n\n');
+  const aiBlock = AI_AGENTS.map(
+    (ua) => `User-agent: ${ua}\nContent-Signal: ${CONTENT_SIGNAL}\nAllow: /`,
+  ).join('\n\n');
 
   const body = `# All crawlers, including AI and answer engines, are welcome.
 # Sitemap + /llms.txt are the canonical entry points for indexing.
+# Content-Signal: ${CONTENT_SIGNAL}
+#   search    — index for search results
+#   ai-train  — use as training data
+#   ai-input  — cite live in answer engines
 User-agent: *
+Content-Signal: ${CONTENT_SIGNAL}
 Allow: /
 Disallow: /api/
 

--- a/vercel.json
+++ b/vercel.json
@@ -19,6 +19,12 @@
       ]
     },
     {
+      "source": "/",
+      "headers": [
+        { "key": "Link", "value": "</llms.txt>; rel=\"alternate\"; type=\"text/plain\"; title=\"LLM-friendly site index\", </sitemap.xml>; rel=\"sitemap\"; type=\"application/xml\", </llms.txt>; rel=\"describedby\"; type=\"text/plain\"" }
+      ]
+    },
+    {
       "source": "/_app/immutable/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
Two free wins from isitagentready.com (Cloudflare agent-readiness scanner):

1. **\`robots.txt\`**: \`Content-Signal: search=yes, ai-train=yes, ai-input=yes\` per UA. Explicit content-licence stamp for AI agents per [Cloudflare proposal](https://blog.cloudflare.com/content-signals/).
2. **Vercel headers**: agent-useful \`Link\` headers on \`/\`:
   - \`</llms.txt>; rel="alternate"; type="text/plain"; title="LLM-friendly site index"\`
   - \`</sitemap.xml>; rel="sitemap"; type="application/xml"\`
   - \`</llms.txt>; rel="describedby"; type="text/plain"\`

Stacks with the existing modulepreload \`Link\` headers SvelteKit emits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)