### PR TITLE
perf(hp): trim analog card particles 4000 -> 1500 (-63%)

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -347,7 +347,11 @@
 									     bright glowing forms regardless of which book is featured. -->
 									<CanvasComp color={[245 / 255, 244 / 255, 240 / 255]} />
 								{:else if item.handle === 'anything-but-analog'}
-									<CanvasComp countOverride={4000} hideText pointSize={2} repelRadius={50} lowDpr />
+									<!-- Card-scale particle field: 1500 (was 4000) at point
+									     size 3 (was 2). Same visual density on a ~280 px card
+									     at ~60 % of the per-frame physics cost — particle
+									     repel is O(n) per frame. -->
+									<CanvasComp countOverride={1500} hideText pointSize={3} repelRadius={40} lowDpr />
 								{:else if item.handle === 'thoughts'}
 									<!-- Pause the walker tick while the cursor is over the
 									     carousel — day30's per-frame repel loop is the heaviest


### PR DESCRIPTION
Analog gallery card was running **4000 particles with cursor repel on a ~280 px card**. Particle repel is O(n) per frame.

Trim to **1500** + bump \`pointSize\` 2 → 3 so on-screen density looks identical; \`repelRadius\` 50 → 40 to match the smaller field. ~60% less per-frame physics for the same visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)