### PR TITLE
fix(voronoi): match canvas buffer to display aspect + render at DPR

### DIFF
--- a/src/lib/components/canvas/actions/voronoi.ts
+++ b/src/lib/components/canvas/actions/voronoi.ts
@@ -407,8 +407,13 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
   node.addEventListener('touchend', onTouchEnd);
 
   function resize() {
-    node.width = Math.max(1, Math.round(node.offsetWidth * renderScale));
-    node.height = Math.max(1, Math.round(node.offsetHeight * renderScale));
+    // Render at the device's physical pixel density (capped at 2× for perf)
+    // so the cell edges stay crisp on retina screens — without this the
+    // buffer is CSS-pixel sized and the browser upscales it, blurring the
+    // lines on a 2–3× phone.
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    node.width = Math.max(1, Math.round(node.offsetWidth * renderScale * dpr));
+    node.height = Math.max(1, Math.round(node.offsetHeight * renderScale * dpr));
     gl.viewport(0, 0, node.width, node.height);
     gl.uniform2f(uResolution, node.width, node.height);
     const resolvedScale = scale ?? (node.offsetWidth < MOBILE_BREAK ? SCALE_MOBILE : SCALE_DESKTOP);
@@ -430,15 +435,26 @@ export const voronoi: Action<HTMLCanvasElement, VoronoiParams> = (node, initialP
   );
   observer.observe(node);
 
-  // Skip height-only resizes. iOS Safari grows the viewport as the URL
-  // bar collapses on scroll — without this filter every scroll reshuffles
-  // every cell, which reads as the whole hero re-rolling under the user.
-  // Width changes (rotation, real layout shifts) still trigger a re-fit.
+  // Re-fit on width changes (rotation, real layout shifts) and on aspect
+  // changes. The aspect trigger is what catches the one-time banner reshape
+  // when the source image loads and the container swaps the placeholder aspect
+  // for the image's real one — without it the canvas keeps the wrong-aspect
+  // buffer and object-cover scales it up, blurring + cropping the result.
+  //
+  // Height-only changes at a CONSTANT aspect are still ignored: iOS Safari
+  // grows the viewport as the URL bar collapses on scroll, scaling dvh-sized
+  // banners proportionally (aspect unchanged) — re-fitting there would
+  // reshuffle every cell under the user.
   let lastWidth = node.offsetWidth;
+  let lastAspect = node.offsetWidth / Math.max(1, node.offsetHeight);
   let resizeTimer = 0;
   const resizeObserver = new ResizeObserver(() => {
-    if (node.offsetWidth === lastWidth) return;
-    lastWidth = node.offsetWidth;
+    const width = node.offsetWidth;
+    const aspect = width / Math.max(1, node.offsetHeight);
+    const aspectChanged = Math.abs(aspect - lastAspect) > lastAspect * 0.01;
+    if (width === lastWidth && !aspectChanged) return;
+    lastWidth = width;
+    lastAspect = aspect;
     clearTimeout(resizeTimer);
     resizeTimer = setTimeout(resize, 100) as unknown as number;
   });


### PR DESCRIPTION
The /self voronoi banners were off-center and blurry on mobile (your screenshots). Two causes, both fixed:

## Aspect mismatch (the off-center + most of the blur)
Banners start at a placeholder aspect (1.78) and reshape to the image's real aspect once it loads. The canvas `ResizeObserver` skipped height-only changes (an iOS URL-bar guard), so a **portrait** banner kept its `390×219` landscape buffer while displaying `390×693` — `object-cover` then scaled that buffer ~3× and center-cropped it, which read as blurry **and** off-center (a zoomed center strip of a landscape render).

Now it also re-fits on **aspect** change (the image-load reshape), so the buffer matches the display. Constant-aspect dvh scroll jitter is still ignored, so the iOS guard holds. Verified in-browser: buffer now `390×693`, exactly matching the display.

## Missing devicePixelRatio (retina crispness)
The buffer was sized in CSS pixels, never multiplied by DPR, so a 2–3× phone upscaled it. Renders at `min(dpr, 2)×` now.

## Verified
`svelte-check` 0 errors, build clean. Aspect fix confirmed in headless (buffer matches display, "PIECE OF PAPER" renders the full portrait composition centered). The DPR half only shows on a real retina device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)