### PR TITLE
perf(hp gallery): dt-based cursor physics + analog pointSize back to 1

### DIFF
--- a/src/lib/components/canvas/actions/metaball.ts
+++ b/src/lib/components/canvas/actions/metaball.ts
@@ -189,12 +189,19 @@ export const metaball: Action<HTMLCanvasElement, MetaballParams> = (node, initia
   let raf = 0;
   let isVisible = true;
   const t0 = performance.now();
+  let lastTickT = performance.now();
 
   function tick() {
     raf = 0;
     if (!isVisible) return;
     const now = performance.now();
     const t = (now - t0) / 1000;
+    // dt expressed in 60fps-frame units, clamped so a tab-switch resume
+    // doesn't fling balls across the canvas. Lets mobile (30fps) feel
+    // as snappy as desktop (60fps): each tick integrates two frames'
+    // worth of attract impulse + damping.
+    const dt = Math.min((now - lastTickT) / 16.67, 3);
+    lastTickT = now;
 
     let attractX = 0;
     let attractY = 0;
@@ -218,22 +225,24 @@ export const metaball: Action<HTMLCanvasElement, MetaballParams> = (node, initia
         // Stiffer attract + lower velocity damping so blobs coalesce
         // around the cursor in ~200 ms instead of the old ~600 ms drift.
         // Tangent stays gentler than radial — keeps the spiral readable.
-        b.vx += (dx / dist) * 0.35;
-        b.vy += (dy / dist) * 0.35;
-        b.vx += (-dy / dist) * 0.14;
-        b.vy += (dx / dist) * 0.14;
-        b.vx *= 0.88;
-        b.vy *= 0.88;
+        b.vx += (dx / dist) * 0.35 * dt;
+        b.vy += (dy / dist) * 0.35 * dt;
+        b.vx += (-dy / dist) * 0.14 * dt;
+        b.vy += (dx / dist) * 0.14 * dt;
+        const damp = Math.pow(0.88, dt);
+        b.vx *= damp;
+        b.vy *= damp;
       } else {
         const speed = Math.sqrt(b.vx * b.vx + b.vy * b.vy);
         if (speed > 1.3) {
-          b.vx *= 0.98;
-          b.vy *= 0.98;
+          const d = Math.pow(0.98, dt);
+          b.vx *= d;
+          b.vy *= d;
         }
       }
 
-      b.x += b.vx;
-      b.y += b.vy;
+      b.x += b.vx * dt;
+      b.y += b.vy * dt;
       if (b.x < 0 || b.x > w) b.vx *= -1;
       if (b.y < 0 || b.y > h) b.vy *= -1;
     }

--- a/src/lib/components/canvas/actions/particle-text.ts
+++ b/src/lib/components/canvas/actions/particle-text.ts
@@ -33,6 +33,7 @@ in vec2 a_velocity;
 
 uniform vec2 u_resolution;
 uniform vec2 u_mouse;
+uniform float u_dt;
 uniform sampler2D u_collision;
 
 out vec2 v_position;
@@ -49,12 +50,15 @@ void main() {
     if (distSq < radiusSq && distSq > 0.5) {
       float dist = sqrt(distSq);
       float falloff = 1.0 - dist / ${glf(repelRadius)};
-      float force = falloff * falloff * ${glf(REPEL_STRENGTH)};
+      // u_dt expressed in 60fps-frame units — at 30fps it's 2, so each tick
+      // integrates two frames of repel impulse + position advance. Keeps the
+      // cursor responsiveness frame-rate independent.
+      float force = falloff * falloff * ${glf(REPEL_STRENGTH)} * u_dt;
       vel += (diff / dist) * force;
     }
   }
 
-  pos += vel;
+  pos += vel * u_dt;
 
   vec2 uv = pos / u_resolution;
   if (uv.x >= 0.0 && uv.x <= 1.0 && uv.y >= 0.0 && uv.y <= 1.0) {
@@ -237,6 +241,7 @@ export const particleText: Action<HTMLCanvasElement, ParticleTextParams> = (node
   let uU = {
     resolution: null as WebGLUniformLocation | null,
     mouse: null as WebGLUniformLocation | null,
+    dt: null as WebGLUniformLocation | null,
     collision: null as WebGLUniformLocation | null,
   };
   let rA = { position: -1, color: -1 };
@@ -275,6 +280,7 @@ export const particleText: Action<HTMLCanvasElement, ParticleTextParams> = (node
     uU = {
       resolution: gl.getUniformLocation(updateProg, 'u_resolution'),
       mouse: gl.getUniformLocation(updateProg, 'u_mouse'),
+      dt: gl.getUniformLocation(updateProg, 'u_dt'),
       collision: gl.getUniformLocation(updateProg, 'u_collision'),
     };
     rA = {
@@ -568,9 +574,18 @@ export const particleText: Action<HTMLCanvasElement, ParticleTextParams> = (node
     updateRect();
   }
 
+  let lastTickT = performance.now();
+
   function tick() {
     rafId = 0;
     if (!gl || !particlesInitialized || !textTexture || !isVisible) return;
+
+    const now = performance.now();
+    // dt in 60fps-frame units, clamped so a tab-switch resume doesn't
+    // teleport particles. Lets mobile (30fps) feel as snappy as desktop:
+    // shader integrates two frames of repel + advance per tick.
+    const dt = Math.min((now - lastTickT) / 16.67, 3);
+    lastTickT = now;
 
     const inIdx = activeIdx;
     const outIdx = animate ? 1 - activeIdx : activeIdx;
@@ -579,6 +594,7 @@ export const particleText: Action<HTMLCanvasElement, ParticleTextParams> = (node
       gl.useProgram(updateProg);
       gl.uniform2f(uU.resolution, w, h);
       gl.uniform2f(uU.mouse, mouseX, mouseY);
+      gl.uniform1f(uU.dt, dt);
       gl.uniform1i(uU.collision, 0);
       gl.activeTexture(gl.TEXTURE0);
       gl.bindTexture(gl.TEXTURE_2D, textTexture);

--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -326,17 +326,15 @@
 									     bright glowing forms regardless of which book is featured. -->
 									<CanvasComp color={[245 / 255, 244 / 255, 240 / 255]} />
 								{:else if item.handle === 'anything-but-analog'}
-									<!-- Card-scale particle field: 1500 (was 4000) at point
-									     size 3 (was 2). Same visual density on a ~280 px card
-									     at ~60 % of the per-frame physics cost — particle
-									     repel is O(n) per frame.
-									     color: brand --black (rgb 26,26,20) — matches the day21
-									     ABA sketch palette so the homepage tile reads as a
-									     preview of the route's primary sketch. -->
+									<!-- Card-scale particle field, 1500 dots in brand --black
+									     (rgb 26,26,20) so the homepage tile reads as a preview
+									     of the day21 ABA sketch palette. pointSize back to 1 —
+									     3 was too chunky and read as distracting blobs at this
+									     card size. -->
 									<CanvasComp
 										countOverride={1500}
 										hideText
-										pointSize={3}
+										pointSize={1}
 										repelRadius={40}
 										lowDpr
 										color={[26, 26, 20]}


### PR DESCRIPTION
## Summary

Mobile-side cursor lag on shelf + analog cards: the per-frame constants from #189 felt right at 60 fps desktop but each impulse arrived half as often at 30 fps phone. Switch both canvases to dt-based integration so per-second responsiveness is frame-rate independent.

- **metaball.ts**: track `lastTickT`, compute `dt = (now - lastTickT) / 16.67` clamped `[0, 3]`. Scale attract/orbit impulses, damping power, and position step by `dt`. 60 fps → `dt=1` (identical to before); 30 fps → `dt=2`.
- **particle-text.ts**: add `u_dt` uniform on the update program. Scale the repel impulse and position advance by `u_dt` in the transform-feedback vertex shader.
- **Gallery.svelte**: analog card `pointSize` `3 → 1` — three was too chunky for the ~280 px card and read as distracting blobs.

## Test plan

- [x] Local build clean
- [ ] Prod deploy succeeds
- [ ] Visually verify analog dots are smaller / fine field
- [ ] Verify cursor responsiveness flat across CPU throttle levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)