### PR TITLE
feat(snake): sequence the open/close (letters first, then game)

### DIFF
--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -1,16 +1,53 @@
 // Module-level reactive state for the "click the s" snake easter egg on
-// the homepage. BrandSignoff sets active=true when the wordmark's "s" is
-// clicked; Gallery, Guide, and the SnakeGame component all react.
+// the homepage.
+//
+// Two flags, intentionally split so the open/close UI sequences read in
+// the right order:
+//
+//   active        — wordmark "threesam → snake" letter animation runs
+//   gameMounted   — SnakeGame component is in the DOM (fades in/out
+//                   via Svelte's transition:fade on the wrapper)
+//
+// Opening:  active=true at click → 1200 ms later → gameMounted=true.
+//           So the letters finish their transition first, THEN the game
+//           fades up on top.
+//
+// Closing:  gameMounted=false at click → 500 ms later → active=false.
+//           Game fades out first, THEN the letters reverse back to
+//           "threesam".
+const OPEN_DELAY_MS = 1200;
+const CLOSE_DELAY_MS = 500;
+
 class GameMode {
 	active = $state(false);
+	gameMounted = $state(false);
+	private openTimer: number | null = null;
+	private closeTimer: number | null = null;
+
 	start() {
+		if (this.closeTimer !== null) {
+			clearTimeout(this.closeTimer);
+			this.closeTimer = null;
+		}
 		this.active = true;
+		if (this.openTimer !== null) clearTimeout(this.openTimer);
+		this.openTimer = window.setTimeout(() => {
+			this.gameMounted = true;
+			this.openTimer = null;
+		}, OPEN_DELAY_MS);
 	}
+
 	stop() {
-		this.active = false;
-	}
-	toggle() {
-		this.active = !this.active;
+		if (this.openTimer !== null) {
+			clearTimeout(this.openTimer);
+			this.openTimer = null;
+		}
+		this.gameMounted = false;
+		if (this.closeTimer !== null) clearTimeout(this.closeTimer);
+		this.closeTimer = window.setTimeout(() => {
+			this.active = false;
+			this.closeTimer = null;
+		}, CLOSE_DELAY_MS);
 	}
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import Gallery from '$lib/components/gallery/Gallery.svelte';
   import BrandSignoff from '$lib/components/frame/BrandSignoff.svelte';
   import SnakeGame from '$lib/components/snake/SnakeGame.svelte';
+  import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
 
@@ -41,7 +42,9 @@
 
   <BrandSignoff heading gameClickable />
 
-  {#if gameMode.active}
-    <SnakeGame />
+  {#if gameMode.gameMounted}
+    <div transition:fade={{ duration: 500 }}>
+      <SnakeGame />
+    </div>
   {/if}
 </main>


### PR DESCRIPTION
Splits gameMode into `active` (wordmark animation) + `gameMounted` (game in DOM, faded via transition:fade). 1200 ms delay between letters finishing and game appearing on open; 500 ms delay between game fading out and letters reversing on close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)