### PR TITLE
feat(seo): add Substack to Person sameAs

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -97,6 +97,7 @@ const PERSON_NODE = {
     "https://www.linkedin.com/in/threesam/",
     "https://github.com/threesam",
     "https://soundcloud.com/threesam",
+    "https://substack.com/@threesam",
     "https://x.com/six_to_m",
     "https://sixtom.com",
   ],


### PR DESCRIPTION
substack.com/@threesam joins the Person sameAs (with the existing linkedin/github/soundcloud/x + sixtom.com cross-link), strengthening the one-entity graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)