### PR TITLE
style(hp gallery): analog card double the particles (not size)

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -333,9 +333,9 @@
 									     (rgb 26,26,20) so the homepage tile reads as a preview
 									     of the day21 ABA sketch palette. -->
 									<CanvasComp
-										countOverride={1500}
+										countOverride={3000}
 										hideText
-										pointSize={2}
+										pointSize={1}
 										repelRadius={40}
 										lowDpr
 										color={[26, 26, 20]}


### PR DESCRIPTION
Reverts pointSize 2 → 1 and bumps countOverride 1500 → 3000. Denser dot field, same dot size as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)