### PR TITLE
chore(agentic): A2A-compliant Agent Card

### DIFF
--- a/src/routes/.well-known/agent.json/+server.ts
+++ b/src/routes/.well-known/agent.json/+server.ts
@@ -2,13 +2,28 @@ import { SITE_URL, SITE_DESCRIPTION, PERSON_NAME, PERSON_ALT, SITE_PAGES } from 
 
 export const prerender = true;
 
-// A2A Agent Card (well-known/agent.json). For a content-only site this
-// declares the site as a passive content surface — no interactive
-// agent endpoint — and points to llms.txt as the primary indexable
-// digest. Spec: agent2agent.dev / well-known-agent style descriptor.
+// A2A Agent Card per the A2A spec (agent2agent.dev). Declares this as a
+// passive content surface — the "skills" are honest HTTP GETs over the
+// content surfaces (llms.txt, raw markdown, sitemap), not an
+// interactive agent endpoint. Lives at both /.well-known/agent.json and
+// /.well-known/agent-card.json (canonical A2A path).
+
+const MARKDOWN_PATHS = new Set(['/dad', '/benny', '/self']);
+
 export function GET() {
+	const pages = SITE_PAGES.map((p) => {
+		const page: Record<string, unknown> = {
+			name: p.label,
+			url: `${SITE_URL}${p.path}`,
+			description: p.blurb,
+		};
+		if (MARKDOWN_PATHS.has(p.path)) page.markdownUrl = `${SITE_URL}${p.path}.md`;
+		return page;
+	});
+
 	const card = {
 		schemaVersion: '0.1',
+		version: '0.1.0',
 		name: 'threesam',
 		description: SITE_DESCRIPTION,
 		url: SITE_URL,
@@ -18,25 +33,54 @@ export function GET() {
 			alternateName: PERSON_ALT,
 			url: SITE_URL,
 		},
+		supportedInterfaces: [
+			{
+				type: 'http',
+				url: SITE_URL,
+				description: 'Public HTTP — read pages, markdown, sitemap, llms.txt.',
+			},
+		],
+		skills: [
+			{
+				id: 'fetch-llms-txt',
+				name: 'Fetch site digest',
+				description: 'Return the LLM-friendly site index (llmstxt.org format).',
+				method: 'GET',
+				url: `${SITE_URL}/llms.txt`,
+			},
+			{
+				id: 'fetch-sitemap',
+				name: 'Fetch sitemap',
+				description: 'Return the XML sitemap of every indexable URL.',
+				method: 'GET',
+				url: `${SITE_URL}/sitemap.xml`,
+			},
+			{
+				id: 'fetch-essay-markdown',
+				name: 'Fetch raw essay markdown',
+				description:
+					'Return raw markdown for long-form essays (no HTML frame). One URL per page.',
+				method: 'GET',
+				urls: Array.from(MARKDOWN_PATHS).map((p) => `${SITE_URL}${p}.md`),
+			},
+			{
+				id: 'fetch-page',
+				name: 'Fetch a page',
+				description:
+					'Return the canonical HTML for any public page. JSON-LD @graph in the head includes Person + WebSite + page-specific schema.',
+				method: 'GET',
+				urls: SITE_PAGES.map((p) => `${SITE_URL}${p.path}`),
+			},
+		],
 		contentIndex: {
 			llmsTxt: `${SITE_URL}/llms.txt`,
 			sitemap: `${SITE_URL}/sitemap.xml`,
 			robots: `${SITE_URL}/robots.txt`,
+			apiCatalog: `${SITE_URL}/.well-known/api-catalog`,
 		},
-		// Pages with a markdown surface include `markdownUrl` — agents
-		// can fetch the raw .md for the long-form prose pages without
-		// parsing the rendered HTML.
-		pages: SITE_PAGES.map((p) => {
-			const hasMarkdown = ['/dad', '/benny', '/self'].includes(p.path);
-			const page: Record<string, unknown> = {
-				name: p.label,
-				url: `${SITE_URL}${p.path}`,
-				description: p.blurb,
-			};
-			if (hasMarkdown) page.markdownUrl = `${SITE_URL}${p.path}.md`;
-			return page;
-		}),
-		license: 'Content available for AI training, search indexing, and citation. See robots.txt Content-Signal.',
+		pages,
+		license:
+			'Content available for AI training, search indexing, and citation. See robots.txt Content-Signal.',
 	};
 
 	return new Response(JSON.stringify(card, null, 2), {


### PR DESCRIPTION
The agent card was valid JSON but failed A2A schema validation — missing required \`version\`, \`skills\`, \`supportedInterfaces\`. Add all three honestly:

- \`version\`: \`0.1.0\`
- \`supportedInterfaces\`: HTTP-only (no interactive endpoint claimed)
- \`skills\`: honest HTTP GETs over the existing surfaces (\`llms.txt\`, sitemap, raw markdown, pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)