### PR TITLE
feat: umami click events for untracked engagement targets

### DIFF
--- a/src/lib/components/Nav.svelte
+++ b/src/lib/components/Nav.svelte
@@ -13,6 +13,7 @@
     href="https://sixtom.com"
     target="_blank"
     rel="noopener noreferrer"
+    data-umami-event="sixtom-click"
     class="rounded-full px-3 py-1.5 font-mono text-[10px] tracking-label text-zinc-400 transition-transform duration-300 hover:scale-110 hover:duration-[4000ms] hover:ease-out md:text-xs"
   >
     studio ↗

--- a/src/lib/components/banners/AnythingButAnalogBanner.svelte
+++ b/src/lib/components/banners/AnythingButAnalogBanner.svelte
@@ -37,7 +37,11 @@
 {/snippet}
 
 {#if href}
-	<a href={href} class="block">
+	<a
+		href={href}
+		class="block"
+		onclick={() => window.umami?.track('aba-banner-click')}
+	>
 		{@render body()}
 	</a>
 {:else}

--- a/src/lib/message-mode.svelte.ts
+++ b/src/lib/message-mode.svelte.ts
@@ -71,6 +71,9 @@ class MessageMode {
 	}
 
 	start() {
+		// Funnel entry for the message form — pairs with message-sent /
+		// message-error so open → sent conversion is measurable.
+		safeTrack('message-open');
 		this.clearTimers();
 		this.active = true;
 		this.sending = false;

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -127,6 +127,7 @@
         href={card.href}
         onmouseenter={enterCard}
         onmouseleave={leaveCard}
+        onclick={() => window.umami?.track("thoughts-card-click", { href: card.href })}
         class="group relative block transition-transform duration-700 hover:[transform:rotate(-1.3deg)]"
       >
         <!-- mobile: image-fills card, bottom-left white title + description over a dark→transparent fade -->


### PR DESCRIPTION
Instruments the untracked meaningful click targets with umami events so engagement becomes measurable. Part of the fleet CTA-tracking sweep.

| event | element | location |
|---|---|---|
| `thoughts-card-click` (+`href` data) | essay/page cards (5) | `src/routes/thoughts/+page.svelte` |
| `aba-banner-click` | anything-but-analog full-bleed banner anchor | `src/lib/components/banners/AnythingButAnalogBanner.svelte` (rendered on /self) |
| `message-open` | "message me?" wordmark tail → `messageMode.start()` | `src/lib/message-mode.svelte.ts` |
| `sixtom-click` | "studio ↗" → sixtom.com anchor | `src/lib/components/Nav.svelte` |

Additive only — existing event names untouched.

Notes:

- **Internal SvelteKit-routed anchors use `onclick` `track()` calls, not `data-umami-event`** — umami's delegated click handler `preventDefault()`s same-tab anchors carrying the attribute and re-navigates via `location.href`, which would silently swap client-side routing for full page loads. The data attribute is only used on the `target="_blank"` sixtom anchor, where umami doesn't intercept.
- **Finding: `Nav.svelte` is currently unmounted** (nothing imports it), so `sixtom-click` cannot fire today — the only sixtom.com anchor on the site is in that dead component. The garden→sixtom bridge has no live UI element; until one exists, outbound sixtom clicks from prose links are still visible via the existing `outbound-click` (host=sixtom.com). Instrumented anyway so the bridge is measured the moment Nav returns.
- `message-open` pairs with the frozen `message-sent` / `message-error` so quiet-list funnel conversion (open → sent) is readable.
- Deliberate skips: goodreads shelf links + benny facebook/instagram (already measured by the delegated `outbound-click` with host/path/from — named duplicates would double-count), sounds page (fully instrumented: `sounds-play/pause/resume/complete`), RSS (no feed or RSS link exists on the site), back-to-/thoughts + "go home" nav links (pageview + referrer already cover), snake/invaders easter-egg entries (not CTA/link surface; new permanent names out of sweep scope).

Gates: `pnpm lint` ✓ · `pnpm check` ✓ (676 files, 0 errors 0 warnings) · `pnpm test` ✓ (30/30) · `pnpm build` ✓ (no `format:check` script or prettier config exists in this repo). Codex adversarial pass over the diff: NO FINDINGS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3Qq6dLuU7UZtoGgorrMrT