### PR TITLE
perf(hp): mobile-tier configs for shelf metaballs + analog particles

### DIFF
--- a/src/lib/components/canvas/MetaballCanvas.svelte
+++ b/src/lib/components/canvas/MetaballCanvas.svelte
@@ -8,9 +8,10 @@
     color = [0.1, 0.1, 0.08],
     trackCursor = true,
     target = null,
+    lowDpr = false,
   }: Props = $props();
 
-  const params: MetaballParams = $derived({ color, trackCursor, target });
+  const params: MetaballParams = $derived({ color, trackCursor, target, lowDpr });
 </script>
 
 <canvas class="absolute inset-0 h-full w-full" use:metaball={params}></canvas>

--- a/src/lib/components/canvas/actions/metaball.ts
+++ b/src/lib/components/canvas/actions/metaball.ts
@@ -59,6 +59,9 @@ export interface MetaballParams {
   color?: [number, number, number];
   trackCursor?: boolean;
   target?: { x: number; y: number } | null;
+  /** Cut the canvas backing-buffer scale further on weak GPUs (mobile).
+   *  Default 0.5 → 0.25, i.e. 1/4 the fragment-shader work per frame. */
+  lowDpr?: boolean;
 }
 
 export const metaball: Action<HTMLCanvasElement, MetaballParams> = (node, initialParams) => {
@@ -107,12 +110,12 @@ export const metaball: Action<HTMLCanvasElement, MetaballParams> = (node, initia
   let pointerActive = false;
   const balls: Ball[] = [];
 
-  const RES_SCALE = 0.5;
+  let resScale = params.lowDpr ? 0.25 : 0.5;
   function resize() {
     w = node.clientWidth;
     h = node.clientHeight;
-    node.width = Math.max(1, Math.round(w * RES_SCALE));
-    node.height = Math.max(1, Math.round(h * RES_SCALE));
+    node.width = Math.max(1, Math.round(w * resScale));
+    node.height = Math.max(1, Math.round(h * resScale));
     gl.viewport(0, 0, node.width, node.height);
     const rect = node.getBoundingClientRect();
     rectLeft = rect.left;
@@ -278,7 +281,12 @@ export const metaball: Action<HTMLCanvasElement, MetaballParams> = (node, initia
 
   return {
     update(next: MetaballParams) {
+      const lowDprChanged = !!next.lowDpr !== !!params.lowDpr;
       params = next;
+      if (lowDprChanged) {
+        resScale = params.lowDpr ? 0.25 : 0.5;
+        resize();
+      }
     },
     destroy() {
       cancelAnimationFrame(raf);

--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -53,6 +53,13 @@
 	// during hover frees the main thread so pointer events land in
 	// ~50 ms instead of ~170 ms.
 	let isHoveringSection = $state(false);
+	// Mobile / coarse-pointer devices: cut GPU work on the heavy cards
+	// (shelf metaballs, analog particles). Desktop visual stays untouched;
+	// mobile gets ~1/4 the metaball fragment work and ~1/3 the particle
+	// physics. One-shot detection at mount — viewport changes between
+	// mobile/desktop tiers mid-session are rare and tearing down + re-
+	// mounting WebGL canvases would jank more than the benefit.
+	let isMobile = $state(false);
 
 	// `isActive`: has this card ever been in the buffer? Governs mount.
 	function isActive(i: number): boolean {
@@ -93,6 +100,10 @@
 	onMount(() => {
 		if (!stripEl) return;
 		const section = stripEl.parentElement!;
+
+		// One-shot mobile detection — coarse pointer OR sub-768 viewport.
+		// Routed into the heavy cards (shelf metaballs, analog particles).
+		isMobile = window.matchMedia('(max-width: 768px), (pointer: coarse)').matches;
 
 		let offsetRef = 0;
 		let speedRef = SPEED;
@@ -343,15 +354,29 @@
 								{:else if item.handle === 'deana'}
 									<CanvasComp />
 								{:else if item.handle === 'shelf'}
-									<!-- Cream (--white) blobs on the dark card background — read as
-									     bright glowing forms regardless of which book is featured. -->
-									<CanvasComp color={[245 / 255, 244 / 255, 240 / 255]} />
+									<!-- Cream (--white) blobs on the dark card background — read
+									     as bright glowing forms regardless of which book is featured.
+									     lowDpr on mobile drops the fragment-shader scale 0.5 -> 0.25
+									     (1/4 the per-frame work). Visual: slightly chunkier metaball
+									     edges — already pixelated via PIXEL_SIZE=6, unnoticeable on
+									     a small card. -->
+									<CanvasComp
+										color={[245 / 255, 244 / 255, 240 / 255]}
+										lowDpr={isMobile}
+									/>
 								{:else if item.handle === 'anything-but-analog'}
-									<!-- Card-scale particle field: 1500 (was 4000) at point
-									     size 3 (was 2). Same visual density on a ~280 px card
-									     at ~60 % of the per-frame physics cost — particle
-									     repel is O(n) per frame. -->
-									<CanvasComp countOverride={1500} hideText pointSize={3} repelRadius={40} lowDpr />
+									<!-- Card-scale particle field. Desktop: 1500 particles at
+									     point size 3. Mobile: 500 at point size 4 — same density
+									     on a small card at ~1/3 the per-frame physics. Particle
+									     repel is O(n) per frame so the linear cut is directly
+									     perceptible. -->
+									<CanvasComp
+										countOverride={isMobile ? 500 : 1500}
+										hideText
+										pointSize={isMobile ? 4 : 3}
+										repelRadius={isMobile ? 30 : 40}
+										lowDpr
+									/>
 								{:else if item.handle === 'thoughts'}
 									<!-- Pause the walker tick while the cursor is over the
 									     carousel — day30's per-frame repel loop is the heaviest


### PR DESCRIPTION
User reports shelf + analog cards slow on mobile; desktop fine. Both GPU/CPU-bound on weaker mobile chips.

**Changes:**
- New \`lowDpr\` param on \`metaball\` action. Default \`RES_SCALE=0.5\`; \`lowDpr=true\` → 0.25 → 1/4 the per-frame fragment-shader work. \`MetaballCanvas\` forwards.
- \`Gallery\` detects mobile via \`matchMedia('(max-width: 768px), (pointer: coarse)')\` at mount and routes into:
  - shelf: \`lowDpr={isMobile}\`
  - analog: \`countOverride\` 1500 → **500**, \`pointSize\` 3 → 4, \`repelRadius\` 40 → 30 on mobile. ~1/3 the per-frame physics (repel is O(n)).
- Desktop visuals untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)