### PR TITLE
message form: name field, top-aligned letter, clearer send action

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -106,7 +106,14 @@
   <span
     class="msg-tail-group"
     class:clickable={messageClickable}
-    onclick={messageClickable ? () => messageMode.start() : undefined}
+    onclick={messageClickable
+      ? () => {
+          // Consume the reveal on entry so the wordmark is back to
+          // "threesam" (not stuck on "message me?") when the letter closes.
+          messageOn = false;
+          messageMode.start();
+        }
+      : undefined}
   >
     {#each MESSAGE_TAIL as l, i (`msg-${i}`)}
       <span class="msg-tail" style="--msg-delay: {100 + i * 80}ms">{l}</span>

--- a/src/lib/components/message/MessageLetter.svelte
+++ b/src/lib/components/message/MessageLetter.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
 	import { messageMode } from '$lib/message-mode.svelte';
-	import { MAX_BODY_LEN, MAX_EMAIL_LEN } from '$lib/message-schema';
+	import { MAX_BODY_LEN, MAX_EMAIL_LEN, MAX_NAME_LEN } from '$lib/message-schema';
 
 	// Imitates a handwritten letter: "hey Sam," at the top, an invisible
 	// textarea where the cursor starts (no placeholder — the blinking
@@ -48,9 +48,19 @@
 			bind:value={messageMode.body}
 			rows="6"
 			maxlength={MAX_BODY_LEN}
+			placeholder="your message"
 			aria-label="your message"
 		></textarea>
 		<p class="line signoff">sincerely,</p>
+		<input
+			class="name"
+			type="text"
+			autocomplete="name"
+			maxlength={MAX_NAME_LEN}
+			placeholder="your name?"
+			aria-label="your name"
+			bind:value={messageMode.name}
+		/>
 		<input
 			class="email"
 			type="email"
@@ -91,9 +101,12 @@
 		z-index: 35;
 		inset: 0;
 		display: grid;
-		place-items: center;
+		place-items: start center;
+		overflow-y: auto;
 		background: var(--white);
-		padding: 6rem 1.5rem 8rem;
+		/* Snap to the top (below the nav coin); leave room at the bottom so
+		   the fixed "send message" action never covers the last field. */
+		padding: 4.5rem 1.5rem 8rem;
 	}
 	@media (min-width: 768px) {
 		.card {
@@ -140,6 +153,7 @@
 		margin-top: 1.2rem;
 	}
 	.body,
+	.name,
 	.email {
 		width: 100%;
 		background: transparent;
@@ -155,14 +169,13 @@
 		min-height: 8rem;
 		line-height: 1.55;
 	}
-	.email {
-		padding-left: 0;
-	}
 	.body::placeholder,
+	.name::placeholder,
 	.email::placeholder {
 		color: rgba(0, 0, 0, 0.35);
 	}
 	.body:focus,
+	.name:focus,
 	.email:focus {
 		outline: none;
 	}

--- a/src/lib/components/message/MessageLetter.svelte
+++ b/src/lib/components/message/MessageLetter.svelte
@@ -105,8 +105,10 @@
 		overflow-y: auto;
 		background: var(--white);
 		/* Snap to the top (below the nav coin); leave room at the bottom so
-		   the fixed "send message" action never covers the last field. */
-		padding: 4.5rem 1.5rem 8rem;
+		   the fixed "send message" action never covers the last field —
+		   growing with the keyboard inset so the email field can scroll
+		   clear of the action when the keyboard is open. */
+		padding: 4.5rem 1.5rem calc(8rem + var(--kb-inset, 0px));
 	}
 	@media (min-width: 768px) {
 		.card {

--- a/src/lib/components/message/SendAction.svelte
+++ b/src/lib/components/message/SendAction.svelte
@@ -2,111 +2,84 @@
 	import { fade } from 'svelte/transition';
 	import { messageMode } from '$lib/message-mode.svelte';
 
-	// Bottom-right action label. Two letter sets sit in the same flex row,
-	// one collapsed at a time — same trick the wordmark uses for
-	// threesam ↔ snake / threesam ↔ message me?:
-	//
-	//   .ready  → form is filled & valid → "send it?" expands, "message
-	//             me?" collapses, click submits
-	//   default → "message me?" reads as a label, no-op click
-	const MESSAGE_CHARS = ['m', 'e', 's', 's', 'a', 'g', 'e', ' ', 'm', 'e', '?'];
-	const SEND_CHARS = ['s', 'e', 'n', 'd', ' ', 'i', 't', '?'];
-
+	// Bottom-right "send message" action. Muted + disabled until the letter is
+	// filled out — message + name + a valid email — then it lights up and
+	// submits on click / Enter / Space (native <button> handles the keys).
 	const ready = $derived(messageMode.formValid && !messageMode.sending && !messageMode.sent);
+	const label = $derived(messageMode.sending ? 'sending...' : 'send message');
+
+	// Keep the action visible above the on-screen keyboard. iOS Safari leaves
+	// position:fixed pinned to the layout viewport (i.e. behind the keyboard),
+	// so track the visual viewport and lift the button by the covered height.
+	$effect(() => {
+		const vv = window.visualViewport;
+		if (!vv) return;
+		const root = document.documentElement;
+		const update = () => {
+			const inset = Math.max(0, window.innerHeight - vv.height - vv.offsetTop);
+			root.style.setProperty('--kb-inset', `${inset}px`);
+		};
+		update();
+		vv.addEventListener('resize', update);
+		vv.addEventListener('scroll', update);
+		return () => {
+			vv.removeEventListener('resize', update);
+			vv.removeEventListener('scroll', update);
+			root.style.removeProperty('--kb-inset');
+		};
+	});
 
 	function onClick() {
 		if (!ready) return;
 		void messageMode.send();
 	}
-
-	function onKey(e: KeyboardEvent) {
-		if (!ready) return;
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			void messageMode.send();
-		}
-	}
 </script>
 
-<div
+<button
+	type="button"
 	class="action"
 	class:ready
-	class:clickable={ready}
-	role="button"
-	tabindex={ready ? 0 : -1}
-	aria-disabled={!ready}
-	aria-label={ready ? 'send the message' : 'message Sam — fill in the message and your email'}
+	disabled={!ready}
 	onclick={onClick}
-	onkeydown={onKey}
 	transition:fade={{ duration: 350 }}
 >
-	{#each MESSAGE_CHARS as l, i (`msg-${i}`)}
-		<span class="msg" style="--d: {i * 60}ms">{l}</span>
-	{/each}
-	{#each SEND_CHARS as l, i (`snd-${i}`)}
-		<span class="snd" style="--d: {i * 70}ms">{l}</span>
-	{/each}
-</div>
+	{label}
+</button>
 
 <style>
 	.action {
 		position: fixed;
-		bottom: 1.5rem;
 		right: 1.5rem;
+		bottom: calc(1.5rem + var(--kb-inset, 0px));
 		z-index: 50;
-		display: flex;
-		align-items: baseline;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		background: none;
 		font-family: 'Recursive Mono', ui-monospace, monospace;
 		font-weight: 700;
 		font-size: 1.875rem;
 		letter-spacing: 0.04em;
 		color: var(--black);
+		white-space: nowrap;
+		opacity: 0.3;
+		cursor: not-allowed;
 		user-select: none;
-		cursor: default;
+		transition: opacity 300ms ease-out;
 	}
 	@media (min-width: 768px) {
 		.action {
-			bottom: 2rem;
 			right: 2rem;
+			bottom: calc(2rem + var(--kb-inset, 0px));
 			font-size: 2.25rem;
 		}
 	}
-	.action.clickable {
+	.action.ready {
+		opacity: 1;
 		cursor: pointer;
 	}
-	.msg,
-	.snd {
-		display: inline-block;
-		overflow: hidden;
-		white-space: pre;
-		transition:
-			max-width 450ms cubic-bezier(0.4, 0, 0.2, 1),
-			opacity 350ms ease-out;
-		max-width: 1em;
-		opacity: 1;
-		transition-delay: 0ms;
-	}
-	/* "send it?" is the alt set — collapsed by default. */
-	.snd {
-		max-width: 0;
-		opacity: 0;
-	}
-	/* READY (form valid): "message me?" collapses, "send it?" expands,
-	   both staggered so the morph reads as a transformation rather than
-	   a swap. */
-	.ready .msg {
-		max-width: 0;
-		opacity: 0;
-		transition-delay: var(--d, 0ms);
-	}
-	.ready .snd {
-		max-width: 1em;
-		opacity: 1;
-		transition-delay: var(--d, 0ms);
-	}
 	@media (prefers-reduced-motion: reduce) {
-		.msg,
-		.snd {
+		.action {
 			transition: none;
 		}
 	}

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -13,15 +13,16 @@
 //   sent    — post succeeded; brief "sent it!" beat before auto-close
 //   error   — null when fine; string when the post failed
 
-import { EMAIL_RX, MAX_EMAIL_LEN, MAX_BODY_LEN } from '$lib/message-schema';
+import { EMAIL_RX, MAX_EMAIL_LEN, MAX_NAME_LEN, MAX_BODY_LEN } from '$lib/message-schema';
 
 const CLOSE_DELAY_MS = 500;
 const SENT_HOLD_MS = 1500;
 
 class MessageMode {
 	active = $state(false);
-	email = $state('');
 	body = $state('');
+	name = $state('');
+	email = $state('');
 	// Honeypot — bound to a hidden field the user never sees. Bots that fill
 	// every input trip it; the server silently 200s without sending.
 	website = $state('');
@@ -41,11 +42,14 @@ class MessageMode {
 	}
 
 	get formValid() {
+		const name = this.name.trim();
 		const email = this.email.trim();
 		const body = this.body.trim();
 		return (
 			body.length > 0 &&
 			body.length <= MAX_BODY_LEN &&
+			name.length > 0 &&
+			name.length <= MAX_NAME_LEN &&
 			email.length <= MAX_EMAIL_LEN &&
 			EMAIL_RX.test(email)
 		);
@@ -65,8 +69,9 @@ class MessageMode {
 		// Reset the form only after the close animation completes so the
 		// fields don't visibly clear while the card is still fading out.
 		this.sched(CLOSE_DELAY_MS, () => {
-			this.email = '';
 			this.body = '';
+			this.name = '';
+			this.email = '';
 			this.website = '';
 			this.sending = false;
 			this.sent = false;
@@ -83,6 +88,7 @@ class MessageMode {
 				method: 'POST',
 				headers: { 'content-type': 'application/json' },
 				body: JSON.stringify({
+					name: this.name.trim(),
 					email: this.email.trim(),
 					body: this.body.trim(),
 					website: this.website,

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -80,7 +80,7 @@ class MessageMode {
 	}
 
 	async send() {
-		if (this.sending || !this.formValid) return;
+		if (this.sending || this.sent || !this.formValid) return;
 		this.sending = true;
 		this.error = null;
 		try {

--- a/src/lib/message-schema.ts
+++ b/src/lib/message-schema.ts
@@ -4,4 +4,5 @@
 // client would let someone hit "send it?" only to get a confusing 400.
 export const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 export const MAX_EMAIL_LEN = 200;
+export const MAX_NAME_LEN = 100;
 export const MAX_BODY_LEN = 5000;

--- a/src/routes/api/message/+server.ts
+++ b/src/routes/api/message/+server.ts
@@ -23,7 +23,7 @@ import { json, error } from '@sveltejs/kit';
 import { env } from '$env/dynamic/private';
 import { Resend } from 'resend';
 import { createTtlCache } from '$lib/server/ttl-cache';
-import { EMAIL_RX, MAX_EMAIL_LEN, MAX_BODY_LEN } from '$lib/message-schema';
+import { EMAIL_RX, MAX_EMAIL_LEN, MAX_NAME_LEN, MAX_BODY_LEN } from '$lib/message-schema';
 import type { RequestHandler } from './$types';
 
 const RATE_LIMIT_MS = 60_000;
@@ -48,6 +48,7 @@ type LogEvent =
 	| 'honeypot'
 	| 'rate_limited'
 	| 'invalid_payload'
+	| 'invalid_name'
 	| 'invalid_email'
 	| 'invalid_message'
 	| 'resend_error'
@@ -74,7 +75,7 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 	const ip = getClientAddress();
 
 	const payload = (await request.json().catch(() => null)) as
-		| { email?: unknown; body?: unknown; website?: unknown }
+		| { name?: unknown; email?: unknown; body?: unknown; website?: unknown }
 		| null;
 	if (!payload) {
 		log('invalid_payload', { ip });
@@ -88,8 +89,13 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 		return json({ ok: true });
 	}
 
+	const name = typeof payload.name === 'string' ? payload.name.trim() : '';
 	const email = typeof payload.email === 'string' ? payload.email.trim() : '';
 	const body = typeof payload.body === 'string' ? payload.body.trim() : '';
+	if (!name || name.length > MAX_NAME_LEN) {
+		log('invalid_name', { ip, nameLen: name.length });
+		error(400, 'invalid name');
+	}
 	if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RX.test(email)) {
 		log('invalid_email', { ip, emailLen: email.length });
 		error(400, 'invalid email');
@@ -123,8 +129,8 @@ export const POST: RequestHandler = async ({ request, getClientAddress }) => {
 			from,
 			to: TO_EMAIL,
 			replyTo: email,
-			subject: `message me — ${email}`,
-			text: body,
+			subject: `message me — ${name}`,
+			text: `${body}\n\n— ${name}\n${email}`,
 		})
 		.catch((err: unknown) => {
 			// Network/SDK throw (vs the structured { error } below).


### PR DESCRIPTION
UX iteration on the "message me?" letter form (verified on mobile + desktop).

## Changes
- **Name field.** `sincerely,` → `your name?` → `your email?`. Sent in the POST, validated server-side (≤100 chars), surfaced in the email (subject `message me — {name}`, body signed `— {name} / {email}`).
- **`your message`** placeholder on the textarea.
- **Top-aligned letter** (below the nav coin) instead of vertically centered, and scrollable — better with the keyboard open.
- **Send action** is now a real `<button>` reading **`send message`**: muted + disabled until message + name + a valid email, then it lights up. Lifts above the on-screen keyboard via the VisualViewport API; the card's bottom padding grows with the keyboard inset.

## Fixes (from review + a reported bug)
- **Wordmark stuck on "message me?" after exiting the letter** — `BrandSignoff`'s reveal state wasn't reset. Now reverts to `threesam` on close.
- **Double-send guard** — `send()` also checks `sent`, so Enter during the 1.5s "sent" hold can't re-fire (the keyboard-submit path bypassed the disabled button).

## Verified
- `svelte-check` 0 errors, production build clean, `svelte-autofixer` clean.
- Security review: no vulnerability (the `name` goes through Resend's JSON API — no header injection; not logged).
- Visual: mobile empty/filled + desktop confirmed; the stuck-state fix confirmed in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)