### PR TITLE
feat(snake): again? replay prompt in wordmark slot

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -34,7 +34,7 @@
   this={tag}
   class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
-  class:wordmark-hidden={gameMode.countdownText || gameMode.gameMounted}
+  class:wordmark-hidden={gameMode.countdownText || gameMode.gameMounted || gameMode.gameOver}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
     <span class="letter">{l}</span>

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { fade } from 'svelte/transition';
 	import { gameMode } from '$lib/game-mode.svelte';
 
 	// Snake game. Coin (yellow) page bg shines through; the snake + food
@@ -203,6 +202,13 @@
 		void gameOver;
 		draw();
 	});
+
+	// Surface local gameOver to the shared store so the page can render
+	// the "game over" / "again?" overlay above the canvas — and so the
+	// wordmark stays hidden through the replay countdown.
+	$effect(() => {
+		gameMode.gameOver = gameOver;
+	});
 </script>
 
 <!-- touch-action: none disables the browser's default panning + pinch +
@@ -218,31 +224,17 @@
 	ontouchend={onTouchEnd}
 >
 	<canvas bind:this={canvas}></canvas>
-	{#if gameOver}
-		<!-- Game-over panel anchored bottom-left so "play again" triggers a
-		     fresh burst up through the same corner the snake first emerged
-		     from. transition:fade lets the panel dissolve while the new
-		     snake rises out of the canvas below. -->
-		<div
-			class="pointer-events-auto absolute bottom-6 left-6 font-mono text-black md:bottom-8 md:left-8"
-			transition:fade={{ duration: 300 }}
-		>
-			<p class="mb-2 text-3xl font-bold tracking-pill uppercase">game over</p>
-			<p class="mb-4 text-base">score: {score}</p>
-			<button
-				class="rounded-full bg-black px-6 py-2 font-bold uppercase tracking-pill text-[var(--coin)] hover:bg-zinc-900"
-				onclick={reset}
-			>
-				play again
-			</button>
-		</div>
-	{:else}
-		<!-- Bare number top-left, sized to match the wordmark in the opposite
-		     corner — the context makes "this is the score" obvious. -->
-		<div
-			class="pointer-events-none absolute left-6 top-6 font-mono text-3xl font-bold text-black md:left-8 md:top-8 md:text-4xl"
-		>
+	<!-- Top-left badge — same position + size in both states. Bare
+	     number while playing; "game over" label once the snake dies. The
+	     bottom-left "again?" replay prompt is rendered by the parent so
+	     it can outlive this component's unmount during the countdown. -->
+	<div
+		class="pointer-events-none absolute left-6 top-6 font-mono text-3xl font-bold text-black md:left-8 md:top-8 md:text-4xl"
+	>
+		{#if gameOver}
+			<span class="uppercase tracking-pill">game over</span>
+		{:else}
 			{score}
-		</div>
-	{/if}
+		{/if}
+	</div>
 </div>

--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -1,9 +1,9 @@
 // Module-level reactive state for the "click the s" snake easter egg on
 // the homepage.
 //
-// The bottom-left wordmark is the countdown vehicle — "snake" → "3" → "2"
-// → "1" → game burst. Centered countdown felt scattered; anchoring it to
-// the wordmark spot makes the camera follow the action.
+// The bottom-left wordmark slot is the countdown vehicle — "snake" → "3"
+// → "2" → "1" → game burst. Centered countdown felt scattered; anchoring
+// it to the wordmark spot makes the camera follow the action.
 //
 // Flags driving the UI:
 //
@@ -12,9 +12,14 @@
 //   countdownText   — empty | "3" | "2" | "1"; when non-empty, the
 //                     wordmark hides and this text takes its bottom-left
 //                     slot
-//   gameMounted     — SnakeGame fades up from below as the final "1"
-//                     scales out — reads as the snake bursting up
-//                     through the letter
+//   gameMounted     — SnakeGame is in the DOM (ticking + drawing). The
+//                     game snake itself enters from below the canvas, so
+//                     the "burst" is the creature rising, not a CSS
+//                     animation on the wrapper.
+//   gameOver        — written by SnakeGame when its snake dies. The page
+//                     reads this to swap the top-left score for a "game
+//                     over" label and to show the bottom-left "again?"
+//                     replay prompt.
 const LETTER_ANIM_MS = 1200;
 const COUNT_STEP_MS = 500;
 const CLOSE_DELAY_MS = 500;
@@ -23,6 +28,7 @@ class GameMode {
 	active = $state(false);
 	countdownText = $state('');
 	gameMounted = $state(false);
+	gameOver = $state(false);
 	private timers: number[] = [];
 
 	private sched(ms: number, fn: () => void) {
@@ -40,6 +46,7 @@ class GameMode {
 		this.active = true;
 		this.countdownText = '';
 		this.gameMounted = false;
+		this.gameOver = false;
 
 		let t = LETTER_ANIM_MS;
 		this.sched(t, () => (this.countdownText = '3'));
@@ -55,10 +62,33 @@ class GameMode {
 		});
 	}
 
+	// Replay after game-over. Skip the letter animation (we're already in
+	// game mode) and run the same 3 → 2 → 1 → burst-up sequence with a
+	// fresh snake. Setting countdownText synchronously *before* tearing
+	// down the dead canvas keeps the bottom-left slot continuously owned
+	// by countdown text — no wordmark flicker between "again?" and "3".
+	restart() {
+		this.clearTimers();
+		this.countdownText = '3';
+		this.gameOver = false;
+		this.gameMounted = false;
+
+		let t = COUNT_STEP_MS;
+		this.sched(t, () => (this.countdownText = '2'));
+		t += COUNT_STEP_MS;
+		this.sched(t, () => (this.countdownText = '1'));
+		t += COUNT_STEP_MS;
+		this.sched(t, () => {
+			this.countdownText = '';
+			this.gameMounted = true;
+		});
+	}
+
 	stop() {
 		this.clearTimers();
 		this.countdownText = '';
 		this.gameMounted = false;
+		this.gameOver = false;
 		this.sched(CLOSE_DELAY_MS, () => (this.active = false));
 	}
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,6 +62,21 @@
       <SnakeGame />
     </div>
   {/if}
+
+  <!-- Replay prompt: shown when the snake's dead, sits in the wordmark
+       slot (same coords as the "snake" letters / countdown digit). Click
+       runs gameMode.restart() — countdown starts synchronously, so the
+       fade-out of "again?" overlaps the fade-in of "3" in the same spot. -->
+  {#if gameMode.gameOver}
+    <button
+      type="button"
+      class="absolute bottom-6 left-6 z-50 cursor-pointer font-mono text-3xl font-bold text-black md:bottom-8 md:left-8 md:text-4xl"
+      onclick={() => gameMode.restart()}
+      out:fade={{ duration: 300 }}
+    >
+      again?
+    </button>
+  {/if}
 </main>
 
 <style>


### PR DESCRIPTION
Replace the centered "play again" panel with two corner cues:
- top-left swaps the score number for a "game over" label
- bottom-left wordmark slot shows "again?" — click triggers the same 3-2-1-burst countdown the opening uses, with a fresh snake rising up through the same corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)