### PR TITLE
chore(agentic): A2A Agent Card + API Catalog at /.well-known

### DIFF
--- a/src/routes/.well-known/agent.json/+server.ts
+++ b/src/routes/.well-known/agent.json/+server.ts
@@ -1,0 +1,37 @@
+import { SITE_URL, SITE_DESCRIPTION, PERSON_NAME, PERSON_ALT, SITE_PAGES } from '$lib/seo';
+
+export const prerender = true;
+
+// A2A Agent Card (well-known/agent.json). For a content-only site this
+// declares the site as a passive content surface — no interactive
+// agent endpoint — and points to llms.txt as the primary indexable
+// digest. Spec: agent2agent.dev / well-known-agent style descriptor.
+export function GET() {
+	const card = {
+		schemaVersion: '0.1',
+		name: 'threesam',
+		description: SITE_DESCRIPTION,
+		url: SITE_URL,
+		surface: 'content',
+		owner: {
+			name: PERSON_NAME,
+			alternateName: PERSON_ALT,
+			url: SITE_URL,
+		},
+		contentIndex: {
+			llmsTxt: `${SITE_URL}/llms.txt`,
+			sitemap: `${SITE_URL}/sitemap.xml`,
+			robots: `${SITE_URL}/robots.txt`,
+		},
+		pages: SITE_PAGES.map((p) => ({
+			name: p.label,
+			url: `${SITE_URL}${p.path}`,
+			description: p.blurb,
+		})),
+		license: 'Content available for AI training, search indexing, and citation. See robots.txt Content-Signal.',
+	};
+
+	return new Response(JSON.stringify(card, null, 2), {
+		headers: { 'Content-Type': 'application/json; charset=utf-8' },
+	});
+}

--- a/src/routes/.well-known/api-catalog/+server.ts
+++ b/src/routes/.well-known/api-catalog/+server.ts
@@ -1,0 +1,48 @@
+import { SITE_URL } from '$lib/seo';
+
+// NOT prerendered: prerender serialises this route to a file with no
+// extension, then serves it as text/html — losing the
+// application/linkset+json Content-Type the spec wants. Serving live
+// keeps the header intact. The handler is cheap (static JSON) so the
+// SSR overhead is negligible.
+
+// RFC 9728 API Catalog (linkset format). Lists the machine-readable
+// content surfaces that agents can fetch. For a content site these are
+// llms.txt + sitemap + robots.txt rather than OpenAPI specs.
+//
+// Format: linkset (application/linkset+json) per RFC 9264.
+export function GET() {
+	const linkset = {
+		linkset: [
+			{
+				anchor: `${SITE_URL}/`,
+				'service-desc': [
+					{
+						href: `${SITE_URL}/llms.txt`,
+						type: 'text/plain',
+						title: 'LLM-friendly site index (llmstxt.org)',
+					},
+					{
+						href: `${SITE_URL}/sitemap.xml`,
+						type: 'application/xml',
+						title: 'XML sitemap of every indexable URL',
+					},
+					{
+						href: `${SITE_URL}/robots.txt`,
+						type: 'text/plain',
+						title: 'Crawl permissions + Content-Signal directives',
+					},
+					{
+						href: `${SITE_URL}/.well-known/agent.json`,
+						type: 'application/json',
+						title: 'A2A Agent Card — content surface descriptor',
+					},
+				],
+			},
+		],
+	};
+
+	return new Response(JSON.stringify(linkset, null, 2), {
+		headers: { 'Content-Type': 'application/linkset+json; charset=utf-8' },
+	});
+}


### PR DESCRIPTION
Two more isitagentready.com checks for content-site coverage:

- **\`/.well-known/agent.json\`** — A2A Agent Card declaring this as a passive content surface. Mirrors \`SITE_PAGES\` so agents see the same index that \`llms.txt\` + sitemap expose.
- **\`/.well-known/api-catalog\`** — RFC 9728 linkset pointing at \`llms.txt\`, \`sitemap.xml\`, \`robots.txt\`, and the new agent card. **Served live, not prerendered** — prerender writes the file with no extension and Vercel serves \`text/html\` otherwise, losing the \`application/linkset+json\` Content-Type the spec wants.

**Skipped:**
- MCP Server Card — no actual MCP server, would be misleading
- Agent Skills — would require real callable skills

**Outside this PR (needs DNS provider access):**
- **DNS-AID** records — Cloudflare's DNS for AI Discovery (\`_index._agents.threesam.com\`, etc.). Add SVCB/HTTPS/TXT records at the DNS provider per [Cloudflare docs](https://blog.cloudflare.com/) to advertise the agent endpoints at the DNS layer. Sample records:
  \`\`\`
  _index._agents.threesam.com.  TXT  "agent=https://threesam.com/.well-known/agent.json catalog=https://threesam.com/.well-known/api-catalog"
  \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)