### PR TITLE
chore(favicon): bump cache-bust v=2 → v=3

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,9 +5,9 @@
     <!-- SVG favicon scales for any tab/bookmark size; .ico fallback covers
          older browsers; apple-touch-icon is what iOS uses for home-screen
          and share previews. ?v=N busts the prior EyeOcean-eye cache. -->
-    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg?v=2" />
-    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico?v=2" />
-    <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png?v=2" />
+    <link rel="icon" type="image/svg+xml" href="%sveltekit.assets%/favicon.svg?v=3" />
+    <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico?v=3" />
+    <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png?v=3" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     %sveltekit.head%
   </head>


### PR DESCRIPTION
Browser cache showing stale favicon. Files on disk are correct; query string bump forces re-fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)