### PR TITLE
refactor(img): extract <Img> component with fade-in + LCP gate

### DIFF
--- a/src/lib/components/Img.svelte
+++ b/src/lib/components/Img.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	interface Props {
+		src: string;
+		srcset?: string;
+		sizes?: string;
+		alt?: string;
+		/** When true: load eager, fetchpriority high, AND start visible (no fade
+		 *  gate). The fade would otherwise hide the LCP candidate behind itself. */
+		eager?: boolean;
+		decoding?: 'sync' | 'async' | 'auto';
+		width?: number | string;
+		height?: number | string;
+		fadeMs?: number;
+		class?: string;
+	}
+
+	let {
+		src,
+		srcset,
+		sizes,
+		alt = '',
+		eager = false,
+		decoding = 'async',
+		width,
+		height,
+		fadeMs = 700,
+		class: className = '',
+	}: Props = $props();
+
+	// Eager (LCP candidate) always shows; lazy gates the reveal on the img's
+	// load event so a scrolled-to image never flashes a half-decoded frame.
+	let hasLoaded = $state(false);
+	let visible = $derived(eager || hasLoaded);
+</script>
+
+<img
+	{src}
+	{srcset}
+	{sizes}
+	{alt}
+	{decoding}
+	{width}
+	{height}
+	loading={eager ? 'eager' : 'lazy'}
+	fetchpriority={eager ? 'high' : 'auto'}
+	onload={() => (hasLoaded = true)}
+	class="transition-opacity ease-out {className}"
+	style:opacity={visible ? 1 : 0}
+	style:transition-duration="{fadeMs}ms"
+/>

--- a/src/lib/components/messages/AsciiImageSection.svelte
+++ b/src/lib/components/messages/AsciiImageSection.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import DanaLabel from './DanaLabel.svelte';
+	import Img from '$lib/components/Img.svelte';
 	import { asciiSrcset, type AsciiSrc } from '$lib/deana/images';
 
 	interface Props {
@@ -10,28 +11,18 @@
 	}
 
 	let { ascii, eager = false }: Props = $props();
-
-	// Lazy sections gate visual reveal on the img's load event so a scrolled-to
-	// section never flashes a half-decoded frame. The eager hero skips the gate
-	// — hiding the LCP candidate behind a 700 ms fade would tank the score.
-	let loaded = $state(eager);
 </script>
 
 <section
 	class="relative h-dvh w-full overflow-hidden bg-white"
 	style="content-visibility: auto; contain-intrinsic-size: 100vw 100dvh;"
 >
-	<img
+	<Img
 		src={ascii.lg}
 		srcset={asciiSrcset(ascii)}
 		sizes="100vw"
-		alt=""
-		loading={eager ? 'eager' : 'lazy'}
-		fetchpriority={eager ? 'high' : 'auto'}
-		decoding="async"
-		onload={() => (loaded = true)}
-		class="absolute inset-0 h-full w-full object-cover transition-opacity duration-700 ease-out"
-		style:opacity={loaded ? 1 : 0}
+		{eager}
+		class="absolute inset-0 h-full w-full object-cover"
 	/>
 	<span
 		class="pointer-events-none absolute bottom-6 left-6 z-10 font-mono text-2xl font-bold uppercase tracking-pill text-black md:bottom-10 md:left-10 md:text-5xl"


### PR DESCRIPTION
Lifts the fade-in pattern out of AsciiImageSection into `$lib/components/Img.svelte`. Same behaviour:
- `eager` → loading=eager, fetchpriority=high, AND skips the fade (LCP candidate paints unhidden)
- lazy → fades in 700 ms on `load` event (bitmap-ready)

Derived shape avoids the local-prop capture warning the svelte autofixer flags on `let loaded = $state(eager)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)