### PR TITLE
fix(home): even ink gaps around the tagline diver

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -281,6 +281,10 @@
     width: 1.4em;
     height: 1.4em;
     display: block;
+    /* even breathing room: "certainly" contributes 0.2em trailing
+       letter-space on the left, "uncertain" a 0.4em margin on the right —
+       shifting the figure 0.2em right makes both visual gaps 0.4em */
+    margin-left: 0.2em;
   }
   @media (min-width: 768px) {
     .diver {


### PR DESCRIPTION
'certainly' carries 0.2em trailing letter-space, 'uncertain' a 0.4em
margin — shifting the figure 0.2em right inside its slot makes both
visual gaps 0.4em. Measured post-fix at 1440x900: 6.3px / 6.4px.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WgxTZ9dqNKMEwCJRVEPXTQ
