### PR TITLE
revert: #180 — day30 hover pause feels glitchy on hover-off

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -47,12 +47,6 @@
 	let activeRange = $state<[number, number]>([0, 0]);
 	let mountedHi = $state(-1);
 	let canvasesArmed = $state(false);
-	// True while the cursor sits over the carousel section. The thoughts
-	// (day30) sketch is the heaviest per-tick canvas we have (~100 ms
-	// walker repel loop on prod) and isn't cursor-reactive — pausing it
-	// during hover frees the main thread so pointer events land in
-	// ~50 ms instead of ~170 ms.
-	let isHoveringSection = $state(false);
 
 	// `isActive`: has this card ever been in the buffer? Governs mount.
 	function isActive(i: number): boolean {
@@ -215,11 +209,9 @@
 
 		function onEnter() {
 			targetSpeedRef = 0;
-			isHoveringSection = true;
 		}
 		function onLeave() {
 			targetSpeedRef = SPEED;
-			isHoveringSection = false;
 			wake();
 		}
 
@@ -353,16 +345,7 @@
 									     repel is O(n) per frame. -->
 									<CanvasComp countOverride={1500} hideText pointSize={3} repelRadius={40} lowDpr />
 								{:else if item.handle === 'thoughts'}
-									<!-- Pause the walker tick while the cursor is over the
-									     carousel — day30's per-frame repel loop is the heaviest
-									     animation here and it doesn't track the cursor, so we
-									     can freeze the last frame to free the main thread for
-									     pointer events without losing anything visible. -->
-									<CanvasComp
-										slug="30"
-										active={inView(i) && !isHoveringSection}
-										interactive={false}
-									/>
+									<CanvasComp slug="30" active={inView(i)} interactive={false} />
 								{:else if item.handle === 'sounds'}
 									<CanvasComp fixed={false} />
 								{/if}


### PR DESCRIPTION
Reverts PR #180. User: \"thoughts card is wrong, shouldn't stop, when you hover off it start again which is glitchy UX.\"

Stop→resume on hover-off reads as a stutter (walkers freeze then snap back to moving). Better to keep them ticking smoothly. The input-delay fix #180 was traded; we'll revisit if real device profiling shows a hot spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)