### PR TITLE
style(deana): desktop scroll-snap on fullscreen ASCII sections

### DIFF
--- a/src/lib/components/messages/AsciiImageSection.svelte
+++ b/src/lib/components/messages/AsciiImageSection.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <section
-	class="relative h-dvh w-full overflow-hidden bg-white"
+	class="relative h-dvh w-full overflow-hidden bg-white lg:snap-start"
 	style="content-visibility: auto; contain-intrinsic-size: 100vw 100dvh;"
 >
 	<img

--- a/src/routes/deana/+page.svelte
+++ b/src/routes/deana/+page.svelte
@@ -41,7 +41,11 @@
   })}
 />
 
-<main class="bg-white">
+<!-- Desktop scroll-snap: main becomes a contained scroller at lg+ and the
+     full-screen AsciiImageSections snap into view (proximity, so tall data
+     sections in between scroll freely). Mobile leaves it as native document
+     scroll — snap-mandatory on touch reads as fighty. -->
+<main class="bg-white lg:h-dvh lg:overflow-y-auto lg:snap-y lg:snap-proximity">
   <AsciiImageSection ascii={DEANA_ASCII[0]} eager />
 
   <section class="w-full bg-white px-3 py-12 md:px-6 md:py-24">


### PR DESCRIPTION
At lg+ `<main>` becomes a contained scroller (h-dvh + overflow-y-auto) with `scroll-snap-type: y proximity`, each AsciiImageSection gets `scroll-snap-align: start`. Full-screen hero photos snap into view; data sections between them stay free-scroll (proximity only snaps when nearby). Mobile stays native document scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)