### PR TITLE
feat: ?test ejects this browser from analytics

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,6 +9,19 @@
     <link rel="icon" type="image/x-icon" href="%sveltekit.assets%/favicon.ico?v=7" />
     <link rel="apple-touch-icon" href="%sveltekit.assets%/apple-touch-icon.png?v=7" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      // testing eject: ?test flips umami's native kill switch for this
+      // browser (persistent); ?test=0 rejoins. The tracker (injected in
+      // +layout) checks localStorage before every send.
+      try {
+        var q = new URLSearchParams(location.search);
+        if (q.has('test')) {
+          q.get('test') === '0'
+            ? localStorage.removeItem('umami.disabled')
+            : localStorage.setItem('umami.disabled', '1');
+        }
+      } catch (e) {}
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">


### PR DESCRIPTION
?test flips umami's native localStorage kill switch (`umami.disabled`) in an inline head script — runs before the +layout tracker injection; persistent per browser, `?test=0` rejoins. Part of the all-properties testing-eject sweep (pyre-divers#47 is the sibling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZAb3Vq5TYyhXRxZbKyeX