### PR TITLE
feat(snake): bottom-left game over → again? choreography

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -34,10 +34,7 @@
   this={tag}
   class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
-  class:wordmark-hidden={gameMode.countdownText ||
-    gameMode.gameMounted ||
-    gameMode.gameOver ||
-    gameMode.replayReady}
+  class:wordmark-hidden={gameMode.wordmarkSlotOccupied}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
     <span class="letter">{l}</span>

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -34,7 +34,10 @@
   this={tag}
   class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
-  class:wordmark-hidden={gameMode.countdownText || gameMode.gameMounted || gameMode.gameOver}
+  class:wordmark-hidden={gameMode.countdownText ||
+    gameMode.gameMounted ||
+    gameMode.gameOver ||
+    gameMode.replayReady}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
     <span class="letter">{l}</span>

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -107,9 +107,12 @@
 		else if (e.key === 'ArrowDown' || e.key === 's' || e.key === 'S') setDir([0, 1]);
 		else if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') setDir([-1, 0]);
 		else if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') setDir([1, 0]);
-		else if (e.key === 'r' || e.key === 'R') reset();
 		else if (e.key === 'Escape') gameMode.stop();
 		else return;
+		// "r" restart removed: it called the local reset() which left
+		// gameMode's pending game-over/replay timers running — the "again?"
+		// prompt would pop on top of a live game ~2 s later. Restart now
+		// flows exclusively through gameMode.restart() via the button.
 		e.preventDefault();
 	}
 

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -203,11 +203,12 @@
 		draw();
 	});
 
-	// Surface local gameOver to the shared store so the page can render
-	// the "game over" / "again?" overlay above the canvas — and so the
-	// wordmark stays hidden through the replay countdown.
+	// Fire the page's game-over choreography once when the local snake
+	// dies. handleGameOver() guards against re-entry, so this fires once
+	// per game; nothing else needs to happen when gameOver flips back to
+	// false (the whole component re-mounts on restart with a fresh state).
 	$effect(() => {
-		gameMode.gameOver = gameOver;
+		if (gameOver) gameMode.handleGameOver();
 	});
 </script>
 
@@ -224,17 +225,13 @@
 	ontouchend={onTouchEnd}
 >
 	<canvas bind:this={canvas}></canvas>
-	<!-- Top-left badge — same position + size in both states. Bare
-	     number while playing; "game over" label once the snake dies. The
-	     bottom-left "again?" replay prompt is rendered by the parent so
-	     it can outlive this component's unmount during the countdown. -->
+	<!-- Bare score, top-left. Stays put across the whole session — game
+	     play, dead-snake pause, and the replay countdown all read against
+	     the same number. The bottom-left wordmark slot is where the page
+	     stages "game over" → "again?" → countdown digits. -->
 	<div
 		class="pointer-events-none absolute left-6 top-6 font-mono text-3xl font-bold text-black md:left-8 md:top-8 md:text-4xl"
 	>
-		{#if gameOver}
-			<span class="uppercase tracking-pill">game over</span>
-		{:else}
-			{score}
-		{/if}
+		{score}
 	</div>
 </div>

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -60,11 +60,13 @@
 		const head: [number, number] = [snake[0][0] + dir[0], snake[0][1] + dir[1]];
 		if (head[0] < 0 || head[0] >= cols || head[1] < 0 || head[1] >= rows) {
 			gameOver = true;
+			gameMode.handleGameOver();
 			return;
 		}
 		for (const [sx, sy] of snake) {
 			if (sx === head[0] && sy === head[1]) {
 				gameOver = true;
+				gameMode.handleGameOver();
 				return;
 			}
 		}
@@ -170,6 +172,8 @@
 		draw();
 	}
 
+	let tickId: number | undefined;
+
 	onMount(() => {
 		resize();
 		window.addEventListener('keydown', onKey);
@@ -184,12 +188,12 @@
 		document.body.style.overflow = 'hidden';
 		document.body.style.overscrollBehavior = 'none';
 
-		const id = window.setInterval(() => {
+		tickId = window.setInterval(() => {
 			step();
 			draw();
 		}, TICK_MS);
 		return () => {
-			window.clearInterval(id);
+			if (tickId !== undefined) window.clearInterval(tickId);
 			window.removeEventListener('keydown', onKey);
 			window.removeEventListener('resize', resize);
 			document.documentElement.style.overflow = prevHtmlOverflow;
@@ -199,19 +203,22 @@
 	});
 
 	$effect(() => {
-		// Redraw whenever reactive state changes that draw() reads
+		// Redraw on state changes draw() actually reads. gameOver isn't
+		// one of them — it doesn't affect pixels — so it stays out.
 		void snake;
 		void food;
-		void gameOver;
 		draw();
 	});
 
-	// Fire the page's game-over choreography once when the local snake
-	// dies. handleGameOver() guards against re-entry, so this fires once
-	// per game; nothing else needs to happen when gameOver flips back to
-	// false (the whole component re-mounts on restart with a fresh state).
+	// Stop the tick the instant the snake dies. The canvas already shows
+	// the final frame; without this, step() (early-returning) and draw()
+	// (re-painting an unchanged picture) keep firing 9×/s through the
+	// 2 s "game over" hold and the indefinite "again?" wait.
 	$effect(() => {
-		if (gameOver) gameMode.handleGameOver();
+		if (gameOver && tickId !== undefined) {
+			window.clearInterval(tickId);
+			tickId = undefined;
+		}
 	});
 </script>
 

--- a/src/lib/components/snake/SnakeGame.svelte
+++ b/src/lib/components/snake/SnakeGame.svelte
@@ -210,12 +210,15 @@
 		draw();
 	});
 
-	// Stop the tick the instant the snake dies. The canvas already shows
-	// the final frame; without this, step() (early-returning) and draw()
-	// (re-painting an unchanged picture) keep firing 9×/s through the
-	// 2 s "game over" hold and the indefinite "again?" wait.
+	// Freeze the tick on either edge that ends the game:
+	//   - local gameOver true (snake died) — avoids ~9 wasted redraws/s
+	//     through the "game over" hold and the indefinite "again?" wait.
+	//   - gameMode.gameMounted false (user quit) — Svelte's transition:fade
+	//     keeps this component in the DOM for 400 ms after the {#if} flips
+	//     false; without freezing here the snake would visibly slither
+	//     through the outro instead of freezing in place.
 	$effect(() => {
-		if (gameOver && tickId !== undefined) {
+		if ((gameOver || !gameMode.gameMounted) && tickId !== undefined) {
 			window.clearInterval(tickId);
 			tickId = undefined;
 		}

--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -67,21 +67,27 @@ class GameMode {
 		});
 	}
 
-	// SnakeGame calls this once when its snake dies. We hold "game over"
-	// in the wordmark slot for 2 s, fade it out, then surface "again?" in
-	// the same slot — never overlapping. The dead canvas stays painted
-	// behind both messages.
+	// SnakeGame calls this once at the edge where its local gameOver flips
+	// true. Hold "game over" in the wordmark slot for the dwell, fade it
+	// out, then surface "again?" — never overlapping (replayReady flips
+	// only after the fade-out window completes).
 	handleGameOver() {
-		if (this.gameOver || this.replayReady) return;
 		this.gameOver = true;
-		this.sched(GAME_OVER_HOLD_MS, () => {
-			this.gameOver = false;
-			// Wait for the fade-out before showing the replay prompt so the
-			// two messages don't overlap in the same slot.
-			this.sched(GAME_OVER_FADE_MS, () => {
-				this.replayReady = true;
-			});
-		});
+		this.sched(GAME_OVER_HOLD_MS, () => (this.gameOver = false));
+		this.sched(GAME_OVER_HOLD_MS + GAME_OVER_FADE_MS, () => (this.replayReady = true));
+	}
+
+	// True whenever something other than the idle wordmark owns the
+	// bottom-left slot (countdown digit, live/dead game canvas, "game
+	// over" message, or "again?" prompt). BrandSignoff reads this to
+	// hide the wordmark during those beats.
+	get wordmarkSlotOccupied() {
+		return (
+			this.countdownText !== '' ||
+			this.gameMounted ||
+			this.gameOver ||
+			this.replayReady
+		);
 	}
 
 	// Replay after game-over. Skip the letter animation (we're already in

--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -1,34 +1,38 @@
 // Module-level reactive state for the "click the s" snake easter egg on
 // the homepage.
 //
-// The bottom-left wordmark slot is the countdown vehicle — "snake" → "3"
-// → "2" → "1" → game burst. Centered countdown felt scattered; anchoring
-// it to the wordmark spot makes the camera follow the action.
+// The bottom-left wordmark slot is a single stage that hosts everything
+// non-canvas: "snake" → "3" → "2" → "1" → (game) → "game over" → "again?"
+// → "3" → … Centered overlays felt scattered — anchoring everything to
+// the same corner makes the camera follow the action.
 //
 // Flags driving the UI:
 //
 //   active          — wordmark "threesam → snake" letter animation runs;
 //                     gallery + tagline fade out
-//   countdownText   — empty | "3" | "2" | "1"; when non-empty, the
-//                     wordmark hides and this text takes its bottom-left
-//                     slot
+//   countdownText   — "" | "3" | "2" | "1"; when non-empty, the wordmark
+//                     hides and this text takes its bottom-left slot
 //   gameMounted     — SnakeGame is in the DOM (ticking + drawing). The
 //                     game snake itself enters from below the canvas, so
 //                     the "burst" is the creature rising, not a CSS
 //                     animation on the wrapper.
-//   gameOver        — written by SnakeGame when its snake dies. The page
-//                     reads this to swap the top-left score for a "game
-//                     over" label and to show the bottom-left "again?"
-//                     replay prompt.
+//   gameOver        — "game over" message is showing (a 2 s hold, then
+//                     fades out). Triggered by SnakeGame when its snake
+//                     dies via handleGameOver().
+//   replayReady     — "again?" prompt is showing. Click → restart().
+
 const LETTER_ANIM_MS = 1200;
 const COUNT_STEP_MS = 500;
 const CLOSE_DELAY_MS = 500;
+const GAME_OVER_HOLD_MS = 2000;
+const GAME_OVER_FADE_MS = 400;
 
 class GameMode {
 	active = $state(false);
 	countdownText = $state('');
 	gameMounted = $state(false);
 	gameOver = $state(false);
+	replayReady = $state(false);
 	private timers: number[] = [];
 
 	private sched(ms: number, fn: () => void) {
@@ -47,6 +51,7 @@ class GameMode {
 		this.countdownText = '';
 		this.gameMounted = false;
 		this.gameOver = false;
+		this.replayReady = false;
 
 		let t = LETTER_ANIM_MS;
 		this.sched(t, () => (this.countdownText = '3'));
@@ -62,15 +67,33 @@ class GameMode {
 		});
 	}
 
+	// SnakeGame calls this once when its snake dies. We hold "game over"
+	// in the wordmark slot for 2 s, fade it out, then surface "again?" in
+	// the same slot — never overlapping. The dead canvas stays painted
+	// behind both messages.
+	handleGameOver() {
+		if (this.gameOver || this.replayReady) return;
+		this.gameOver = true;
+		this.sched(GAME_OVER_HOLD_MS, () => {
+			this.gameOver = false;
+			// Wait for the fade-out before showing the replay prompt so the
+			// two messages don't overlap in the same slot.
+			this.sched(GAME_OVER_FADE_MS, () => {
+				this.replayReady = true;
+			});
+		});
+	}
+
 	// Replay after game-over. Skip the letter animation (we're already in
 	// game mode) and run the same 3 → 2 → 1 → burst-up sequence with a
 	// fresh snake. Setting countdownText synchronously *before* tearing
 	// down the dead canvas keeps the bottom-left slot continuously owned
-	// by countdown text — no wordmark flicker between "again?" and "3".
+	// by countdown text — no flicker between "again?" and "3".
 	restart() {
 		this.clearTimers();
 		this.countdownText = '3';
 		this.gameOver = false;
+		this.replayReady = false;
 		this.gameMounted = false;
 
 		let t = COUNT_STEP_MS;
@@ -89,6 +112,7 @@ class GameMode {
 		this.countdownText = '';
 		this.gameMounted = false;
 		this.gameOver = false;
+		this.replayReady = false;
 		this.sched(CLOSE_DELAY_MS, () => (this.active = false));
 	}
 }

--- a/src/lib/game-mode.svelte.ts
+++ b/src/lib/game-mode.svelte.ts
@@ -71,7 +71,14 @@ class GameMode {
 	// true. Hold "game over" in the wordmark slot for the dwell, fade it
 	// out, then surface "again?" — never overlapping (replayReady flips
 	// only after the fade-out window completes).
+	//
+	// `gameMounted` guard handles the Esc-during-collision race: stop()
+	// sets gameMounted=false synchronously, but the SnakeGame outro keeps
+	// ticking for ~400 ms. A late step() during that window could call
+	// here over an already-closing game; we'd schedule a "replayReady"
+	// timer that surfaces "again?" on the idle homepage 2.4 s later.
 	handleGameOver() {
+		if (!this.gameMounted) return;
 		this.gameOver = true;
 		this.sched(GAME_OVER_HOLD_MS, () => (this.gameOver = false));
 		this.sched(GAME_OVER_HOLD_MS + GAME_OVER_FADE_MS, () => (this.replayReady = true));

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,8 +57,13 @@
     </div>
   {/if}
 
+  <!-- SnakeGame wrapped in transition:fade so the dead canvas dissolves
+       smoothly when restart()/stop() unmounts it — without this, the
+       canvas snapped off instantly while the countdown digit / wordmark
+       faded in. Svelte defers DOM removal until the outro completes,
+       so the component's own cleanup runs at fade-end. -->
   {#if gameMode.gameMounted}
-    <div class="burst-in">
+    <div transition:fade={{ duration: 400 }}>
       <SnakeGame />
     </div>
   {/if}
@@ -111,23 +116,8 @@
       transform: translateY(0) scale(1);
     }
   }
-  /* Game wrapper just fades in — the burst-up motion is the game snake
-     itself slithering up out of the bottom-left where the countdown was,
-     not the canvas moving. */
-  :global(.burst-in) {
-    animation: burst-in 400ms ease-out;
-  }
-  @keyframes burst-in {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
-    }
-  }
   @media (prefers-reduced-motion: reduce) {
-    :global(.countdown-digit),
-    :global(.burst-in) {
+    :global(.countdown-digit) {
       animation: none;
     }
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -63,15 +63,30 @@
     </div>
   {/if}
 
-  <!-- Replay prompt: shown when the snake's dead, sits in the wordmark
-       slot (same coords as the "snake" letters / countdown digit). Click
-       runs gameMode.restart() — countdown starts synchronously, so the
-       fade-out of "again?" overlaps the fade-in of "3" in the same spot. -->
+  <!-- Post-death choreography. The dead snake canvas stays painted; the
+       bottom-left wordmark slot stages two beats in sequence (never
+       overlapping — gameMode times the gap so the out-fade completes
+       before "again?" mounts):
+
+       1. "game over" lingers ~2 s then fades out.
+       2. "again?" fades in — click runs gameMode.restart(), which
+          synchronously hands the slot off to the "3" countdown digit. -->
   {#if gameMode.gameOver}
+    <div
+      class="pointer-events-none absolute bottom-6 left-6 z-50 font-mono text-3xl font-bold uppercase tracking-pill text-black md:bottom-8 md:left-8 md:text-4xl"
+      in:fade={{ duration: 250 }}
+      out:fade={{ duration: 400 }}
+    >
+      game over
+    </div>
+  {/if}
+
+  {#if gameMode.replayReady}
     <button
       type="button"
       class="absolute bottom-6 left-6 z-50 cursor-pointer font-mono text-3xl font-bold text-black md:bottom-8 md:left-8 md:text-4xl"
       onclick={() => gameMode.restart()}
+      in:fade={{ duration: 250 }}
       out:fade={{ duration: 300 }}
     >
       again?


### PR DESCRIPTION
Bottom-left wordmark slot now stages every post-letter beat — game over (2s hold + fade), then again? fades in. Click again? → countdown 3-2-1 → fresh snake bursts up. Score stays top-left; dead snake stays painted behind both messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)