### PR TITLE
style(hp gallery): analog card pointSize 1 → 2

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -335,7 +335,7 @@
 									<CanvasComp
 										countOverride={1500}
 										hideText
-										pointSize={1}
+										pointSize={2}
 										repelRadius={40}
 										lowDpr
 										color={[26, 26, 20]}


### PR DESCRIPTION
Doubles the particle dots so they register at card scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)