### PR TITLE
feat(snake): click the s in threesam to play snake

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -8,30 +8,67 @@
   // `tone` flips the text colour: 'dark' (--black) over the coin homepage,
   // 'light' (--white) over the Anchor's dark cloud-footer bottom.
   // The parent must be positioned (relative) — the corners anchor to it.
-  let { heading = false, tone = 'dark' }: { heading?: boolean; tone?: 'dark' | 'light' } =
-    $props();
+  // `gameClickable` exposes the snake-game easter egg: clicking the "s"
+  // toggles gameMode and triggers the letter-collapse → "snake" sequence.
+  import { gameMode } from '$lib/game-mode.svelte';
+
+  let {
+    heading = false,
+    tone = 'dark',
+    gameClickable = false,
+  }: { heading?: boolean; tone?: 'dark' | 'light'; gameClickable?: boolean } = $props();
   const tag = $derived(heading ? 'h1' : 'div');
   const color = $derived(tone === 'light' ? 'text-white' : 'text-black');
+
+  // "threesam" + the inert "n a k e" tail. Each letter is a flex item; when
+  // game mode is active the original t/h/r/e/e/a/m collapse (opacity 0,
+  // max-width 0) so the "s" slides to the start, then the trailing n/a/k/e
+  // expand from max-width 0 to spell "snake".
+  const PRE_LETTERS = ['t', 'h', 'r', 'e', 'e'];
+  const POST_LETTERS = ['a', 'm'];
+  const SNAKE_TAIL = ['n', 'a', 'k', 'e'];
+  const active = $derived(gameMode.active);
 </script>
 
 <svelte:element
   this={tag}
-  class="absolute bottom-6 left-6 z-10 font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
+  class="wordmark absolute bottom-6 left-6 z-10 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
+  class:is-game={active}
 >
-  threesam
+  {#each PRE_LETTERS as l, i (`pre-${i}`)}
+    <span class="letter">{l}</span>
+  {/each}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <span
+    class="letter s-letter"
+    class:clickable={gameClickable && !active}
+    onclick={gameClickable ? () => (active ? gameMode.stop() : gameMode.start()) : undefined}
+    role={gameClickable ? 'button' : undefined}
+    tabindex={gameClickable ? 0 : undefined}
+    onkeydown={gameClickable
+      ? (e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            if (active) gameMode.stop();
+            else gameMode.start();
+          }
+        }
+      : undefined}
+  >s</span>
+  {#each POST_LETTERS as l, i (`post-${i}`)}
+    <span class="letter">{l}</span>
+  {/each}
+  {#each SNAKE_TAIL as l, i (`tail-${i}`)}
+    <span class="tail" style="--tail-delay: {200 + i * 130}ms">{l}</span>
+  {/each}
 </svelte:element>
-<!-- Tagline is always anchored bottom-right. Stacks one word per line on
-     mobile (where horizontal room is tight); collapses back to a single
-     line on md+. On md+ an alien sits between the two words at 0 width
-     and fades in on hover, pushing "certainly" leftward as it expands. -->
+<!-- Tagline (anchored bottom-right) — unchanged, with the alien gag from
+     PR #215 still kicking in on hover. -->
 <p
   class="tagline absolute right-6 bottom-6 z-10 text-right font-mono text-sm leading-tight tracking-hero {color} md:right-8 md:bottom-8 md:text-base"
 >
   <span class="block md:inline">certainly</span><span class="alien" aria-hidden="true"
     ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-      <!-- Classic gray-alien head: rounded teardrop body, two angled almond
-           eyes. Body uses currentColor so it matches the tone prop; eyes
-           stay coin so the glyph reads as alien even over dark surrounds. -->
       <path
         fill="currentColor"
         d="M16 3c5.7 0 9.5 3.6 9.5 9 0 5.6-4 16-9.5 16S6.5 17.6 6.5 12c0-5.4 3.8-9 9.5-9z"
@@ -42,10 +79,41 @@
 </p>
 
 <style>
-  /* The alien collapses to zero on rest so the tagline reads as plain text.
-     On hover it expands to ~1.4em, opacity ramps from 0→1, sliding "certainly"
-     out of the way. Hidden entirely on mobile — the tagline wraps to two
-     lines there and the gag is desktop-only. */
+  .wordmark {
+    align-items: baseline;
+  }
+  .letter,
+  .tail {
+    display: inline-block;
+    overflow: hidden;
+    white-space: pre;
+    transition:
+      max-width 450ms cubic-bezier(0.4, 0, 0.2, 1),
+      opacity 350ms ease-out;
+    max-width: 1em;
+    opacity: 1;
+  }
+  /* Trailing snake letters start collapsed and silent. */
+  .tail {
+    max-width: 0;
+    opacity: 0;
+    transition-delay: 0ms;
+  }
+  .s-letter.clickable {
+    cursor: pointer;
+  }
+  /* GAME ACTIVE — every non-s letter collapses; the snake tail expands
+     with staggered delays so the wordmark reads "s" → "snake". */
+  .is-game .letter:not(.s-letter) {
+    max-width: 0;
+    opacity: 0;
+  }
+  .is-game .tail {
+    max-width: 1em;
+    opacity: 1;
+    transition-delay: var(--tail-delay, 0ms);
+  }
+  /* Alien hover gag preserved from #215 */
   .alien {
     display: none;
     vertical-align: middle;
@@ -71,6 +139,8 @@
     }
   }
   @media (prefers-reduced-motion: reduce) {
+    .letter,
+    .tail,
     .alien {
       transition: none;
     }

--- a/src/lib/components/frame/Guide.svelte
+++ b/src/lib/components/frame/Guide.svelte
@@ -1,12 +1,21 @@
 <script lang="ts">
   import { preloadCode } from '$app/navigation';
   import { NAV_ROUTES } from '$lib/nav';
+  import { gameMode } from '$lib/game-mode.svelte';
 
   let open = $state(false);
   let hovered = $state(false);
   let locked = $state(false);
+  // Snake game on the homepage: the back face's rotated "+" is already an
+  // "x" glyph, so we reuse it. When the game is active, clicking the coin
+  // quits the game instead of opening the nav menu.
+  const inGame = $derived(gameMode.active);
 
   function handleCoinClick() {
+    if (inGame) {
+      gameMode.stop();
+      return;
+    }
     open = !open;
     if (!open) {
       hovered = false;
@@ -15,6 +24,7 @@
   }
 
   function handleCoinMouseEnter() {
+    if (inGame) return;
     if (!locked) hovered = true;
     // Warm all route JS chunks on first coin hover — no-op on subsequent calls.
     for (const r of NAV_ROUTES) {
@@ -29,6 +39,7 @@
 
   // Derived coin transform — no nested ternary.
   const coinTransform = $derived((() => {
+    if (inGame) return 'rotateY(180deg) rotate(45deg)';
     if (open) return 'rotateY(180deg) rotate(45deg)';
     if (hovered) return 'rotateY(180deg)';
     return 'rotateY(0deg)';

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -1,0 +1,194 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { gameMode } from '$lib/game-mode.svelte';
+
+	// Snake game. Coin (yellow) page bg shines through; the snake + food
+	// render in --black on a fully-transparent canvas. Keyboard arrows or
+	// WASD to steer on desktop; swipe gestures on touch.
+
+	const CELL = 24;
+	let canvas: HTMLCanvasElement | undefined = $state();
+	let cols = $state(20);
+	let rows = $state(20);
+	let snake = $state<Array<[number, number]>>([]);
+	let dir = $state<[number, number]>([1, 0]);
+	let pendingDir = $state<[number, number]>([1, 0]);
+	let food = $state<[number, number]>([0, 0]);
+	let score = $state(0);
+	let gameOver = $state(false);
+
+	const TICK_MS = 110;
+
+	function reset() {
+		const cx = Math.floor(cols / 2);
+		const cy = Math.floor(rows / 2);
+		snake = [
+			[cx, cy],
+			[cx - 1, cy],
+			[cx - 2, cy],
+		];
+		dir = [1, 0];
+		pendingDir = [1, 0];
+		score = 0;
+		gameOver = false;
+		placeFood();
+	}
+
+	function placeFood() {
+		const occupied = new Set(snake.map(([x, y]) => `${x},${y}`));
+		const free: Array<[number, number]> = [];
+		for (let x = 0; x < cols; x++) {
+			for (let y = 0; y < rows; y++) {
+				if (!occupied.has(`${x},${y}`)) free.push([x, y]);
+			}
+		}
+		if (free.length === 0) return;
+		food = free[Math.floor(Math.random() * free.length)];
+	}
+
+	function step() {
+		if (gameOver) return;
+		dir = pendingDir;
+		const head: [number, number] = [snake[0][0] + dir[0], snake[0][1] + dir[1]];
+		if (head[0] < 0 || head[0] >= cols || head[1] < 0 || head[1] >= rows) {
+			gameOver = true;
+			return;
+		}
+		for (const [sx, sy] of snake) {
+			if (sx === head[0] && sy === head[1]) {
+				gameOver = true;
+				return;
+			}
+		}
+		snake = [head, ...snake];
+		if (head[0] === food[0] && head[1] === food[1]) {
+			score += 1;
+			placeFood();
+		} else {
+			snake = snake.slice(0, -1);
+		}
+	}
+
+	function draw() {
+		if (!canvas) return;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		const dpr = window.devicePixelRatio || 1;
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+		ctx.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
+		ctx.fillStyle = '#1a1a14';
+		const pad = 2;
+		for (const [x, y] of snake) {
+			ctx.fillRect(x * CELL + pad, y * CELL + pad, CELL - pad * 2, CELL - pad * 2);
+		}
+		const [fx, fy] = food;
+		ctx.beginPath();
+		ctx.arc(fx * CELL + CELL / 2, fy * CELL + CELL / 2, CELL / 2 - 4, 0, Math.PI * 2);
+		ctx.fill();
+	}
+
+	function setDir(d: [number, number]) {
+		if (gameOver) return;
+		if (d[0] === -dir[0] && d[1] === -dir[1]) return;
+		pendingDir = d;
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (!gameMode.active) return;
+		if (e.key === 'ArrowUp' || e.key === 'w' || e.key === 'W') setDir([0, -1]);
+		else if (e.key === 'ArrowDown' || e.key === 's' || e.key === 'S') setDir([0, 1]);
+		else if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') setDir([-1, 0]);
+		else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') setDir([1, 0]);
+		else if (e.key === 'r' || e.key === 'R') reset();
+		else if (e.key === 'Escape') gameMode.stop();
+		else return;
+		e.preventDefault();
+	}
+
+	let touchStart: { x: number; y: number } | null = null;
+	function onTouchStart(e: TouchEvent) {
+		const t = e.touches[0];
+		if (t) touchStart = { x: t.clientX, y: t.clientY };
+	}
+	function onTouchEnd(e: TouchEvent) {
+		if (!touchStart) return;
+		const t = e.changedTouches[0];
+		if (!t) return;
+		const dx = t.clientX - touchStart.x;
+		const dy = t.clientY - touchStart.y;
+		touchStart = null;
+		if (Math.abs(dx) < 20 && Math.abs(dy) < 20) return;
+		if (Math.abs(dx) > Math.abs(dy)) setDir([dx > 0 ? 1 : -1, 0]);
+		else setDir([0, dy > 0 ? 1 : -1]);
+	}
+
+	function resize() {
+		if (!canvas) return;
+		const w = window.innerWidth;
+		const h = window.innerHeight;
+		cols = Math.max(8, Math.floor(w / CELL));
+		rows = Math.max(8, Math.floor(h / CELL));
+		const dpr = window.devicePixelRatio || 1;
+		canvas.width = cols * CELL * dpr;
+		canvas.height = rows * CELL * dpr;
+		canvas.style.width = `${cols * CELL}px`;
+		canvas.style.height = `${rows * CELL}px`;
+		// Snap snake + food into the new grid if they're out of range.
+		if (snake.length === 0 || snake.some(([x, y]) => x >= cols || y >= rows)) reset();
+		else if (food[0] >= cols || food[1] >= rows) placeFood();
+		draw();
+	}
+
+	onMount(() => {
+		resize();
+		window.addEventListener('keydown', onKey);
+		window.addEventListener('resize', resize);
+		const id = window.setInterval(() => {
+			step();
+			draw();
+		}, TICK_MS);
+		return () => {
+			window.clearInterval(id);
+			window.removeEventListener('keydown', onKey);
+			window.removeEventListener('resize', resize);
+		};
+	});
+
+	$effect(() => {
+		// Redraw whenever reactive state changes that draw() reads
+		void snake;
+		void food;
+		void gameOver;
+		draw();
+	});
+</script>
+
+<div
+	class="fixed inset-0 z-40 grid place-items-center bg-[var(--coin)]"
+	role="application"
+	aria-label="snake game"
+	ontouchstart={onTouchStart}
+	ontouchend={onTouchEnd}
+>
+	<canvas bind:this={canvas}></canvas>
+	{#if gameOver}
+		<div
+			class="pointer-events-auto absolute inset-x-0 top-1/2 -translate-y-1/2 grid place-items-center font-mono text-black"
+		>
+			<p class="mb-2 text-3xl font-bold tracking-pill uppercase">game over</p>
+			<p class="mb-4 text-base">score: {score}</p>
+			<button
+				class="rounded-full bg-black px-6 py-2 font-bold uppercase tracking-pill text-[var(--coin)] hover:bg-zinc-900"
+				onclick={reset}
+			>
+				play again
+			</button>
+		</div>
+	{:else}
+		<div
+			class="pointer-events-none absolute left-6 top-6 font-mono text-sm font-bold uppercase tracking-pill text-black md:left-8 md:top-8"
+		>
+			score: {score}
+		</div>
+	{/if}
+</div>

--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -1,0 +1,17 @@
+// Module-level reactive state for the "click the s" snake easter egg on
+// the homepage. BrandSignoff sets active=true when the wordmark's "s" is
+// clicked; Gallery, Guide, and the SnakeGame component all react.
+class GameMode {
+	active = $state(false);
+	start() {
+		this.active = true;
+	}
+	stop() {
+		this.active = false;
+	}
+	toggle() {
+		this.active = !this.active;
+	}
+}
+
+export const gameMode = new GameMode();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,8 @@
   import SeoHead from '$lib/components/SeoHead.svelte';
   import Gallery from '$lib/components/gallery/Gallery.svelte';
   import BrandSignoff from '$lib/components/frame/BrandSignoff.svelte';
+  import SnakeGame from '$lib/components/snake/SnakeGame.svelte';
+  import { gameMode } from '$lib/game-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
 
   // Structured site index for search + answer engines. Mirrors the
@@ -21,16 +23,25 @@
 
 <!--
   Single-viewport homepage on a flat --coin field: a 50dvh gallery strip
-  centered between 25dvh top/bottom spacers. No page scroll. The animated cloud
-  sky was retired for the homepage (no image fetched); the shared CloudCanvas
-  still runs elsewhere via the layout Anchor, which stays suppressed on `/`.
+  centered between 25dvh top/bottom spacers. No page scroll. Clicking the
+  "s" in the threesam wordmark triggers an easter-egg snake game that fades
+  the gallery, transforms "threesam" → "snake", and flips the menu coin into
+  an x glyph for quit. State lives in $lib/game-mode.
 -->
 <main class="relative flex h-dvh w-full flex-col overflow-hidden bg-coin">
   <div class="h-[25dvh] w-full"></div>
-  <div class="relative h-[50dvh] w-full">
+  <div
+    class="relative h-[50dvh] w-full transition-opacity duration-500 ease-out"
+    class:opacity-0={gameMode.active}
+    class:pointer-events-none={gameMode.active}
+  >
     <Gallery />
   </div>
   <div class="h-[25dvh] w-full"></div>
 
-  <BrandSignoff heading />
+  <BrandSignoff heading gameClickable />
+
+  {#if gameMode.active}
+    <SnakeGame />
+  {/if}
 </main>


### PR DESCRIPTION
Click the **s** in the homepage `threesam` wordmark to:

- Fade the gallery out
- Transform 'threesam' → 's' (anchored left) → letters n/a/k/e fade in to spell 'snake'
- Mount a fullscreen Snake game on the coin background (black snake, black food circle)
- Flip the menu coin to its x glyph (quit)

Arrow keys / WASD / swipe to steer. Esc or click the x to quit. R to restart on game-over.

Files:
- `$lib/game-mode.svelte.ts` — reactive gameMode singleton
- `$lib/components/snake/SnakeGame.svelte` — the game
- `BrandSignoff.svelte` — per-letter spans with collapse/expand transitions
- `Guide.svelte` — coin shows x glyph + quits on click while active
- `+page.svelte` — gallery fade-out + conditional SnakeGame mount

🤖 Generated with [Claude Code](https://claude.com/claude-code)