### PR TITLE
refactor(img): use <Img> for shelf grid + sounds covers

### DIFF
--- a/src/lib/components/Img.svelte
+++ b/src/lib/components/Img.svelte
@@ -11,7 +11,10 @@
 		width?: number | string;
 		height?: number | string;
 		fadeMs?: number;
+		draggable?: boolean;
+		onerror?: (e: Event) => void;
 		class?: string;
+		style?: string;
 	}
 
 	let {
@@ -24,7 +27,10 @@
 		width,
 		height,
 		fadeMs = 700,
+		draggable,
+		onerror,
 		class: className = '',
+		style = '',
 	}: Props = $props();
 
 	// Eager (LCP candidate) always shows; lazy gates the reveal on the img's
@@ -41,10 +47,11 @@
 	{decoding}
 	{width}
 	{height}
+	{draggable}
+	{onerror}
 	loading={eager ? 'eager' : 'lazy'}
 	fetchpriority={eager ? 'high' : 'auto'}
 	onload={() => (hasLoaded = true)}
 	class="transition-opacity ease-out {className}"
-	style:opacity={visible ? 1 : 0}
-	style:transition-duration="{fadeMs}ms"
+	style="opacity: {visible ? 1 : 0}; transition-duration: {fadeMs}ms; {style}"
 />

--- a/src/routes/shelf/+page.svelte
+++ b/src/routes/shelf/+page.svelte
@@ -3,6 +3,7 @@
   import { collectionPageNode } from "$lib/seo";
   import ShelfHero from "$lib/components/ShelfHero.svelte";
   import { proxyImg } from "$lib/img";
+  import Img from "$lib/components/Img.svelte";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -43,12 +44,11 @@
         class="group relative block break-inside-avoid p-1.5 md:transition-[background-color,box-shadow] md:duration-300 md:ease-out md:hover:z-10 md:hover:bg-coin md:hover:shadow-[0_0_0_4px_var(--coin)]"
       >
         {#if book.coverUrl}
-          <img
+          <Img
             src={proxyImg(book.coverUrl, 320)}
             alt={book.cleanTitle}
             width={book.coverW ?? 200}
             height={book.coverH ?? 300}
-            loading="lazy"
             class="block h-auto w-full md:transition-[filter] md:duration-300 md:group-hover:grayscale"
           />
         {:else}

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -6,6 +6,7 @@
   import { player, attach, playTrack, toggle, seek, setScrubbing } from "$lib/sounds/player.svelte";
   import type { PageData } from "./$types";
   import type { Cue, Song } from "$lib/sounds/types";
+  import Img from "$lib/components/Img.svelte";
 
   let { data }: { data: PageData } = $props();
   let { manifest, base } = $derived(data);
@@ -261,13 +262,11 @@
         <div class="card" style="--rot:{fan(i)}deg; z-index:{40 - i};">
           <span class="ph">?</span>
           {#if t.cover}
-            <img
+            <Img
               src={coverUrl(t.cover)}
               alt=""
-              draggable="false"
-              loading={featured && i === 0 ? 'eager' : 'lazy'}
-              decoding="async"
-              fetchpriority={featured && i === 0 ? 'high' : 'low'}
+              draggable={false}
+              eager={featured && i === 0}
               onerror={imgErr}
             />
           {/if}
@@ -303,12 +302,9 @@
     <div class="hmbm-poster">
       <span class="hmbm-poster-ph" aria-hidden="true">?</span>
       {#if HMBM_FILM.poster}
-        <img
+        <Img
           src={coverUrl(HMBM_FILM.poster)}
           alt="how many blind mice? — film poster"
-          loading="lazy"
-          decoding="async"
-          fetchpriority="low"
           onerror={imgErr}
         />
       {/if}


### PR DESCRIPTION
Extends `<Img>` with `onerror`, `draggable`, and `style` pass-through. Swaps:
- /shelf grid book covers
- /sounds song tile covers (featured && i === 0 maps to `eager`)
- /sounds HMBM film poster

ShelfHero's featured cover stays raw `<img>` — needs `bind:this` for the shadow-color pixel read, which Img doesn't forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)