### PR TITLE
chore(agentic): raw markdown surfaces at /dad.md, /benny.md, /self.md

### DIFF
--- a/src/routes/.well-known/agent.json/+server.ts
+++ b/src/routes/.well-known/agent.json/+server.ts
@@ -23,11 +23,19 @@ export function GET() {
 			sitemap: `${SITE_URL}/sitemap.xml`,
 			robots: `${SITE_URL}/robots.txt`,
 		},
-		pages: SITE_PAGES.map((p) => ({
-			name: p.label,
-			url: `${SITE_URL}${p.path}`,
-			description: p.blurb,
-		})),
+		// Pages with a markdown surface include `markdownUrl` — agents
+		// can fetch the raw .md for the long-form prose pages without
+		// parsing the rendered HTML.
+		pages: SITE_PAGES.map((p) => {
+			const hasMarkdown = ['/dad', '/benny', '/self'].includes(p.path);
+			const page: Record<string, unknown> = {
+				name: p.label,
+				url: `${SITE_URL}${p.path}`,
+				description: p.blurb,
+			};
+			if (hasMarkdown) page.markdownUrl = `${SITE_URL}${p.path}.md`;
+			return page;
+		}),
 		license: 'Content available for AI training, search indexing, and citation. See robots.txt Content-Signal.',
 	};
 

--- a/src/routes/.well-known/api-catalog/+server.ts
+++ b/src/routes/.well-known/api-catalog/+server.ts
@@ -37,6 +37,21 @@ export function GET() {
 						type: 'application/json',
 						title: 'A2A Agent Card — content surface descriptor',
 					},
+					{
+						href: `${SITE_URL}/dad.md`,
+						type: 'text/markdown',
+						title: 'Long-form essay: dad (raw markdown)',
+					},
+					{
+						href: `${SITE_URL}/benny.md`,
+						type: 'text/markdown',
+						title: 'Long-form essay: benny (raw markdown)',
+					},
+					{
+						href: `${SITE_URL}/self.md`,
+						type: 'text/markdown',
+						title: 'Long-form essay: self (raw markdown)',
+					},
 				],
 			},
 		],

--- a/src/routes/benny.md/+server.ts
+++ b/src/routes/benny.md/+server.ts
@@ -1,0 +1,14 @@
+import { getContent } from '$lib/content';
+import { error } from '@sveltejs/kit';
+
+export const prerender = true;
+
+export async function GET() {
+	const raw = await getContent('benny');
+	if (raw == null) error(404);
+	return new Response(raw, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	});
+}

--- a/src/routes/dad.md/+server.ts
+++ b/src/routes/dad.md/+server.ts
@@ -1,0 +1,18 @@
+import { getContent } from '$lib/content';
+import { error } from '@sveltejs/kit';
+
+// Raw markdown surface for /dad — same content as the HTML route, no
+// frame, served as text/markdown so AI agents can ingest it without
+// parsing the rendered page. Discoverable via the api-catalog +
+// agent.json descriptors at /.well-known.
+export const prerender = true;
+
+export async function GET() {
+	const raw = await getContent('dad');
+	if (raw == null) error(404);
+	return new Response(raw, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	});
+}

--- a/src/routes/self.md/+server.ts
+++ b/src/routes/self.md/+server.ts
@@ -1,0 +1,14 @@
+import { getContent } from '$lib/content';
+import { error } from '@sveltejs/kit';
+
+export const prerender = true;
+
+export async function GET() {
+	const raw = await getContent('self');
+	if (raw == null) error(404);
+	return new Response(raw, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8',
+		},
+	});
+}

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,24 @@
       ]
     },
     {
+      "source": "/dad",
+      "headers": [
+        { "key": "Link", "value": "</dad.md>; rel=\"alternate\"; type=\"text/markdown\"; title=\"Raw markdown\"" }
+      ]
+    },
+    {
+      "source": "/benny",
+      "headers": [
+        { "key": "Link", "value": "</benny.md>; rel=\"alternate\"; type=\"text/markdown\"; title=\"Raw markdown\"" }
+      ]
+    },
+    {
+      "source": "/self",
+      "headers": [
+        { "key": "Link", "value": "</self.md>; rel=\"alternate\"; type=\"text/markdown\"; title=\"Raw markdown\"" }
+      ]
+    },
+    {
       "source": "/_app/immutable/(.*)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
Markdown-for-Agents content surface — sibling \`.md\` endpoints (prerendered) so AI agents can fetch the raw long-form essays without parsing the rendered HTML.

- \`src/routes/{dad,benny,self}.md/+server.ts\`: prerendered GETs returning the raw \`content/<slug>.md\` with \`Content-Type: text/markdown\`.
- \`agent.json\`: each page entry now includes \`markdownUrl\` where it exists.
- \`api-catalog\` linkset: adds the .md surfaces with \`type=text/markdown\`.
- Vercel \`Link\` headers on \`/dad\`, \`/benny\`, \`/self\`: \`</.md>; rel="alternate"; type="text/markdown"\` for header-only discovery.

Why not Accept-header negotiation? Prerendered routes don't hit \`hooks.server.ts\` — Vercel serves the static HTML directly. Sibling \`.md\` paths stay prerenderable (free at the edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)