### PR TITLE
feat(snake): burst up from 3rd col, off-screen start

### DIFF
--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -20,15 +20,22 @@
 	const TICK_MS = 110;
 
 	function reset() {
-		const cx = Math.floor(cols / 2);
-		const cy = Math.floor(rows / 2);
+		// Spawn fully below the canvas (head at y=rows is off-screen by one
+		// row; body trails further down). Direction is up, so the first few
+		// ticks march the snake into view from below — head emerges at the
+		// 3rd column where the "1" countdown was, reading as the snake
+		// bursting up through the letter. step()'s lower-boundary check is
+		// only `head[1] >= rows` *after* a move, so the off-screen start
+		// state itself never triggers game-over.
+		const startX = 2;
+		const startY = rows;
 		snake = [
-			[cx, cy],
-			[cx - 1, cy],
-			[cx - 2, cy],
+			[startX, startY],
+			[startX, startY + 1],
+			[startX, startY + 2],
 		];
-		dir = [1, 0];
-		pendingDir = [1, 0];
+		dir = [0, -1];
+		pendingDir = [0, -1];
 		score = 0;
 		gameOver = false;
 		placeFood();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import Gallery from '$lib/components/gallery/Gallery.svelte';
   import BrandSignoff from '$lib/components/frame/BrandSignoff.svelte';
   import SnakeGame from '$lib/components/snake/SnakeGame.svelte';
+  import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
 
@@ -48,6 +49,7 @@
   {#if gameMode.countdownText}
     <div
       class="pointer-events-none absolute bottom-6 left-6 z-50 font-mono text-3xl font-bold text-black md:bottom-8 md:left-8 md:text-4xl"
+      out:fade={{ duration: 300 }}
     >
       {#key gameMode.countdownText}
         <span class="countdown-digit inline-block">{gameMode.countdownText}</span>
@@ -79,19 +81,18 @@
       transform: translateY(0) scale(1);
     }
   }
-  /* Game wrapper rises up from below + fades in — "snake bursts up
-     through the letter" — and shrinks back down on close. */
+  /* Game wrapper just fades in — the burst-up motion is the game snake
+     itself slithering up out of the bottom-left where the countdown was,
+     not the canvas moving. */
   :global(.burst-in) {
-    animation: burst-in 500ms cubic-bezier(0.2, 0.7, 0.2, 1);
+    animation: burst-in 400ms ease-out;
   }
   @keyframes burst-in {
     from {
       opacity: 0;
-      transform: translateY(60px) scale(0.96);
     }
     to {
       opacity: 1;
-      transform: translateY(0) scale(1);
     }
   }
   @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
Snake creature now spawns fully off-screen below at the 3rd column, moving up — reads as it bursting up through the bottom-left countdown letter. "1" gets a 300 ms out-fade so its dissolve overlaps the snake's rise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)