### PR TITLE
feat(message): message me? letter form easter egg

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "marked": "17.0.5",
     "marked-emoji": "2.0.2",
     "node-emoji": "2.2.0",
+    "resend": "6.12.4",
     "sharp": "0.34.5",
     "three": "0.183.2"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       node-emoji:
         specifier: 2.2.0
         version: 2.2.0
+      resend:
+        specifier: 6.12.4
+        version: 6.12.4
       sharp:
         specifier: 0.34.5
         version: 0.34.5
@@ -1104,6 +1107,9 @@ packages:
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1694,6 +1700,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
@@ -2158,6 +2167,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  postal-mime@2.7.4:
+    resolution: {integrity: sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2215,6 +2227,15 @@ packages:
   require-in-the-middle@7.5.2:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
+
+  resend@6.12.4:
+    resolution: {integrity: sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -2312,6 +2333,9 @@ packages:
   speedline-core@1.4.3:
     resolution: {integrity: sha512-DI7/OuAUD+GMpR6dmu8lliO2Wg5zfeh+/xsdyJZCzd8o5JgFUjCeLsBDuZjIQJdwXS3J0L/uZYrELKYqx+PXog==}
     engines: {node: '>=8.0'}
+
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
@@ -3448,6 +3472,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.15': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
@@ -4059,6 +4085,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-xml-builder@1.2.0:
     dependencies:
       path-expression-matcher: 1.5.0
@@ -4497,6 +4525,8 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  postal-mime@2.7.4: {}
+
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.12
@@ -4567,6 +4597,11 @@ snapshots:
       resolve: 1.22.12
     transitivePeerDependencies:
       - supports-color
+
+  resend@6.12.4:
+    dependencies:
+      postal-mime: 2.7.4
+      standardwebhooks: 1.0.0
 
   resolve-from@5.0.0: {}
 
@@ -4697,6 +4732,11 @@ snapshots:
       '@types/node': 25.8.0
       image-ssim: 0.2.0
       jpeg-js: 0.4.4
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   streamx@2.25.0:
     dependencies:

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -11,12 +11,19 @@
   // `gameClickable` exposes the snake-game easter egg: clicking the "s"
   // toggles gameMode and triggers the letter-collapse → "snake" sequence.
   import { gameMode } from '$lib/game-mode.svelte';
+  import { messageMode } from '$lib/message-mode.svelte';
 
   let {
     heading = false,
     tone = 'dark',
     gameClickable = false,
-  }: { heading?: boolean; tone?: 'dark' | 'light'; gameClickable?: boolean } = $props();
+    messageClickable = false,
+  }: {
+    heading?: boolean;
+    tone?: 'dark' | 'light';
+    gameClickable?: boolean;
+    messageClickable?: boolean;
+  } = $props();
   const tag = $derived(heading ? 'h1' : 'div');
   const color = $derived(tone === 'light' ? 'text-white' : 'text-black');
 
@@ -33,12 +40,13 @@
 
   // Persistent reveal of the message tail — primary path on touch (no hover);
   // also lets desktop users click instead of holding the mouse over the "m".
-  // Reset when the game starts so the two tails never both expand at once.
+  // The toggle no-ops while the game is running so the two tails can't
+  // both expand at once.
   let messageOn = $state(false);
-  const toggleMessage = () => (messageOn = !messageOn);
-  $effect(() => {
-    if (active) messageOn = false;
-  });
+  const toggleMessage = () => {
+    if (active) return;
+    messageOn = !messageOn;
+  };
 </script>
 
 <svelte:element
@@ -46,7 +54,7 @@
   class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
   class:show-message={messageOn && !active}
-  class:wordmark-hidden={gameMode.wordmarkSlotOccupied}
+  class:wordmark-hidden={gameMode.wordmarkSlotOccupied || messageMode.active}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
     <span class="letter">{l}</span>
@@ -88,18 +96,30 @@
   {#each SNAKE_TAIL as l, i (`tail-${i}`)}
     <span class="tail" style="--tail-delay: {200 + i * 130}ms">{l}</span>
   {/each}
-  {#each MESSAGE_TAIL as l, i (`msg-${i}`)}
-    <span class="msg-tail" style="--msg-delay: {100 + i * 80}ms">{l}</span>
-  {/each}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- Single delegated handler for the whole message tail. `display:
+       contents` keeps the inner spans as direct flex children of the
+       wordmark; clicks on any letter bubble here. Letters are
+       individually unclickable when collapsed (max-width: 0 → no
+       hitbox), so the wrapper only fires when something is visible. -->
+  <span
+    class="msg-tail-group"
+    class:clickable={messageClickable}
+    onclick={messageClickable ? () => messageMode.start() : undefined}
+  >
+    {#each MESSAGE_TAIL as l, i (`msg-${i}`)}
+      <span class="msg-tail" style="--msg-delay: {100 + i * 80}ms">{l}</span>
+    {/each}
+  </span>
 </svelte:element>
-<!-- Tagline (anchored bottom-right). Fades out at the same time as the
-     gallery while gameMode.active so "snake" + game read as the only
-     content. -->
+<!-- Tagline (anchored bottom-right). Fades out alongside the gallery
+     during snake game or "message me?" letter mode so the active
+     experience reads as the only content. -->
 <p
   class="tagline absolute right-6 bottom-6 z-10 text-right font-mono text-sm leading-tight tracking-hero {color} md:right-8 md:bottom-8 md:text-base"
-  class:tagline-hidden={active}
->
-  <span class="block md:inline">certainly</span><span class="alien" aria-hidden="true"
+  class:tagline-hidden={active || messageMode.active}
+><span class="block md:inline">certainly</span><span class="alien" aria-hidden="true"
     ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
       <path
         fill="currentColor"
@@ -133,8 +153,12 @@
     opacity: 0;
     transition-delay: 0ms;
   }
+  .msg-tail-group {
+    display: contents;
+  }
   .s-letter.clickable,
-  .m-letter.clickable {
+  .m-letter.clickable,
+  .msg-tail-group.clickable .msg-tail {
     cursor: pointer;
   }
   .tagline {

--- a/src/lib/components/frame/Guide.svelte
+++ b/src/lib/components/frame/Guide.svelte
@@ -2,18 +2,24 @@
   import { preloadCode } from '$app/navigation';
   import { NAV_ROUTES } from '$lib/nav';
   import { gameMode } from '$lib/game-mode.svelte';
+  import { messageMode } from '$lib/message-mode.svelte';
 
   let open = $state(false);
   let hovered = $state(false);
   let locked = $state(false);
-  // Snake game on the homepage: the back face's rotated "+" is already an
-  // "x" glyph, so we reuse it. When the game is active, clicking the coin
-  // quits the game instead of opening the nav menu.
-  const inGame = $derived(gameMode.active);
+  // The back-face "+" already renders as an "x" once rotated, so any
+  // homepage easter-egg mode (snake game, "message me?" letter) borrows
+  // it: the coin flips to the x glyph and a click quits that mode
+  // instead of opening the nav menu.
+  const inMode = $derived(gameMode.active || messageMode.active);
 
   function handleCoinClick() {
-    if (inGame) {
+    if (gameMode.active) {
       gameMode.stop();
+      return;
+    }
+    if (messageMode.active) {
+      messageMode.stop();
       return;
     }
     open = !open;
@@ -24,7 +30,7 @@
   }
 
   function handleCoinMouseEnter() {
-    if (inGame) return;
+    if (inMode) return;
     if (!locked) hovered = true;
     // Warm all route JS chunks on first coin hover — no-op on subsequent calls.
     for (const r of NAV_ROUTES) {
@@ -39,8 +45,7 @@
 
   // Derived coin transform — no nested ternary.
   const coinTransform = $derived((() => {
-    if (inGame) return 'rotateY(180deg) rotate(45deg)';
-    if (open) return 'rotateY(180deg) rotate(45deg)';
+    if (inMode || open) return 'rotateY(180deg) rotate(45deg)';
     if (hovered) return 'rotateY(180deg)';
     return 'rotateY(0deg)';
   })());

--- a/src/lib/components/message/MessageLetter.svelte
+++ b/src/lib/components/message/MessageLetter.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { messageMode } from '$lib/message-mode.svelte';
+
+	// Imitates a handwritten letter: "hey Sam," at the top, an invisible
+	// textarea where the cursor starts (no placeholder — the blinking
+	// caret IS the affordance), then "sincerely," and a borderless email
+	// input. Fullscreen on mobile; centered card on desktop.
+
+	// `use:autofocus` — drop the cursor into the textarea the moment the
+	// card mounts so the user can start typing without an extra tap. The
+	// action runs once per node, which is exactly when we want focus.
+	const autofocus = (node: HTMLTextAreaElement) => {
+		node.focus({ preventScroll: true });
+	};
+
+	// Escape closes the letter. role="dialog" carries this expectation;
+	// without it keyboard users have no exit path (the coin x is the
+	// pointer path).
+	$effect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') messageMode.stop();
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	});
+</script>
+
+<div
+	class="card"
+	role="dialog"
+	aria-modal="true"
+	aria-label="message Sam"
+	transition:fade={{ duration: 350 }}
+>
+	<form
+		class="sheet"
+		onsubmit={(e) => {
+			e.preventDefault();
+			messageMode.send();
+		}}
+	>
+		<p class="line greeting">hey Sam,</p>
+		<textarea
+			class="body"
+			use:autofocus
+			bind:value={messageMode.body}
+			rows="6"
+			maxlength="5000"
+			aria-label="your message"
+		></textarea>
+		<p class="line signoff">sincerely,</p>
+		<input
+			class="email"
+			type="email"
+			autocomplete="email"
+			inputmode="email"
+			maxlength="200"
+			placeholder="your email?"
+			aria-label="your email"
+			bind:value={messageMode.email}
+		/>
+		<!-- Honeypot: invisible to humans, irresistible to bots. Server
+		     silently 200s if it's non-empty. tabindex=-1 + autocomplete=off
+		     so a real user tabbing through doesn't accidentally land on it.
+		     Enter on the email input submits the form natively — no
+		     visible button needed; SendAction (bottom-right) is the
+		     pointer/keyboard target. -->
+		<input
+			class="honeypot"
+			type="text"
+			name="website"
+			tabindex="-1"
+			autocomplete="off"
+			aria-hidden="true"
+		/>
+		{#if messageMode.error}
+			<p class="error" role="alert">{messageMode.error}</p>
+		{/if}
+		{#if messageMode.sent}
+			<p class="sent" role="status">sent — talk soon.</p>
+		{/if}
+	</form>
+</div>
+
+<style>
+	.card {
+		position: fixed;
+		z-index: 35;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		background: var(--white);
+		padding: 6rem 1.5rem 8rem;
+	}
+	@media (min-width: 768px) {
+		.card {
+			inset: auto;
+			top: 50%;
+			left: 50%;
+			width: min(560px, calc(100vw - 4rem));
+			max-height: calc(100dvh - 8rem);
+			padding: 0;
+			background: transparent;
+			transform: translate(-50%, -50%);
+			place-items: stretch;
+		}
+	}
+	.sheet {
+		width: 100%;
+		max-width: 560px;
+		color: var(--black);
+		font-family: 'Recursive Mono', ui-monospace, monospace;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	@media (min-width: 768px) {
+		.sheet {
+			background: var(--white);
+			border-radius: 14px;
+			padding: 2.4rem 2.2rem 2.6rem;
+			box-shadow:
+				0 30px 70px -10px rgba(0, 0, 0, 0.35),
+				0 10px 20px -10px rgba(0, 0, 0, 0.25);
+		}
+	}
+	.line {
+		margin: 0;
+		font-size: 1.1rem;
+		font-weight: 600;
+		letter-spacing: 0.01em;
+	}
+	.greeting {
+		margin-bottom: 0.4rem;
+	}
+	.signoff {
+		margin-top: 1.2rem;
+	}
+	.body,
+	.email {
+		width: 100%;
+		background: transparent;
+		border: 0;
+		padding: 0;
+		margin: 0;
+		font: inherit;
+		color: inherit;
+		resize: none;
+		caret-color: var(--black);
+	}
+	.body {
+		min-height: 8rem;
+		line-height: 1.55;
+	}
+	.email {
+		padding-left: 0;
+	}
+	.body::placeholder,
+	.email::placeholder {
+		color: rgba(0, 0, 0, 0.35);
+	}
+	.body:focus,
+	.email:focus {
+		outline: none;
+	}
+	.honeypot {
+		position: absolute;
+		left: -9999px;
+		width: 1px;
+		height: 1px;
+		opacity: 0;
+		pointer-events: none;
+	}
+	.error,
+	.sent {
+		margin: 0.4rem 0 0;
+		font-size: 0.85rem;
+		font-weight: 600;
+	}
+	.error {
+		color: #b00020;
+	}
+	.sent {
+		color: var(--black);
+		opacity: 0.7;
+	}
+</style>

--- a/src/lib/components/message/SendAction.svelte
+++ b/src/lib/components/message/SendAction.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import { fade } from 'svelte/transition';
+	import { messageMode } from '$lib/message-mode.svelte';
+
+	// Bottom-right action label. Two letter sets sit in the same flex row,
+	// one collapsed at a time — same trick the wordmark uses for
+	// threesam ↔ snake / threesam ↔ message me?:
+	//
+	//   .ready  → form is filled & valid → "send it?" expands, "message
+	//             me?" collapses, click submits
+	//   default → "message me?" reads as a label, no-op click
+	const MESSAGE_CHARS = ['m', 'e', 's', 's', 'a', 'g', 'e', ' ', 'm', 'e', '?'];
+	const SEND_CHARS = ['s', 'e', 'n', 'd', ' ', 'i', 't', '?'];
+
+	const ready = $derived(messageMode.formValid && !messageMode.sending && !messageMode.sent);
+
+	function onClick() {
+		if (!ready) return;
+		void messageMode.send();
+	}
+
+	function onKey(e: KeyboardEvent) {
+		if (!ready) return;
+		if (e.key === 'Enter' || e.key === ' ') {
+			e.preventDefault();
+			void messageMode.send();
+		}
+	}
+</script>
+
+<div
+	class="action"
+	class:ready
+	class:clickable={ready}
+	role="button"
+	tabindex={ready ? 0 : -1}
+	aria-disabled={!ready}
+	aria-label={ready ? 'send the message' : 'message Sam — fill in the message and your email'}
+	onclick={onClick}
+	onkeydown={onKey}
+	transition:fade={{ duration: 350 }}
+>
+	{#each MESSAGE_CHARS as l, i (`msg-${i}`)}
+		<span class="msg" style="--d: {i * 60}ms">{l}</span>
+	{/each}
+	{#each SEND_CHARS as l, i (`snd-${i}`)}
+		<span class="snd" style="--d: {i * 70}ms">{l}</span>
+	{/each}
+</div>
+
+<style>
+	.action {
+		position: fixed;
+		bottom: 1.5rem;
+		right: 1.5rem;
+		z-index: 50;
+		display: flex;
+		align-items: baseline;
+		font-family: 'Recursive Mono', ui-monospace, monospace;
+		font-weight: 700;
+		font-size: 1.875rem;
+		letter-spacing: 0.04em;
+		color: var(--black);
+		user-select: none;
+		cursor: default;
+	}
+	@media (min-width: 768px) {
+		.action {
+			bottom: 2rem;
+			right: 2rem;
+			font-size: 2.25rem;
+		}
+	}
+	.action.clickable {
+		cursor: pointer;
+	}
+	.msg,
+	.snd {
+		display: inline-block;
+		overflow: hidden;
+		white-space: pre;
+		transition:
+			max-width 450ms cubic-bezier(0.4, 0, 0.2, 1),
+			opacity 350ms ease-out;
+		max-width: 1em;
+		opacity: 1;
+		transition-delay: 0ms;
+	}
+	/* "send it?" is the alt set — collapsed by default. */
+	.snd {
+		max-width: 0;
+		opacity: 0;
+	}
+	/* READY (form valid): "message me?" collapses, "send it?" expands,
+	   both staggered so the morph reads as a transformation rather than
+	   a swap. */
+	.ready .msg {
+		max-width: 0;
+		opacity: 0;
+		transition-delay: var(--d, 0ms);
+	}
+	.ready .snd {
+		max-width: 1em;
+		opacity: 1;
+		transition-delay: var(--d, 0ms);
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.msg,
+		.snd {
+			transition: none;
+		}
+	}
+</style>

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -1,0 +1,94 @@
+// "message me?" easter egg state. Clicking the revealed message tail in
+// the bottom-left wordmark enters a letter-writing mode: gallery + tagline
+// + wordmark fade out, a cream letter card appears (centered on desktop,
+// fullscreen on mobile), and the bottom-right action morphs from
+// "message me?" to "send it?" once both fields are filled. Click sends
+// via /api/message (Resend → sam@threesam.com).
+//
+// Flags driving the UI:
+//
+//   active  — fade gallery + wordmark + tagline; reveal the letter card
+//             and the bottom-right action; coin top-right becomes "x"
+//   sending — post in flight; the action shows "sending..."
+//   sent    — post succeeded; brief "sent it!" beat before auto-close
+//   error   — null when fine; string when the post failed
+
+const CLOSE_DELAY_MS = 500;
+const SENT_HOLD_MS = 1500;
+
+const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+class MessageMode {
+	active = $state(false);
+	email = $state('');
+	body = $state('');
+	sending = $state(false);
+	sent = $state(false);
+	error = $state<string | null>(null);
+	private timers: number[] = [];
+
+	private sched(ms: number, fn: () => void) {
+		const id = window.setTimeout(fn, ms);
+		this.timers.push(id);
+	}
+
+	private clearTimers() {
+		for (const id of this.timers) clearTimeout(id);
+		this.timers = [];
+	}
+
+	get formValid() {
+		return this.body.trim().length > 0 && EMAIL_RX.test(this.email.trim());
+	}
+
+	start() {
+		this.clearTimers();
+		this.active = true;
+		this.sending = false;
+		this.sent = false;
+		this.error = null;
+	}
+
+	stop() {
+		this.clearTimers();
+		this.active = false;
+		// Reset the form only after the close animation completes so the
+		// fields don't visibly clear while the card is still fading out.
+		this.sched(CLOSE_DELAY_MS, () => {
+			this.email = '';
+			this.body = '';
+			this.sending = false;
+			this.sent = false;
+			this.error = null;
+		});
+	}
+
+	async send() {
+		if (this.sending || !this.formValid) return;
+		this.sending = true;
+		this.error = null;
+		try {
+			const res = await fetch('/api/message', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					email: this.email.trim(),
+					body: this.body.trim(),
+				}),
+			});
+			if (!res.ok) {
+				const data = (await res.json().catch(() => null)) as { error?: string } | null;
+				this.error = data?.error || 'failed to send';
+				return;
+			}
+			this.sent = true;
+			this.sched(SENT_HOLD_MS, () => this.stop());
+		} catch {
+			this.error = 'failed to send';
+		} finally {
+			this.sending = false;
+		}
+	}
+}
+
+export const messageMode = new MessageMode();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,8 +3,11 @@
   import Gallery from '$lib/components/gallery/Gallery.svelte';
   import BrandSignoff from '$lib/components/frame/BrandSignoff.svelte';
   import SnakeGame from '$lib/components/snake/SnakeGame.svelte';
+  import MessageLetter from '$lib/components/message/MessageLetter.svelte';
+  import SendAction from '$lib/components/message/SendAction.svelte';
   import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
+  import { messageMode } from '$lib/message-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
 
   // Structured site index for search + answer engines. Mirrors the
@@ -29,18 +32,25 @@
   the gallery, transforms "threesam" → "snake", and flips the menu coin into
   an x glyph for quit. State lives in $lib/game-mode.
 -->
-<main class="relative flex h-dvh w-full flex-col overflow-hidden bg-coin">
+<!-- `inert` while messageMode owns the screen — removes the gallery,
+     wordmark, etc. from tab order + the a11y tree so keyboard users
+     can't reach behind-the-modal content. The Guide coin (top-right)
+     lives outside <main>, so it stays interactive as the close path. -->
+<main
+  class="relative flex h-dvh w-full flex-col overflow-hidden bg-coin"
+  inert={messageMode.active}
+>
   <div class="h-[25dvh] w-full"></div>
   <div
     class="relative h-[50dvh] w-full transition-opacity duration-500 ease-out"
-    class:opacity-0={gameMode.active}
-    class:pointer-events-none={gameMode.active}
+    class:opacity-0={gameMode.active || messageMode.active}
+    class:pointer-events-none={gameMode.active || messageMode.active}
   >
     <Gallery />
   </div>
   <div class="h-[25dvh] w-full"></div>
 
-  <BrandSignoff heading gameClickable />
+  <BrandSignoff heading gameClickable messageClickable />
 
   <!-- Countdown sits in the same bottom-left slot as the wordmark — the
        wordmark fades out for the duration so this is the only thing in
@@ -97,7 +107,20 @@
       again?
     </button>
   {/if}
+
 </main>
+
+<!-- "message me?" letter mode. Sits OUTSIDE main so it stays interactive
+     while main is `inert` — Gallery + wordmark + tagline have already
+     faded out (handled by the active checks above and inside
+     BrandSignoff). The cream letter card animates in
+     centered/fullscreen, and the bottom-right SendAction morphs from
+     "message me?" to "send it?" when both fields are filled. The menu
+     coin top-right flips to "x" (see Guide) so the user can quit. -->
+{#if messageMode.active}
+  <MessageLetter />
+  <SendAction />
+{/if}
 
 <style>
   /* Each digit pops in fast, scales out as the next one (or the game)

--- a/src/routes/api/message/+server.ts
+++ b/src/routes/api/message/+server.ts
@@ -1,0 +1,101 @@
+// POST /api/message — the "message me?" easter-egg endpoint. Receives
+// { email, body, website } from the homepage letter form; sends via
+// Resend to sam@threesam.com.
+//
+// Bot mitigation:
+//   - `website` is a hidden honeypot. Real users can't see it, so any
+//     non-empty value means a bot filled the form; we silently 200 so
+//     the bot thinks it succeeded.
+//   - Best-effort per-IP rate limit (in-memory; resets per cold start
+//     on Vercel, so it's a speed-bump not a fortress).
+//   - Strict size + format validation; nothing about the schema is
+//     forgiving.
+//
+// Env (set in Vercel):
+//   RESEND_API_KEY     — required. Resend dashboard → API Keys.
+//   MESSAGE_FROM_EMAIL — optional. From-address; defaults to the safe
+//                        Resend sandbox `onboarding@resend.dev` so the
+//                        endpoint works before a custom domain is
+//                        verified. Set this once threesam.com (or
+//                        another owned domain) is verified in Resend.
+import { json, error } from '@sveltejs/kit';
+import { env } from '$env/dynamic/private';
+import { Resend } from 'resend';
+import type { RequestHandler } from './$types';
+
+const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_BODY_LEN = 5000;
+const MAX_EMAIL_LEN = 200;
+const RATE_LIMIT_MS = 60_000;
+const RATE_LIMIT_MAX_ENTRIES = 256;
+const TO_EMAIL = 'sam@threesam.com';
+const DEFAULT_FROM = 'onboarding@resend.dev';
+
+const lastSent = new Map<string, number>();
+
+// Lazy module-scope client. Resend is a thin HTTP wrapper that has no
+// connection state worth reusing, but constructing it per request still
+// parses the key + sets up the fetch wrapper — skip that on the hot path.
+let _resend: Resend | null = null;
+function resendClient(): Resend {
+	if (!_resend) _resend = new Resend(env.RESEND_API_KEY);
+	return _resend;
+}
+
+// Evict stale rate-limit entries inline; without this `lastSent` grows
+// unboundedly across a warm serverless instance. Costs O(n) but only
+// runs once the map is past its soft cap.
+function sweepRateLimit(now: number) {
+	if (lastSent.size < RATE_LIMIT_MAX_ENTRIES) return;
+	for (const [ip, ts] of lastSent) {
+		if (now - ts > RATE_LIMIT_MS) lastSent.delete(ip);
+	}
+}
+
+export const POST: RequestHandler = async ({ request, getClientAddress }) => {
+	const payload = (await request.json().catch(() => null)) as
+		| { email?: unknown; body?: unknown; website?: unknown }
+		| null;
+	if (!payload) error(400, 'invalid payload');
+
+	// Honeypot — bots fill every visible field. Any non-empty `website`
+	// means a bot; pretend success so they don't retry.
+	if (typeof payload.website === 'string' && payload.website.trim().length > 0) {
+		return json({ ok: true });
+	}
+
+	const email = typeof payload.email === 'string' ? payload.email.trim() : '';
+	const body = typeof payload.body === 'string' ? payload.body.trim() : '';
+	if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RX.test(email)) {
+		error(400, 'invalid email');
+	}
+	if (!body || body.length > MAX_BODY_LEN) error(400, 'invalid message');
+
+	const ip = getClientAddress();
+	const now = Date.now();
+	const last = lastSent.get(ip);
+	if (last && now - last < RATE_LIMIT_MS) error(429, 'slow down');
+	// Mark the IP *before* the await so two near-simultaneous requests
+	// from the same address don't both read undefined and both send.
+	lastSent.set(ip, now);
+	sweepRateLimit(now);
+
+	if (!env.RESEND_API_KEY) {
+		console.error('[/api/message] RESEND_API_KEY missing');
+		error(500, 'service unavailable');
+	}
+
+	const result = await resendClient().emails.send({
+		from: env.MESSAGE_FROM_EMAIL || DEFAULT_FROM,
+		to: TO_EMAIL,
+		replyTo: email,
+		subject: `message me — ${email}`,
+		text: body,
+	});
+	if (result.error) {
+		console.error('[/api/message] resend error', result.error);
+		error(502, 'failed to send');
+	}
+
+	return json({ ok: true });
+};


### PR DESCRIPTION
Click "message me?" in the wordmark → cream letter card (centered desktop / fullscreen mobile) with hey Sam, + invisible auto-focused textarea + sincerely, + email placeholder. Bottom-right action morphs from "message me?" to "send it?" when both fields filled; click sends via /api/message (Resend → sam@threesam.com).

**Env needed in Vercel before this works:**
- `RESEND_API_KEY` — required. Resend dashboard → API Keys.
- `MESSAGE_FROM_EMAIL` — optional; defaults to onboarding@resend.dev until threesam.com is verified in Resend.

Findings applied from /simplify and /code-review on this branch baked into the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)