### PR TITLE
feat(quiet-list): the guestbook on /thoughts + /sounds — HOLD until listmonk SMTP key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,15 @@ data/finance/
 # git worktrees
 .worktrees/
 
+# leftovers from the Next.js era + agent-session artifacts — never commit.
+# (a stray `git add -A` once swept 6,475 of these into a feature commit.)
+/.next/
+next-env.d.ts
+/.claude/
+/.playwright-mcp/
+/.superset/
+/test-results/
+
 # large media imports
 static/assets/messages/
 data/messages/dianchik/conversation.json

--- a/src/lib/components/QuietList.svelte
+++ b/src/lib/components/QuietList.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  // The quiet list ("guestbook, not billboard"): one line and one field at the
+  // very END of a content page — /thoughts essays, /sounds. Deliberately not a
+  // CTA: no benefit bullets, no subscriber counts, never above the content,
+  // never on the homepage, /self, /benny or /dad. The garden list is double
+  // opt-in, so the success state points at the confirmation mail.
+  import { EMAIL_RX, MAX_EMAIL_LEN } from "$lib/message-schema";
+
+  let { line, placement }: { line: string; placement: string } = $props();
+
+  let email = $state("");
+  let website = $state(""); // honeypot — same trick as the message form
+  let status = $state<"idle" | "sending" | "sent" | "error">("idle");
+
+  const valid = $derived(
+    EMAIL_RX.test(email.trim()) && email.trim().length <= MAX_EMAIL_LEN,
+  );
+
+  async function submit(e: SubmitEvent) {
+    e.preventDefault();
+    if (!valid || status === "sending") return;
+    status = "sending";
+    try {
+      const res = await fetch("/api/subscribe", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), website, placement }),
+      });
+      if (!res.ok) throw new Error(String(res.status));
+      status = "sent";
+      window.umami?.track("quiet-list", { placement });
+    } catch {
+      status = "error";
+    }
+  }
+</script>
+
+<div class="font-mono">
+  {#if status === "sent"}
+    <p class="text-xs text-zinc-500 md:text-sm">
+      sent. confirm in your inbox and you're in.
+    </p>
+  {:else}
+    <p class="text-xs text-zinc-500 md:text-sm">{line}</p>
+    <form onsubmit={submit} class="mt-3 flex items-baseline gap-3">
+      <input
+        type="text"
+        name="website"
+        tabindex="-1"
+        autocomplete="off"
+        bind:value={website}
+        class="hidden"
+        aria-hidden="true"
+      />
+      <input
+        type="email"
+        bind:value={email}
+        maxlength={MAX_EMAIL_LEN}
+        placeholder="address"
+        aria-label="email address"
+        class="w-48 max-w-full border-b border-zinc-700 bg-transparent pb-1 text-sm text-white placeholder:text-zinc-600 focus:border-coin focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={!valid || status === "sending"}
+        class="cursor-pointer text-xs uppercase tracking-section text-zinc-500 transition-colors hover:text-coin disabled:cursor-default disabled:opacity-40"
+      >
+        {status === "sending" ? "…" : "ok"}
+      </button>
+    </form>
+    {#if status === "error"}
+      <p class="mt-2 text-xs text-zinc-600">didn't take. try again?</p>
+    {/if}
+  {/if}
+</div>

--- a/src/routes/api/subscribe/+server.ts
+++ b/src/routes/api/subscribe/+server.ts
@@ -1,0 +1,102 @@
+// POST /api/subscribe — the quiet list ("guestbook") endpoint. Receives
+// { email, website, placement } from the end-of-content form on /thoughts
+// essays and /sounds; forwards to the self-hosted listmonk's PUBLIC
+// subscription endpoint (garden list, double opt-in).
+//
+// This is deliberately NOT growth machinery: the form only exists at the
+// bottom of finished content, and this proxy exists so the page never names
+// the listmonk host (the dead end keeps its seams hidden) and so the same
+// honeypot + rate-limit stance as /api/message guards the box.
+//
+// No credentials involved — the listmonk endpoint is public and the list
+// UUID is the same value any public subscribe form would carry.
+import { json, error } from '@sveltejs/kit';
+import { createTtlCache } from '$lib/server/ttl-cache';
+import { EMAIL_RX, MAX_EMAIL_LEN } from '$lib/message-schema';
+import type { RequestHandler } from './$types';
+
+const LISTMONK_URL = 'https://mail.sixtom.com';
+// `garden` list — essays + first listens. Double opt-in: the confirmation
+// click is itself a digger filter. Never receives sixtom/commercial mail.
+const GARDEN_LIST_UUID = '7d4b7c09-3619-404c-b0bb-1dae0654829b';
+
+const RATE_LIMIT_MS = 60_000;
+const RATE_LIMIT_MAX_ENTRIES = 256;
+const UPSTREAM_TIMEOUT_MS = 5000;
+const MAX_PLACEMENT_LEN = 64;
+
+// Per-IP last-attempt timestamps; same bounded TTL cache as /api/message.
+const rateLimit = createTtlCache<number>({
+	ttlMs: RATE_LIMIT_MS,
+	maxEntries: RATE_LIMIT_MAX_ENTRIES,
+});
+
+// Structured one-line logs, same shape as api/message: email *domain* only.
+type LogEvent = 'subscribed' | 'honeypot' | 'rate_limited' | 'invalid_payload' | 'invalid_email' | 'upstream_error';
+function log(event: LogEvent, fields: Record<string, unknown> = {}) {
+	const line = JSON.stringify({ scope: 'api/subscribe', event, ...fields });
+	if (event === 'upstream_error') console.error(line);
+	else if (event === 'rate_limited' || event === 'honeypot') console.warn(line);
+	else console.log(line);
+}
+
+const emailDomain = (email: string) => email.slice(email.lastIndexOf('@') + 1) || 'unknown';
+
+export const POST: RequestHandler = async ({ request, getClientAddress }) => {
+	const ip = getClientAddress();
+
+	const payload = (await request.json().catch(() => null)) as
+		| { email?: unknown; website?: unknown; placement?: unknown }
+		| null;
+	if (!payload) {
+		log('invalid_payload', { ip });
+		error(400, 'invalid payload');
+	}
+
+	// Honeypot — any non-empty `website` means a bot; pretend success so it
+	// doesn't retry, and nothing reaches the list.
+	if (typeof payload.website === 'string' && payload.website.trim().length > 0) {
+		log('honeypot', { ip });
+		return json({ ok: true });
+	}
+
+	const email = typeof payload.email === 'string' ? payload.email.trim() : '';
+	if (!email || email.length > MAX_EMAIL_LEN || !EMAIL_RX.test(email)) {
+		log('invalid_email', { ip, emailLen: email.length });
+		error(400, 'invalid email');
+	}
+	const placement =
+		typeof payload.placement === 'string' ? payload.placement.slice(0, MAX_PLACEMENT_LEN) : '';
+
+	const last = rateLimit.get(ip);
+	if (last !== undefined) {
+		log('rate_limited', { ip, sinceMs: Date.now() - last });
+		error(429, 'slow down');
+	}
+	rateLimit.set(ip, Date.now());
+
+	const started = Date.now();
+	const res = await fetch(`${LISTMONK_URL}/api/public/subscription`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ email, list_uuids: [GARDEN_LIST_UUID] }),
+		signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+	}).catch((err: unknown) => {
+		// Release the mark so a transient outage doesn't lock a real digger out.
+		rateLimit.delete(ip);
+		log('upstream_error', {
+			ip,
+			thrown: true,
+			message: err instanceof Error ? err.message : String(err),
+		});
+		error(502, 'failed to subscribe');
+	});
+	if (!res.ok) {
+		rateLimit.delete(ip);
+		log('upstream_error', { ip, status: res.status });
+		error(502, 'failed to subscribe');
+	}
+
+	log('subscribed', { ip, emailDomain: emailDomain(email), placement, ms: Date.now() - started });
+	return json({ ok: true });
+};

--- a/src/routes/sounds/+page.svelte
+++ b/src/routes/sounds/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import QuietList from "$lib/components/QuietList.svelte";
   import SeoHead from "$lib/components/SeoHead.svelte";
   import { collectionPageNode } from "$lib/seo";
   import EyeOcean from "$lib/sounds/EyeOcean.svelte";
@@ -330,6 +331,12 @@
     </div>
   </section>
 
+  <!-- The guestbook: end of the listening, same hush behavior as the score
+       section while something plays. -->
+  <section class="quiet" class:hushed={modal} inert={modal}>
+    <QuietList line="new sounds, rarely. first listens go here." placement="sounds" />
+  </section>
+
   <!-- while a grid song plays, a click anywhere pauses it (and brings the cards
        back); the playing card + transport sit above this catcher and keep working -->
   {#if modal}
@@ -646,6 +653,18 @@
   }
   /* recede with the grid while a song plays — focus stays on the one playing card */
   .hmbm.hushed {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* the guestbook row — end of the page, clear of the fixed player bar */
+  .quiet {
+    max-width: 40rem;
+    margin: 0 auto;
+    padding: 3rem 1.2rem calc(var(--player-h) + 4rem);
+    transition: opacity 0.45s ease;
+  }
+  .quiet.hushed {
     opacity: 0;
     pointer-events: none;
   }

--- a/src/routes/thoughts/the-peach/+page.svelte
+++ b/src/routes/thoughts/the-peach/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import QuietList from "$lib/components/QuietList.svelte";
   import SeoHead from "$lib/components/SeoHead.svelte";
   import { articleNode } from "$lib/seo";
   import type { PageData } from "./$types";
@@ -61,9 +62,15 @@
     {@html html}
 
     <footer class="mt-18 border-t border-zinc-800 pt-9 md:mt-24">
+      <!-- The guestbook: only ever after the content, for the diggers who
+           finished it. See QuietList for the doctrine. -->
+      <QuietList
+        line="these land rarely. if you want them when they do — leave an address."
+        placement="thoughts:the-peach"
+      />
       <a
         href="/thoughts"
-        class="font-mono text-xs uppercase tracking-section text-zinc-500 transition-colors hover:text-coin md:text-sm"
+        class="mt-12 inline-block font-mono text-xs uppercase tracking-section text-zinc-500 transition-colors hover:text-coin md:text-sm"
       >
         ← all thoughts
       </a>


### PR DESCRIPTION
**⏸ HOLD — one external dependency:** the garden list is double opt-in and listmonk's SMTP is still the factory placeholder (`dial tcp :25 i/o timeout`, verified in logs). Until the Resend key lands (Sam: resend.com → API Keys → create `listmonk` → paste in chat), a real subscriber sees "didn't take" while half-subscribed. The moment the key is configured this path goes green end-to-end — then merge.

## what this is

The **guestbook, not billboard** — the one sanctioned exception to threesam.com's dead-end doctrine. One line + one field at the very end of finished content:

- `/thoughts/the-peach` footer: *"these land rarely. if you want them when they do — leave an address."*
- `/sounds` (after the score section, hushes while a track plays): *"new sounds, rarely. first listens go here."*

▸ both lines are sketches in your voice — rewrite at will.

## rules enforced in code + comments

never above content · no benefit copy/counts · not on `/`, `/self`, `/benny`, `/dad` · double opt-in (the confirmation click is a digger filter) · `garden` list only, never cross-mailed with sixtom's.

## plumbing

`/api/subscribe` proxies to listmonk's public endpoint so the page never names the host; mirrors `/api/message` exactly (ttl-cache rate limit, honeypot silent-200, structured PII-light logs, shared `message-schema` limits). robots.txt already disallows `/api/`.

## verification

svelte-check: no new errors/warnings (the 1 error + 7 warnings are pre-existing) · svelte-autofixer clean on QuietList · live smoke: honeypot→200-silent, invalid→400, real→row in garden list (502 surfaced as designed while SMTP is dead) · umami event `quiet-list` wired.

## also in this PR

`.gitignore` now covers the Next-era leftovers (`.next/`, `next-env.d.ts`) and agent-session artifacts (`.claude/`, `.playwright-mcp/`, `.superset/`, `test-results/`) — a stray `git add -A` swept 6,475 of those files into the first version of this commit (caught pre-push, commit rebuilt with exactly the 4 intended files).

**At merge time:** visual baselines for the two pages will need a refresh — intentional addition, flagged here rather than silently updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)