### PR TITLE
feat(home): diver easter egg — the door to pyredivers.com

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -34,13 +34,19 @@
   // Hover/click on the "m" runs the same trick with the message tail.
   const PRE_LETTERS = ['t', 'h', 'r', 'e', 'e'];
   // the "a" between s and m is its own span: hovering it morphs the glyph
-  // into the alien, and a click starts space invaders (homepage only)
+  // into the alien, and a click starts space invaders (homepage only).
+  // Ready only while the letter is actually visible — during game/message
+  // modes it collapses, and a collapsed control must be neither tabbable
+  // nor able to start invaders over the active state.
   const SNAKE_TAIL = ['n', 'a', 'k', 'e'];
   const MESSAGE_TAIL = ['e', 's', 's', 'a', 'g', 'e', ' ', 'm', 'e', '?'];
   const active = $derived(gameMode.active);
   // The "threesam → snake" wordmark animation is snake-only; the alien's
   // invaders game has no title sequence.
   const isSnake = $derived(gameMode.active && gameMode.game === 'snake');
+  const aAlienReady = $derived(
+    gameClickable && !gameMode.active && !messageMode.active && !messageMode.revealing,
+  );
 
   // Click-toggled reveal of the message tail (click only — a hover preview
   // would slide the "m" out from under the cursor and flicker). State lives on
@@ -85,18 +91,18 @@
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <span
     class="letter a-letter"
-    class:clickable={gameClickable && !active}
+    class:clickable={aAlienReady}
     role={gameClickable ? 'button' : undefined}
-    tabindex={gameClickable ? 0 : undefined}
+    tabindex={aAlienReady ? 0 : undefined}
     aria-label={gameClickable ? 'play space invaders' : undefined}
     onclick={gameClickable
       ? () => {
-          if (!gameMode.active) gameMode.start('invaders');
+          if (aAlienReady) gameMode.start('invaders');
         }
       : undefined}
     onkeydown={gameClickable
       ? (e: KeyboardEvent) => {
-          if ((e.key === 'Enter' || e.key === ' ') && !gameMode.active) {
+          if ((e.key === 'Enter' || e.key === ' ') && aAlienReady) {
             e.preventDefault();
             gameMode.start('invaders');
           }

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -92,9 +92,9 @@
   <span
     class="letter a-letter"
     class:clickable={aAlienReady}
-    role={gameClickable ? 'button' : undefined}
+    role={aAlienReady ? 'button' : undefined}
     tabindex={aAlienReady ? 0 : undefined}
-    aria-label={gameClickable ? 'play space invaders' : undefined}
+    aria-label={aAlienReady ? 'play space invaders' : undefined}
     onclick={gameClickable
       ? () => {
           if (aAlienReady) gameMode.start('invaders');

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -33,7 +33,8 @@
   // so the "s" slides to the start, then the n/a/k/e tail expands.
   // Hover/click on the "m" runs the same trick with the message tail.
   const PRE_LETTERS = ['t', 'h', 'r', 'e', 'e'];
-  const MID_LETTERS = ['a']; // sits between s and m
+  // the "a" between s and m is its own span: hovering it morphs the glyph
+  // into the alien, and a click starts space invaders (homepage only)
   const SNAKE_TAIL = ['n', 'a', 'k', 'e'];
   const MESSAGE_TAIL = ['e', 's', 's', 'a', 'g', 'e', ' ', 'm', 'e', '?'];
   const active = $derived(gameMode.active);
@@ -81,9 +82,37 @@
         }
       : undefined}
   >s</span>
-  {#each MID_LETTERS as l, i (`mid-${i}`)}
-    <span class="letter">{l}</span>
-  {/each}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <span
+    class="letter a-letter"
+    class:clickable={gameClickable && !active}
+    role={gameClickable ? 'button' : undefined}
+    tabindex={gameClickable ? 0 : undefined}
+    aria-label={gameClickable ? 'play space invaders' : undefined}
+    onclick={gameClickable
+      ? () => {
+          if (!gameMode.active) gameMode.start('invaders');
+        }
+      : undefined}
+    onkeydown={gameClickable
+      ? (e: KeyboardEvent) => {
+          if ((e.key === 'Enter' || e.key === ' ') && !gameMode.active) {
+            e.preventDefault();
+            gameMode.start('invaders');
+          }
+        }
+      : undefined}
+  ><span class="a-glyph">a</span><span class="a-alien" aria-hidden="true"
+      ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+        <path
+          fill="currentColor"
+          d="M16 3c5.7 0 9.5 3.6 9.5 9 0 5.6-4 16-9.5 16S6.5 17.6 6.5 12c0-5.4 3.8-9 9.5-9z"
+        />
+        <ellipse cx="12" cy="15" rx="2.4" ry="4.2" transform="rotate(-18 12 15)" fill="#e8a317" />
+        <ellipse cx="20" cy="15" rx="2.4" ry="4.2" transform="rotate(18 20 15)" fill="#e8a317" />
+      </svg></span
+    ></span
+  >
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <span
     class="letter m-letter"
@@ -127,28 +156,7 @@
 <p
   class="tagline absolute right-6 bottom-6 z-10 text-right font-mono text-sm leading-tight tracking-hero {color} md:right-8 md:bottom-8 md:text-base"
   class:tagline-hidden={active || messageMode.active || (messageClickable && messageMode.revealing)}
-><span class="block md:inline">certainly</span><span
-      class="alien"
-      role="button"
-      tabindex="0"
-      aria-label="play space invaders"
-      onclick={() => {
-        if (!gameMode.active) gameMode.start('invaders');
-      }}
-      onkeydown={(e: KeyboardEvent) => {
-        if ((e.key === 'Enter' || e.key === ' ') && !gameMode.active) {
-          e.preventDefault();
-          gameMode.start('invaders');
-        }
-      }}
-    ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
-      <path
-        fill="currentColor"
-        d="M16 3c5.7 0 9.5 3.6 9.5 9 0 5.6-4 16-9.5 16S6.5 17.6 6.5 12c0-5.4 3.8-9 9.5-9z"
-      />
-      <ellipse cx="12" cy="15" rx="2.4" ry="4.2" transform="rotate(-18 12 15)" fill="#e8a317" />
-      <ellipse cx="20" cy="15" rx="2.4" ry="4.2" transform="rotate(18 20 15)" fill="#e8a317" />
-    </svg></span><a
+><span class="block md:inline">certainly</span><a
       class="diver"
       href="https://pyredivers.com/?dive"
       aria-label="dive into pyre divers"
@@ -247,10 +255,10 @@
     opacity: 1;
     transition-delay: var(--msg-delay, 0ms);
   }
-  /* Alien hover gag preserved from #215; the diver beside it is the door
-     to pyredivers.com — ?dive tells the far side to open on our marigold
-     and run the arrival sequence, so the hop reads as one scene. */
-  .alien,
+  /* The diver in the tagline is the door to pyredivers.com — ?dive tells
+     the far side to open on our marigold and run the arrival sequence, so
+     the hop reads as one scene. Reveal mechanics inherited from the old
+     alien gag (#215); the alien itself now lives in the wordmark's "a". */
   .diver {
     display: none;
     vertical-align: middle;
@@ -258,29 +266,62 @@
     opacity: 0;
     overflow: hidden;
     cursor: pointer;
+    color: inherit;
     transition:
       width 450ms cubic-bezier(0.4, 0, 0.2, 1),
       opacity 450ms ease-out;
   }
-  .diver {
-    color: inherit;
-  }
-  .alien :global(svg),
   .diver :global(svg) {
     width: 1.4em;
     height: 1.4em;
     display: block;
   }
   @media (min-width: 768px) {
-    .alien,
     .diver {
       display: inline-block;
     }
-    .tagline:hover .alien,
-    .tagline:focus-within .alien,
     .tagline:hover .diver,
     .tagline:focus-within .diver {
       width: 1.6em;
+      opacity: 1;
+    }
+  }
+  /* The "a" that is sometimes an alien: hover/focus crossfades the glyph
+     to the invader (homepage only — gameClickable gates the handlers). */
+  .a-letter {
+    position: relative;
+  }
+  .a-letter.clickable {
+    cursor: pointer;
+  }
+  .a-glyph {
+    transition: opacity 200ms ease-out;
+  }
+  .a-alien {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    opacity: 0;
+    transition: opacity 200ms ease-out;
+  }
+  .a-alien :global(svg) {
+    width: 0.85em;
+    height: 0.85em;
+    display: block;
+  }
+  .a-letter.clickable:focus-visible .a-glyph {
+    opacity: 0;
+  }
+  .a-letter.clickable:focus-visible .a-alien {
+    opacity: 1;
+  }
+  @media (hover: hover) {
+    .a-letter.clickable:hover .a-glyph {
+      opacity: 0;
+    }
+    .a-letter.clickable:hover .a-alien {
       opacity: 1;
     }
   }
@@ -288,8 +329,9 @@
     .letter,
     .tail,
     .msg-tail,
-    .alien,
-    .diver {
+    .diver,
+    .a-glyph,
+    .a-alien {
       transition: none;
     }
   }

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -148,7 +148,16 @@
       />
       <ellipse cx="12" cy="15" rx="2.4" ry="4.2" transform="rotate(-18 12 15)" fill="#e8a317" />
       <ellipse cx="20" cy="15" rx="2.4" ry="4.2" transform="rotate(18 20 15)" fill="#e8a317" />
-    </svg></span><span class="block md:ml-[0.4em] md:inline">uncertain</span>
+    </svg></span><a
+      class="diver"
+      href="https://pyredivers.com/?dive"
+      aria-label="dive into pyre divers"
+    ><svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+      <g stroke="currentColor" stroke-width="2.6" stroke-linecap="round" fill="none">
+        <circle cx="16" cy="7" r="3.4" />
+        <path d="M16 10.5 L16 20 M16 13 L9 17 M16 13 L23 17 M16 20 L11 27 M16 20 L21 27" />
+      </g>
+    </svg></a><span class="block md:ml-[0.4em] md:inline">uncertain</span>
 </p>
 
 <style>
@@ -238,8 +247,11 @@
     opacity: 1;
     transition-delay: var(--msg-delay, 0ms);
   }
-  /* Alien hover gag preserved from #215 */
-  .alien {
+  /* Alien hover gag preserved from #215; the diver beside it is the door
+     to pyredivers.com — ?dive tells the far side to open on our marigold
+     and run the arrival sequence, so the hop reads as one scene. */
+  .alien,
+  .diver {
     display: none;
     vertical-align: middle;
     width: 0;
@@ -250,17 +262,24 @@
       width 450ms cubic-bezier(0.4, 0, 0.2, 1),
       opacity 450ms ease-out;
   }
-  .alien :global(svg) {
+  .diver {
+    color: inherit;
+  }
+  .alien :global(svg),
+  .diver :global(svg) {
     width: 1.4em;
     height: 1.4em;
     display: block;
   }
   @media (min-width: 768px) {
-    .alien {
+    .alien,
+    .diver {
       display: inline-block;
     }
     .tagline:hover .alien,
-    .tagline:focus-within .alien {
+    .tagline:focus-within .alien,
+    .tagline:hover .diver,
+    .tagline:focus-within .diver {
       width: 1.6em;
       opacity: 1;
     }
@@ -269,7 +288,8 @@
     .letter,
     .tail,
     .msg-tail,
-    .alien {
+    .alien,
+    .diver {
       transition: none;
     }
   }


### PR DESCRIPTION
Two easter eggs, two doors:

- **Tagline** (`certainly ◦ uncertain`): hovering pops open a single **stick-figure diver** — a real keyboard-focusable `<a>` to `pyredivers.com/?dive`. The `?dive` param is the handshake: the pyre side opens pre-paint on this site's marigold `#e8a317` with the tagline reproduced, fades the words, the figure jumps into the vortex, and the whole crowd pours in from the edges behind it — one continuous scene across the origin hop. Companion: threesam/pyre-divers#35 (**must merge for the arrival to run** — until then `?dive` is inert on prod).
- **Wordmark**: hovering the **'a' in threesam** crossfades the glyph into the alien; clicking starts space invaders. Homepage only (`gameClickable`), keyboard accessible, still collapses correctly during snake/message letter modes.

`svelte-check` 0/0, eslint clean, live dev drive verified both reveals (`threes👽m` on a-hover; diver-only tagline; href resolves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WgxTZ9dqNKMEwCJRVEPXTQ