### PR TITLE
fix(links): tighten prose link underline so it doesn't bleed to the next line

### DIFF
--- a/src/lib/components/link.ts
+++ b/src/lib/components/link.ts
@@ -1,4 +1,4 @@
 // Shared link-styling class string. Import in components that render
 // <a> tags via markup or marked renderer overrides.
 export const linkClasses =
-  'border-b-2 border-coin pb-1.5 hover:pb-0 motion-safe:hover:animate-[link-glitch_2s_ease-in-out_infinite] transition-[padding-bottom] duration-300';
+  'border-b-2 border-coin pb-0.5 hover:pb-0 motion-safe:hover:animate-[link-glitch_2s_ease-in-out_infinite] transition-[padding-bottom] duration-300';


### PR DESCRIPTION
Prose links are inline with `border-b-2` + `pb-1.5` (6px). Inline padding-bottom doesn't reflow the following line, so the underline painted ~8px below the word — drifting into the next line of text (your screenshot). Tightened the resting pad to `pb-0.5` (2px) so the rule hugs its own word; `hover:pb-0` + the glitch animation still fire.

Verified in-browser: the underline now sits tight under the word, cleanly separated from the line below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)