### PR TITLE
chore(agentic): A2A canonical path /.well-known/agent-card.json

### DIFF
--- a/src/routes/.well-known/agent-card.json/+server.ts
+++ b/src/routes/.well-known/agent-card.json/+server.ts
@@ -1,0 +1,4 @@
+// A2A spec canonicalises the agent card at /.well-known/agent-card.json
+// (with -card.json suffix). Re-exports the same handler as agent.json so
+// scanners + agents that follow the spec path land here.
+export { GET, prerender } from '../agent.json/+server';


### PR DESCRIPTION
A2A spec canonicalises the agent card at \`/.well-known/agent-card.json\` (with \`-card.json\` suffix). We had it at \`/.well-known/agent.json\`. Adds an alias route that re-exports the same \`GET\` handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)