### PR TITLE
fix(voronoi): black bg holds until canvas is ready (no flash)

### DIFF
--- a/src/lib/components/canvas/VoronoiCanvas.svelte
+++ b/src/lib/components/canvas/VoronoiCanvas.svelte
@@ -14,6 +14,11 @@
     renderScale = 1,
   }: Props = $props();
 
+  // Canvas starts hidden; the voronoi action fires onReady after the texture
+  // upload + first real frame so we can fade in instead of flashing the
+  // gradient-cells path while the image decodes.
+  let ready = $state(false);
+
   const params: VoronoiParams = $derived({
     invert,
     showLetters,
@@ -22,14 +27,19 @@
     scale,
     fit,
     renderScale,
+    onReady: () => (ready = true),
   });
 </script>
 
-<!-- `bg-black` (--black) sits behind the canvas so any uncovered area
-     during mount/load shows the warm brand dark instead of whatever
-     the container happens to be — voronoi instances always read as
-     "on dark". `object-cover` lets the canvas crop-fill the container
-     when the pixel buffer aspect ratio doesn't match. -->
+<!-- bg-black sits behind the canvas so the pre-ready frames show the warm
+     brand dark instead of whatever the container or page happens to be —
+     voronoi instances always read as "on dark". object-cover lets the
+     canvas crop-fill the container when the buffer aspect ratio doesn't
+     match. -->
 <div class="absolute inset-0 bg-black">
-  <canvas class="absolute inset-0 h-full w-full object-cover" use:voronoi={params}></canvas>
+  <canvas
+    class="absolute inset-0 h-full w-full object-cover transition-opacity duration-500 ease-out"
+    style:opacity={ready ? 1 : 0}
+    use:voronoi={params}
+  ></canvas>
 </div>

--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -248,6 +248,11 @@ export interface VoronoiParams {
   scale?: number;
   fit?: 'contain' | 'cover';
   renderScale?: number;
+  /** Fires once the canvas has painted its first real frame — after the
+   *  image-backed texture is uploaded if imageSrc is set, or immediately
+   *  on the gradient-only path otherwise. Callers can flip an opacity
+   *  transition here to avoid the gradient-then-image flash. */
+  onReady?: () => void;
 }
 
 export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialParams) => {
@@ -260,6 +265,7 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
     scale,
     fit = 'contain',
     renderScale = 1,
+    onReady,
   } = params;
 
   const activeImageSrc =
@@ -276,6 +282,12 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
   let hovering = false;
   let dragging = false;
   let influence = 0;
+  // Image-backed instances skip rendering until the texture is uploaded —
+  // otherwise the shader's gradient cells flash on screen for a frame or
+  // two before the image-sampling path takes over. Gradient-only instances
+  // (no imageSrc) flip this true at init so they paint immediately.
+  let imageReady = !activeImageSrc;
+  let readyFired = false;
   const mouseUv = { x: -10, y: -10 };
   const smoothMouse = { x: -10, y: -10 };
 
@@ -358,6 +370,7 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
       gl.uniform1f(uImageAspect, img.width / img.height);
       gl.uniform1f(uHasImage, 1.0);
+      imageReady = true;
       needsRender = true;
       if (visible && !raf) raf = requestAnimationFrame(render);
     };
@@ -447,11 +460,17 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
       Math.abs(smoothMouse.x - prevMx) > 0.0005 ||
       Math.abs(smoothMouse.y - prevMy) > 0.0005;
 
+    if (!imageReady) return;
+
     if (changed || needsRender) {
       needsRender = false;
       gl.uniform1f(uInfluence, influence);
       gl.uniform2f(uMouse, smoothMouse.x, smoothMouse.y);
       gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+      if (!readyFired) {
+        readyFired = true;
+        onReady?.();
+      }
     }
   }
 


### PR DESCRIPTION
Image-backed voronoi instances flashed the gradient-cell path for a frame or two before the texture upload completed. Most visible on the /self hero on mobile.

- `voronoi` action: render gated on `imageReady`; new `onReady` callback fires after first `drawArrays`
- `VoronoiCanvas`: canvas starts opacity 0, fades to 1 on `onReady`. bg-black wrapper holds underneath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)