### PR TITLE
fix(seo): unlink empty Substack from Person sameAs

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -97,7 +97,9 @@ const PERSON_NODE = {
     "https://www.linkedin.com/in/threesam/",
     "https://github.com/threesam",
     "https://soundcloud.com/threesam",
-    "https://substack.com/@threesam",
+    // Substack deliberately unlisted: the profile has no publication yet, and
+    // a sameAs pointing at an empty shell is an anti-signal. Re-add when
+    // essays actually syndicate there.
     "https://x.com/six_to_m",
     "https://sixtom.com",
   ],


### PR DESCRIPTION
Out of today's growth audit: the Person `sameAs` graph points at a Substack profile with **no publication, 0 posts, 7 followers** — an anti-signal for any human or answer engine that follows the link. Removed (with a comment marking it deliberate) until essays actually syndicate there.

Mirror of threesam/sixtom#126 (which also fixes the broken prod deploy + duplicate og:url there).

One-line diff in `src/lib/seo.ts`; no other substack references exist in src/ or static/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)