### PR TITLE
fix(snake): wordmark over game + tagline fade + button-tap fix

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -32,7 +32,7 @@
 
 <svelte:element
   this={tag}
-  class="wordmark absolute bottom-6 left-6 z-10 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
+  class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
@@ -62,10 +62,12 @@
     <span class="tail" style="--tail-delay: {200 + i * 130}ms">{l}</span>
   {/each}
 </svelte:element>
-<!-- Tagline (anchored bottom-right) — unchanged, with the alien gag from
-     PR #215 still kicking in on hover. -->
+<!-- Tagline (anchored bottom-right). Fades out at the same time as the
+     gallery while gameMode.active so "snake" + game read as the only
+     content. -->
 <p
   class="tagline absolute right-6 bottom-6 z-10 text-right font-mono text-sm leading-tight tracking-hero {color} md:right-8 md:bottom-8 md:text-base"
+  class:tagline-hidden={active}
 >
   <span class="block md:inline">certainly</span><span class="alien" aria-hidden="true"
     ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
@@ -101,6 +103,13 @@
   }
   .s-letter.clickable {
     cursor: pointer;
+  }
+  .tagline {
+    transition: opacity 500ms ease-out;
+  }
+  .tagline-hidden {
+    opacity: 0;
+    pointer-events: none;
   }
   /* GAME ACTIVE — every non-s letter collapses; the snake tail expands
      with staggered delays so the wordmark reads "s" → "snake". */

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -106,7 +106,16 @@
 	}
 
 	let touchStart: { x: number; y: number } | null = null;
+	// Buttons + other interactive controls inside the game (e.g. "play again"
+	// on the game-over overlay) need touchstart→click to fire. preventDefault
+	// on touchstart kills that synthetic click on iOS, so we skip the swipe
+	// handler entirely when the touch begins on an interactive descendant.
+	function isInteractiveTarget(target: EventTarget | null): boolean {
+		const el = target as HTMLElement | null;
+		return !!el?.closest('button, a, [role="button"]');
+	}
 	function onTouchStart(e: TouchEvent) {
+		if (isInteractiveTarget(e.target)) return;
 		// preventDefault on touchstart cancels Arc/Safari's edge-swipe-back
 		// gesture from competing with our left/right swipes.
 		e.preventDefault();
@@ -114,11 +123,13 @@
 		if (t) touchStart = { x: t.clientX, y: t.clientY };
 	}
 	function onTouchMove(e: TouchEvent) {
+		if (isInteractiveTarget(e.target)) return;
 		// Block the vertical-pan / overscroll spring while a touch is in
 		// flight — without this the game container slid up and bounced back.
 		e.preventDefault();
 	}
 	function onTouchEnd(e: TouchEvent) {
+		if (isInteractiveTarget(e.target)) return;
 		e.preventDefault();
 		if (!touchStart) return;
 		const t = e.changedTouches[0];


### PR DESCRIPTION
Wordmark gets z-50 so 'snake' stays visible while game is up; tagline fades with the gallery; touch handlers bail out for interactive descendants so 'play again' is tappable on iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)