### PR TITLE
style(hp gallery): analog card particles 3000 → 6000

### DIFF
--- a/src/lib/components/gallery/Gallery.svelte
+++ b/src/lib/components/gallery/Gallery.svelte
@@ -333,7 +333,7 @@
 									     (rgb 26,26,20) so the homepage tile reads as a preview
 									     of the day21 ABA sketch palette. -->
 									<CanvasComp
-										countOverride={3000}
+										countOverride={6000}
 										hideText
 										pointSize={1}
 										repelRadius={40}


### PR DESCRIPTION
Another 2× to keep the field looking dense. Cost is trivial — pure GPU transform-feedback work, no JS-side per-particle update. /anything-but-analog already runs at 200k–320k on the route, so 6k on a card has generous headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)