### PR TITLE
feat: umami tracking robustness

### DIFF
--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -103,12 +103,20 @@ class MessageMode {
 				// SvelteKit's error() returns { message }, not { error }.
 				const data = (await res.json().catch(() => null)) as { message?: string } | null;
 				this.error = data?.message || 'failed to send';
+				window.umami?.track('message-error');
 				return;
 			}
 			this.sent = true;
+			// ponytail: the server 200s silently on its honeypot path too (so a
+			// caught bot can't tell), which means this can't distinguish a real
+			// send from a bot trip — same accepted ceiling as this repo's own
+			// quiet-list signup event. Server-side emission would fix it; not
+			// worth it for one low-volume contact form.
+			window.umami?.track('message-sent');
 			this.sched(SENT_HOLD_MS, () => this.stop());
 		} catch {
 			this.error = 'failed to send';
+			window.umami?.track('message-error');
 		} finally {
 			this.sending = false;
 		}

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -18,6 +18,17 @@ import { EMAIL_RX, MAX_EMAIL_LEN, MAX_NAME_LEN, MAX_BODY_LEN } from '$lib/messag
 const CLOSE_DELAY_MS = 500;
 const SENT_HOLD_MS = 1500;
 
+// A thrown umami.track() must never reach send()'s own try/catch — that
+// would flip an already-successful send to "failed to send" and skip the
+// auto-close timer. Analytics failures are never this form's problem.
+function safeTrack(name: string) {
+	try {
+		window.umami?.track(name);
+	} catch {
+		/* ignored */
+	}
+}
+
 class MessageMode {
 	active = $state(false);
 	// "message me?" revealed in the wordmark (the "m" was clicked) but the
@@ -103,18 +114,18 @@ class MessageMode {
 				// SvelteKit's error() returns { message }, not { error }.
 				const data = (await res.json().catch(() => null)) as { message?: string } | null;
 				this.error = data?.message || 'failed to send';
-				window.umami?.track('message-error');
+				safeTrack('message-error');
 				return;
 			}
 			this.sent = true;
 			// Honeypot responses are also silent 200s, so this counts accepted
 			// submissions, not guaranteed sends — same ceiling as the repo's own
 			// quiet-list event. Not worth server-side emission for one form.
-			window.umami?.track('message-sent');
+			safeTrack('message-sent');
 			this.sched(SENT_HOLD_MS, () => this.stop());
 		} catch {
 			this.error = 'failed to send';
-			window.umami?.track('message-error');
+			safeTrack('message-error');
 		} finally {
 			this.sending = false;
 		}

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -107,11 +107,9 @@ class MessageMode {
 				return;
 			}
 			this.sent = true;
-			// ponytail: the server 200s silently on its honeypot path too (so a
-			// caught bot can't tell), which means this can't distinguish a real
-			// send from a bot trip — same accepted ceiling as this repo's own
-			// quiet-list signup event. Server-side emission would fix it; not
-			// worth it for one low-volume contact form.
+			// Honeypot responses are also silent 200s, so this counts accepted
+			// submissions, not guaranteed sends — same ceiling as the repo's own
+			// quiet-list event. Not worth server-side emission for one form.
 			window.umami?.track('message-sent');
 			this.sched(SENT_HOLD_MS, () => this.stop());
 		} catch {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -16,12 +16,14 @@
 
   let { children }: { children: import('svelte').Snippet } = $props();
 
-  // Analytics only fire on the canonical prod host. Vercel preview URLs
+  // Analytics only fire on the canonical prod host(s). Vercel preview URLs
   // and local dev see no tracker — so feature work, link checks, and
   // automated runs don't pollute the dashboard. Hostname check happens
   // post-hydration (prerendered HTML is identical across hosts).
+  // Both apex and www serve live 200s (no redirect between them — verified
+  // via curl), so both must be allowlisted or www visitors go untracked.
   onMount(() => {
-    if (location.hostname !== 'threesam.com') return;
+    if (!['threesam.com', 'www.threesam.com'].includes(location.hostname)) return;
     const preconnect = Object.assign(document.createElement('link'), {
       rel: 'preconnect',
       href: 'https://analytics.sixtom.com',


### PR DESCRIPTION
## Summary

Audit-only pass — this site is the healthiest-instrumented in the fleet already (`OutboundTracker.svelte` covers every outbound anchor click sitewide, `gallery-card-click` and the `sounds` page's own `trackEvent` helper cover the two real content interactions). Two real gaps found and closed:

1. **Prod-host analytics gate was apex-only.** `src/routes/+layout.svelte`'s `onMount` guard (`location.hostname !== 'threesam.com'`) is what keeps Vercel previews and local dev from polluting the dashboard — same role a `data-domains` attribute plays elsewhere, just implemented as a pre-injection hostname check instead (arguably stronger: the script never even loads on non-prod). Live-verified via `curl -I` + `dig` that `www.threesam.com` serves its own 200 with the same content-length and no redirect to apex — so any visitor landing on `www` got **zero** tracking. Widened the allowlist to both hosts.
2. **The "message me?" contact form had no tracking at all.** `src/lib/message-mode.svelte.ts`'s `send()` is a real, live way to reach Sam directly, and both the success and failure paths were silent. Added `message-sent` / `message-error`, matching the repo's existing kebab-case event naming (`outbound-click`, `gallery-card-click`).

## Not done here (see the CRO issue)

- `brief.py` in the infra repo already reads `three_ev.get('quiet-list', 0)` for the Monday brief — but no `quiet-list` event exists on `main`. It's fully built (form + `/api/subscribe` proxy to listmonk) on **open PR #253**, titled "HOLD until listmonk SMTP key" — a deliberate hold, not a bug. Nothing to fix in this PR; flagged so it isn't mistaken for a tracking gap.
- `Nav.svelte` — the only component anywhere in the repo with a live-page link to `sixtom.com` (the "studio ↗" pill) — is never imported by any route. Confirmed via `git grep` across the whole tree. This is a product/design call (whether and where to surface the bridge), not a tracking fix, so left alone here.

## Test plan

- [x] `pnpm check` — 0 errors, 0 warnings
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 30/30 passed
- [x] `pnpm build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)