### PR TITLE
feat(wordmark): homepage-only easter egg; fade gallery on message reveal

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -38,27 +38,24 @@
   const MESSAGE_TAIL = ['e', 's', 's', 'a', 'g', 'e', ' ', 'm', 'e', '?'];
   const active = $derived(gameMode.active);
 
-  // Click-toggled reveal of the message tail — the only path on every device
-  // (no hover preview, which would slide the "m" out from under the cursor and
-  // flicker). The toggle no-ops while the game is running so the two tails
-  // can't both expand at once.
-  let messageOn = $state(false);
+  // Click-toggled reveal of the message tail (click only — a hover preview
+  // would slide the "m" out from under the cursor and flicker). State lives on
+  // messageMode so the homepage can fade the gallery + tagline as the letters
+  // fade in, same as the snake game. messageMode.stop() clears it on close, so
+  // the wordmark returns to "threesam". No-op while the game is running so the
+  // two tails can't both expand at once.
   const toggleMessage = () => {
     if (active) return;
-    messageOn = !messageOn;
+    messageMode.revealing = !messageMode.revealing;
   };
-  // When the "message me?" letter closes (the x / Esc), drop the reveal so
-  // the wordmark returns to "threesam" instead of staying on "message me?".
-  $effect(() => {
-    if (!messageMode.active) messageOn = false;
-  });
+  const mLabel = $derived(messageMode.revealing ? 'hide message me?' : 'show message me?');
 </script>
 
 <svelte:element
   this={tag}
   class="wordmark absolute bottom-6 left-6 z-50 flex font-mono text-3xl font-bold tracking-meta {color} md:bottom-8 md:left-8 md:text-4xl"
   class:is-game={active}
-  class:show-message={messageOn && !active}
+  class:show-message={messageClickable && messageMode.revealing && !active}
   class:wordmark-hidden={gameMode.wordmarkSlotOccupied || messageMode.active}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
@@ -86,17 +83,20 @@
   {/each}
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <span
-    class="letter m-letter clickable"
-    onclick={toggleMessage}
-    role="button"
-    tabindex="0"
-    aria-label={messageOn ? 'hide message me?' : 'show message me?'}
-    onkeydown={(e: KeyboardEvent) => {
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        toggleMessage();
-      }
-    }}
+    class="letter m-letter"
+    class:clickable={messageClickable}
+    onclick={messageClickable ? toggleMessage : undefined}
+    role={messageClickable ? 'button' : undefined}
+    tabindex={messageClickable ? 0 : undefined}
+    aria-label={messageClickable ? mLabel : undefined}
+    onkeydown={messageClickable
+      ? (e: KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            toggleMessage();
+          }
+        }
+      : undefined}
   >m</span>
   {#each SNAKE_TAIL as l, i (`tail-${i}`)}
     <span class="tail" style="--tail-delay: {200 + i * 130}ms">{l}</span>
@@ -123,7 +123,7 @@
      experience reads as the only content. -->
 <p
   class="tagline absolute right-6 bottom-6 z-10 text-right font-mono text-sm leading-tight tracking-hero {color} md:right-8 md:bottom-8 md:text-base"
-  class:tagline-hidden={active || messageMode.active}
+  class:tagline-hidden={active || messageMode.active || (messageClickable && messageMode.revealing)}
 ><span class="block md:inline">certainly</span><span class="alien" aria-hidden="true"
     ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
       <path

--- a/src/lib/components/frame/Guide.svelte
+++ b/src/lib/components/frame/Guide.svelte
@@ -11,7 +11,7 @@
   // homepage easter-egg mode (snake game, "message me?" letter) borrows
   // it: the coin flips to the x glyph and a click quits that mode
   // instead of opening the nav menu.
-  const inMode = $derived(gameMode.active || messageMode.active);
+  const inMode = $derived(gameMode.active || messageMode.active || messageMode.revealing);
 
   function handleCoinClick() {
     if (gameMode.active) {
@@ -20,6 +20,12 @@
     }
     if (messageMode.active) {
       messageMode.stop();
+      return;
+    }
+    if (messageMode.revealing) {
+      // "message me?" is revealed but the letter isn't open yet — the x
+      // cancels the reveal (restores the gallery) instead of opening the menu.
+      messageMode.revealing = false;
       return;
     }
     open = !open;

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -20,6 +20,10 @@ const SENT_HOLD_MS = 1500;
 
 class MessageMode {
 	active = $state(false);
+	// "message me?" revealed in the wordmark (the "m" was clicked) but the
+	// letter isn't open yet. Drives the same gallery + tagline fade as the
+	// snake game, so the reveal reads as entering a mode — not a label swap.
+	revealing = $state(false);
 	body = $state('');
 	name = $state('');
 	email = $state('');
@@ -66,6 +70,7 @@ class MessageMode {
 	stop() {
 		this.clearTimers();
 		this.active = false;
+		this.revealing = false;
 		// Reset the form only after the close animation completes so the
 		// fields don't visibly clear while the card is still fading out.
 		this.sched(CLOSE_DELAY_MS, () => {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -43,8 +43,8 @@
   <div class="h-[25dvh] w-full"></div>
   <div
     class="relative h-[50dvh] w-full transition-opacity duration-500 ease-out"
-    class:opacity-0={gameMode.active || messageMode.active}
-    class:pointer-events-none={gameMode.active || messageMode.active}
+    class:opacity-0={gameMode.active || messageMode.active || messageMode.revealing}
+    class:pointer-events-none={gameMode.active || messageMode.active || messageMode.revealing}
   >
     <Gallery />
   </div>


### PR DESCRIPTION
## what

Two asks, both behind the bottom-left wordmark easter egg:

1. **special threesam is homepage-only.** The snake/"message me?" interactivity on the wordmark is now gated on the `messageClickable` prop, which only the homepage passes. The footer wordmark (Anchor, every other page) is plain text — no role, tabindex, aria-label, keydown, or pointer cursor.

2. **clicking "m" fades the gallery as "message me?" fades in** — same beat as starting the snake game. The reveal is lifted from a component-local `messageOn` flag into `messageMode.revealing` (shared singleton state), so the homepage gallery + tagline fade out while the letters expand, and the menu coin flips to "×" to cancel.

## why the state moved

The old reset lived in a `$effect` watching `messageMode.active` — fragile (fires only if that component is mounted, and it caused the earlier "stuck message-me state" report). It's now an invariant of `stop()`: every close path (Esc, coin ×, send success, toggle-off) clears `revealing`, so the wordmark can't get stuck on "message me?".

## state machine

| trigger | result |
|---|---|
| click "m" (homepage) | `revealing = true` → gallery + tagline fade, coin → × |
| click "message me?" tail | `start()` → letter opens (`active` dominates all gates) |
| Esc / coin × (letter open) | `stop()` → clears `active` + `revealing` |
| coin × (revealing, letter closed) | cancels reveal, restores gallery |
| click "m" again | toggles reveal off |

## verification

- `pnpm check` → 0 errors (7 pre-existing unused-CSS warnings in `/sounds`, untouched)
- chrome-devtools: homepage m-click → gallery/tagline opacity 0, coin → ×, × restores; footer "m" inert (no role, click is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)