### PR TITLE
harden message endpoint: server logging, activate honeypot, surface errors

### DIFF
--- a/src/lib/components/message/MessageLetter.svelte
+++ b/src/lib/components/message/MessageLetter.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import { messageMode } from '$lib/message-mode.svelte';
+	import { MAX_BODY_LEN, MAX_EMAIL_LEN } from '$lib/message-schema';
 
 	// Imitates a handwritten letter: "hey Sam," at the top, an invisible
 	// textarea where the cursor starts (no placeholder — the blinking
@@ -46,7 +47,7 @@
 			use:autofocus
 			bind:value={messageMode.body}
 			rows="6"
-			maxlength="5000"
+			maxlength={MAX_BODY_LEN}
 			aria-label="your message"
 		></textarea>
 		<p class="line signoff">sincerely,</p>
@@ -55,7 +56,7 @@
 			type="email"
 			autocomplete="email"
 			inputmode="email"
-			maxlength="200"
+			maxlength={MAX_EMAIL_LEN}
 			placeholder="your email?"
 			aria-label="your email"
 			bind:value={messageMode.email}

--- a/src/lib/components/message/MessageLetter.svelte
+++ b/src/lib/components/message/MessageLetter.svelte
@@ -70,6 +70,7 @@
 			class="honeypot"
 			type="text"
 			name="website"
+			bind:value={messageMode.website}
 			tabindex="-1"
 			autocomplete="off"
 			aria-hidden="true"

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -13,15 +13,18 @@
 //   sent    — post succeeded; brief "sent it!" beat before auto-close
 //   error   — null when fine; string when the post failed
 
+import { EMAIL_RX, MAX_EMAIL_LEN, MAX_BODY_LEN } from '$lib/message-schema';
+
 const CLOSE_DELAY_MS = 500;
 const SENT_HOLD_MS = 1500;
-
-const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 class MessageMode {
 	active = $state(false);
 	email = $state('');
 	body = $state('');
+	// Honeypot — bound to a hidden field the user never sees. Bots that fill
+	// every input trip it; the server silently 200s without sending.
+	website = $state('');
 	sending = $state(false);
 	sent = $state(false);
 	error = $state<string | null>(null);
@@ -38,7 +41,14 @@ class MessageMode {
 	}
 
 	get formValid() {
-		return this.body.trim().length > 0 && EMAIL_RX.test(this.email.trim());
+		const email = this.email.trim();
+		const body = this.body.trim();
+		return (
+			body.length > 0 &&
+			body.length <= MAX_BODY_LEN &&
+			email.length <= MAX_EMAIL_LEN &&
+			EMAIL_RX.test(email)
+		);
 	}
 
 	start() {
@@ -57,6 +67,7 @@ class MessageMode {
 		this.sched(CLOSE_DELAY_MS, () => {
 			this.email = '';
 			this.body = '';
+			this.website = '';
 			this.sending = false;
 			this.sent = false;
 			this.error = null;
@@ -74,11 +85,13 @@ class MessageMode {
 				body: JSON.stringify({
 					email: this.email.trim(),
 					body: this.body.trim(),
+					website: this.website,
 				}),
 			});
 			if (!res.ok) {
-				const data = (await res.json().catch(() => null)) as { error?: string } | null;
-				this.error = data?.error || 'failed to send';
+				// SvelteKit's error() returns { message }, not { error }.
+				const data = (await res.json().catch(() => null)) as { message?: string } | null;
+				this.error = data?.message || 'failed to send';
 				return;
 			}
 			this.sent = true;

--- a/src/lib/message-schema.ts
+++ b/src/lib/message-schema.ts
@@ -1,0 +1,7 @@
+// Shared validation contract for the "message me?" contact form. Imported by
+// both the client (message-mode) and the server (api/message) so the gate the
+// user sees and the gate the server enforces can never drift apart — a looser
+// client would let someone hit "send it?" only to get a confusing 400.
+export const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+export const MAX_EMAIL_LEN = 200;
+export const MAX_BODY_LEN = 5000;

--- a/src/lib/server/ttl-cache.ts
+++ b/src/lib/server/ttl-cache.ts
@@ -27,5 +27,8 @@ export function createTtlCache<V>({ ttlMs, maxEntries = 500 }: TtlCacheOptions) 
       }
       map.set(key, { value, expiresAt: Date.now() + ttlMs });
     },
+    delete(key: string): void {
+      map.delete(key);
+    },
   };
 }

--- a/src/routes/api/message/+server.ts
+++ b/src/routes/api/message/+server.ts
@@ -8,8 +8,9 @@
 //     the bot thinks it succeeded.
 //   - Best-effort per-IP rate limit (in-memory; resets per cold start
 //     on Vercel, so it's a speed-bump not a fortress).
-//   - Strict size + format validation; nothing about the schema is
-//     forgiving.
+//   - Strict size + format validation. The limits live in
+//     $lib/message-schema so the client form gates on the exact same
+//     rules and the two can't drift apart.
 //
 // Env (set in Vercel):
 //   RESEND_API_KEY     — required. Resend dashboard → API Keys.
@@ -21,17 +22,22 @@
 import { json, error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { Resend } from 'resend';
+import { createTtlCache } from '$lib/server/ttl-cache';
+import { EMAIL_RX, MAX_EMAIL_LEN, MAX_BODY_LEN } from '$lib/message-schema';
 import type { RequestHandler } from './$types';
 
-const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MAX_BODY_LEN = 5000;
-const MAX_EMAIL_LEN = 200;
 const RATE_LIMIT_MS = 60_000;
 const RATE_LIMIT_MAX_ENTRIES = 256;
 const TO_EMAIL = 'sam@threesam.com';
 const DEFAULT_FROM = 'onboarding@resend.dev';
 
-const lastSent = new Map<string, number>();
+// Per-IP last-send timestamps. Entries self-expire after RATE_LIMIT_MS and the
+// cache evicts the oldest once past the cap, so the map stays bounded on a warm
+// serverless instance without a manual sweep.
+const rateLimit = createTtlCache<number>({
+	ttlMs: RATE_LIMIT_MS,
+	maxEntries: RATE_LIMIT_MAX_ENTRIES,
+});
 
 // Structured, greppable server log — one JSON line per request outcome so
 // Vercel log search can filter by `event`. Deliberately omits message bodies
@@ -64,16 +70,6 @@ function resendClient(): Resend {
 	return _resend;
 }
 
-// Evict stale rate-limit entries inline; without this `lastSent` grows
-// unboundedly across a warm serverless instance. Costs O(n) but only
-// runs once the map is past its soft cap.
-function sweepRateLimit(now: number) {
-	if (lastSent.size < RATE_LIMIT_MAX_ENTRIES) return;
-	for (const [ip, ts] of lastSent) {
-		if (now - ts > RATE_LIMIT_MS) lastSent.delete(ip);
-	}
-}
-
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ip = getClientAddress();
 
@@ -103,31 +99,46 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		error(400, 'invalid message');
 	}
 
-	const now = Date.now();
-	const last = lastSent.get(ip);
-	if (last && now - last < RATE_LIMIT_MS) {
-		log('rate_limited', { ip, sinceMs: now - last });
-		error(429, 'slow down');
-	}
-	// Mark the IP *before* the await so two near-simultaneous requests
-	// from the same address don't both read undefined and both send.
-	lastSent.set(ip, now);
-	sweepRateLimit(now);
-
+	// Config check before the rate-limit mark so a misconfigured deploy
+	// returns 500 without burning the caller's one-per-minute window.
 	if (!env.RESEND_API_KEY) {
 		log('config_error', { ip, reason: 'RESEND_API_KEY missing' });
 		error(500, 'service unavailable');
 	}
 
+	// Mark the IP *before* the send so two near-simultaneous requests from one
+	// address can't both fire. A failed send releases the mark (below) so a
+	// transient Resend error doesn't lock a real sender out for a minute.
+	const last = rateLimit.get(ip);
+	if (last !== undefined) {
+		log('rate_limited', { ip, sinceMs: Date.now() - last });
+		error(429, 'slow down');
+	}
+	rateLimit.set(ip, Date.now());
+
 	const from = env.MESSAGE_FROM_EMAIL || DEFAULT_FROM;
-	const result = await resendClient().emails.send({
-		from,
-		to: TO_EMAIL,
-		replyTo: email,
-		subject: `message me — ${email}`,
-		text: body,
-	});
+	const started = Date.now();
+	const result = await resendClient()
+		.emails.send({
+			from,
+			to: TO_EMAIL,
+			replyTo: email,
+			subject: `message me — ${email}`,
+			text: body,
+		})
+		.catch((err: unknown) => {
+			// Network/SDK throw (vs the structured { error } below).
+			rateLimit.delete(ip);
+			log('resend_error', {
+				ip,
+				from,
+				thrown: true,
+				message: err instanceof Error ? err.message : String(err),
+			});
+			error(502, 'failed to send');
+		});
 	if (result.error) {
+		rateLimit.delete(ip);
 		log('resend_error', { ip, from, name: result.error.name, message: result.error.message });
 		error(502, 'failed to send');
 	}
@@ -137,7 +148,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		id: result.data?.id,
 		emailDomain: emailDomain(email),
 		bodyLen: body.length,
-		ms: Date.now() - now,
+		ms: Date.now() - started,
 	});
 	return json({ ok: true });
 };

--- a/src/routes/api/message/+server.ts
+++ b/src/routes/api/message/+server.ts
@@ -33,6 +33,28 @@ const DEFAULT_FROM = 'onboarding@resend.dev';
 
 const lastSent = new Map<string, number>();
 
+// Structured, greppable server log — one JSON line per request outcome so
+// Vercel log search can filter by `event`. Deliberately omits message bodies
+// and full sender addresses (logs an email *domain* + lengths only) so the
+// logs stay diagnostic without hoarding PII.
+type LogEvent =
+	| 'sent'
+	| 'honeypot'
+	| 'rate_limited'
+	| 'invalid_payload'
+	| 'invalid_email'
+	| 'invalid_message'
+	| 'resend_error'
+	| 'config_error';
+function log(event: LogEvent, fields: Record<string, unknown> = {}) {
+	const line = JSON.stringify({ scope: 'api/message', event, ...fields });
+	if (event === 'resend_error' || event === 'config_error') console.error(line);
+	else if (event === 'rate_limited' || event === 'honeypot') console.warn(line);
+	else console.log(line);
+}
+
+const emailDomain = (email: string) => email.slice(email.lastIndexOf('@') + 1) || 'unknown';
+
 // Lazy module-scope client. Resend is a thin HTTP wrapper that has no
 // connection state worth reusing, but constructing it per request still
 // parses the key + sets up the fetch wrapper — skip that on the hot path.
@@ -53,49 +75,69 @@ function sweepRateLimit(now: number) {
 }
 
 export const POST: RequestHandler = async ({ request, getClientAddress }) => {
+	const ip = getClientAddress();
+
 	const payload = (await request.json().catch(() => null)) as
 		| { email?: unknown; body?: unknown; website?: unknown }
 		| null;
-	if (!payload) error(400, 'invalid payload');
+	if (!payload) {
+		log('invalid_payload', { ip });
+		error(400, 'invalid payload');
+	}
 
 	// Honeypot — bots fill every visible field. Any non-empty `website`
 	// means a bot; pretend success so they don't retry.
 	if (typeof payload.website === 'string' && payload.website.trim().length > 0) {
+		log('honeypot', { ip });
 		return json({ ok: true });
 	}
 
 	const email = typeof payload.email === 'string' ? payload.email.trim() : '';
 	const body = typeof payload.body === 'string' ? payload.body.trim() : '';
 	if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RX.test(email)) {
+		log('invalid_email', { ip, emailLen: email.length });
 		error(400, 'invalid email');
 	}
-	if (!body || body.length > MAX_BODY_LEN) error(400, 'invalid message');
+	if (!body || body.length > MAX_BODY_LEN) {
+		log('invalid_message', { ip, bodyLen: body.length });
+		error(400, 'invalid message');
+	}
 
-	const ip = getClientAddress();
 	const now = Date.now();
 	const last = lastSent.get(ip);
-	if (last && now - last < RATE_LIMIT_MS) error(429, 'slow down');
+	if (last && now - last < RATE_LIMIT_MS) {
+		log('rate_limited', { ip, sinceMs: now - last });
+		error(429, 'slow down');
+	}
 	// Mark the IP *before* the await so two near-simultaneous requests
 	// from the same address don't both read undefined and both send.
 	lastSent.set(ip, now);
 	sweepRateLimit(now);
 
 	if (!env.RESEND_API_KEY) {
-		console.error('[/api/message] RESEND_API_KEY missing');
+		log('config_error', { ip, reason: 'RESEND_API_KEY missing' });
 		error(500, 'service unavailable');
 	}
 
+	const from = env.MESSAGE_FROM_EMAIL || DEFAULT_FROM;
 	const result = await resendClient().emails.send({
-		from: env.MESSAGE_FROM_EMAIL || DEFAULT_FROM,
+		from,
 		to: TO_EMAIL,
 		replyTo: email,
 		subject: `message me — ${email}`,
 		text: body,
 	});
 	if (result.error) {
-		console.error('[/api/message] resend error', result.error);
+		log('resend_error', { ip, from, name: result.error.name, message: result.error.message });
 		error(502, 'failed to send');
 	}
 
+	log('sent', {
+		ip,
+		id: result.data?.id,
+		emailDomain: emailDomain(email),
+		bodyLen: body.length,
+		ms: Date.now() - now,
+	});
 	return json({ ok: true });
 };


### PR DESCRIPTION
Follow-up hardening for the "message me?" contact form (#237), driven by a security + code-review + simplify pass.

## Observability (the original ask)
- Structured, greppable server logging — one JSON line per outcome (`sent` / `honeypot` / `rate_limited` / `invalid_*` / `resend_error` / `config_error`) so issues are diagnosable in Vercel logs.
- Logs email **domain** + lengths + Resend id + timing — never message bodies or full sender addresses (PII hygiene).
- Thrown sends (network/SDK rejects, vs the structured `{error}`) are now caught and logged instead of producing invisible 500s.

## Bugs found & fixed
- **Honeypot was dead.** The client never sent `website` (it posted only `{email,body}`), so the server's honeypot branch could never fire. Bound the hidden field and included it in the POST — the bot trap now actually works.
- **Form always showed a generic error.** The client read `data.error`, but SvelteKit's `error()` returns `{message}`, so "slow down" / "invalid email" never surfaced. Reads `data.message` now.
- A failed send used to lock the sender's IP for 60s; it now releases the rate-limit window on failure.

## Simplification / reuse
- Replaced the hand-rolled `lastSent` Map + `sweepRateLimit` with the existing `createTtlCache` util (bounded LRU eviction, no manual sweep, fixes an unbounded-growth edge). Added a `delete()` method to the cache for the release-on-failure path.
- Hoisted `EMAIL_RX` + length caps to `$lib/message-schema`, imported by **both** client and server so validation can't drift; client `formValid` and the input `maxlength`s now gate on the same source of truth.
- Moved the `RESEND_API_KEY` config check ahead of the rate-limit mark.

## Verified
- `svelte-check`: 0 errors. Production build: clean. `svelte-autofixer` on the runes module: no issues.
- Security review: no vulnerabilities. Code-review (2 rounds): no correctness defects remaining.
- Known low-risk item consciously accepted: honeypot field name `website` is autofill-prone, but it's off-screen + `tabindex=-1` + `aria-hidden` + `autocomplete=off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)