### PR TITLE
fix(thoughts card): keep walker speed constant across hover throttle

### DIFF
--- a/src/lib/art/sketches/day30.ts
+++ b/src/lib/art/sketches/day30.ts
@@ -1,5 +1,6 @@
 import type { Sketch } from "../types";
 import { sketchMode } from "../sketch-mode";
+import { isCanvasThrottled } from "$lib/perf-flags";
 
 // The crowd — procedural stick figures walking along a gentle NE-biased
 // flow field. Walkers are scattered across the canvas at init and wrap
@@ -354,7 +355,16 @@ export const day30: Sketch = {
           // lockstep with the card flip and the color shift. Cursor
           // orbit (only on routes that pass interactive=true) is
           // unaffected — it stays a deliberate, attention-grabbing pull.
-          const speedScale = 1 - currentSlow * 0.85;
+          //
+          // Frame-rate compensation: the homepage gallery throttles every
+          // canvas to 30 fps while its strip auto-scrolls (sketch-host
+          // drops alternate frames via shouldSkipThrottledFrame). When the
+          // user hovers, the strip stops and throttle releases — without
+          // this compensation walkers visually jump to 2× speed. Doubling
+          // per-tick delta while throttled keeps the perceived speed flat
+          // across the hover transition.
+          const throttleScale = isCanvasThrottled() ? 2 : 1;
+          const speedScale = (1 - currentSlow * 0.85) * throttleScale;
           wk.x += (Math.cos(moveAngle) * wk.speed + repelX * SEPARATION_GAIN) * speedScale + orbitX;
           wk.y += (Math.sin(moveAngle) * wk.speed + repelY * SEPARATION_GAIN) * speedScale + orbitY;
 

--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -300,19 +300,13 @@
 		{#each LOOPED as item, i (item.id + '-' + i)}
 			{@const visible = isActive(i)}
 			{@const cream = paletteFor(i) === 'cream'}
-			<!-- thoughts card stays still — its day30 walker reads as motion already,
-			     and adding the tilt+ring made it feel busy on hover. -->
-			{@const hoverless = item.handle === 'thoughts'}
-			{@const cardHover = hoverless ? '' : 'hover:shadow-none hover:[transform:rotate(-1.3deg)]'}
-			{@const ringPalette = cream ? 'group-hover:ring-white' : 'group-hover:ring-black'}
-			{@const ringHover = hoverless ? '' : ringPalette}
 			<!-- svelte-ignore a11y_no_static_element_interactions -->
 			<a
 				href={item.href}
 				draggable="false"
 				data-sveltekit-preload-data="off"
 				onclick={(e) => handleClick(e, item)}
-				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-sm transition-[transform,box-shadow] duration-700 {cardHover}"
+				class="gallery-card group relative flex h-full shrink-0 flex-col overflow-hidden rounded-2xl shadow-sm transition-[transform,box-shadow] duration-700 hover:shadow-none hover:[transform:rotate(-1.3deg)]"
 				style="aspect-ratio: 20 / 29;"
 			>
 				<!-- image area: locked to 4:5 so canvases that bake at that
@@ -386,9 +380,11 @@
 				<!-- Border overlay: transparent ring at rest; on hover the ring
 				     adopts the card's label-bg color so border and label read
 				     as the same hue. Inset so it paints crisply over the
-				     canvas + label. Thoughts card opts out (hoverless). -->
+				     canvas + label. -->
 				<div
-					class="pointer-events-none absolute inset-0 rounded-2xl ring-2 ring-transparent ring-inset transition-shadow duration-700 {ringHover}"
+					class="pointer-events-none absolute inset-0 rounded-2xl ring-2 ring-transparent ring-inset transition-shadow duration-700 {cream
+						? 'group-hover:ring-white'
+						: 'group-hover:ring-black'}"
 				></div>
 			</a>
 		{/each}


### PR DESCRIPTION
## Summary

Reverts the thoughts-card hoverless treatment from #187 — the tilt + ring belong on every card. The actual jank was on the canvas side:

- The gallery throttles every sketch to 30 fps while its strip auto-scrolls (sketch-host drops alternate frames via [shouldSkipThrottledFrame](https://github.com/threesam/garden/blob/main/src/lib/perf-flags.ts)).
- On hover the strip stops, throttle releases, and the day30 walkers' per-tick delta now gets applied at 60 fps — visually doubling their speed.

day30 now reads `isCanvasThrottled()` inside its tick and doubles its movement `speedScale` while throttled, so perceived speed stays constant across the hover transition.

Same pattern is available for any other gallery sketch that wants flat visual speed under the autoscroll throttle.

## Test plan

- [x] On `/`, hover the thoughts card — tilt + ring fire, walker speed stays visually constant
- [x] All other cards continue to tilt+ring on hover
- [x] `/thoughts` route unaffected (no gallery → `isCanvasThrottled()` stays false → no double scaling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)