### PR TITLE
feat: dive send-off fades the whole homepage, not just the words

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -12,6 +12,7 @@
   // toggles gameMode and triggers the letter-collapse → "snake" sequence.
   import { gameMode } from '$lib/game-mode.svelte';
   import { messageMode } from '$lib/message-mode.svelte';
+  import { diveMode } from '$lib/dive-mode.svelte';
 
   let {
     heading = false,
@@ -60,21 +61,19 @@
   };
   const mLabel = $derived(messageMode.revealing ? 'hide message me?' : 'show message me?');
 
-  // Clicking the tagline runs the send-off: the words fade for 1s while the
-  // diver holds his spot, THEN we navigate — pyredivers.com opens on
-  // marigold with only the stick figure, standing exactly where this one
-  // stands. Modified clicks (new tab, etc.) and reduced-motion users get
-  // the plain navigation.
-  let divingOut = $state(false);
+  // Clicking the tagline runs the send-off: EVERYTHING fades for 1s —
+  // words here, plus the gallery, wordmark, and guide coin via diveMode
+  // (game-screen style) — while the diver holds his spot on the bare
+  // coin field, THEN we navigate — pyredivers.com opens on marigold with
+  // only the stick figure, standing exactly where this one stands.
+  // Modified clicks (new tab, etc.) and reduced-motion users get the
+  // plain navigation.
+  const divingOut = $derived(diveMode.leaving);
   const diveOut = (e: MouseEvent) => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
     if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     e.preventDefault();
-    if (divingOut) return;
-    divingOut = true;
-    setTimeout(() => {
-      location.href = 'https://pyredivers.com/?dive';
-    }, 1000);
+    diveMode.start();
   };
 </script>
 
@@ -84,6 +83,7 @@
   class:is-game={isSnake}
   class:show-message={messageClickable && messageMode.revealing && !active}
   class:wordmark-hidden={gameMode.wordmarkSlotOccupied || messageMode.active}
+  class:diving-away={divingOut}
 >
   {#each PRE_LETTERS as l, i (`pre-${i}`)}
     <span class="letter">{l}</span>
@@ -295,7 +295,14 @@
     cursor: pointer;
   }
   /* the send-off: words fade for 1s before navigation; the diver holds
-     open (even if the cursor drifts) so the hand-off is stick-to-stick */
+     open (even if the cursor drifts) so the hand-off is stick-to-stick.
+     The wordmark leaves on the same clock (gallery + guide fade via
+     diveMode in the page/layout) — everything but him and the coin. */
+  .wordmark.diving-away {
+    opacity: 0;
+    transition: opacity 1s ease;
+    pointer-events: none;
+  }
   .tagline-link > span:not(.diver) {
     transition: opacity 1s ease;
   }

--- a/src/lib/dive-mode.svelte.ts
+++ b/src/lib/dive-mode.svelte.ts
@@ -1,0 +1,23 @@
+// Send-off state for the pyredivers hand-off (the diver in the tagline).
+// Promoted out of BrandSignoff so the WHOLE homepage can fade with the
+// words — gallery, wordmark, guide coin — game-screen style, leaving only
+// the diver standing on the bare coin field before navigation.
+//
+// LEAVE_MS matches the 1s word-fade already shipped in #263.
+
+const DIVE_URL = 'https://pyredivers.com/?dive';
+const LEAVE_MS = 1000;
+
+class DiveMode {
+	leaving = $state(false);
+
+	start() {
+		if (this.leaving) return;
+		this.leaving = true;
+		window.setTimeout(() => {
+			window.location.href = DIVE_URL;
+		}, LEAVE_MS);
+	}
+}
+
+export const diveMode = new DiveMode();

--- a/src/lib/dive-mode.svelte.ts
+++ b/src/lib/dive-mode.svelte.ts
@@ -3,13 +3,26 @@
 // words — gallery, wordmark, guide coin — game-screen style, leaving only
 // the diver standing on the bare coin field before navigation.
 //
-// LEAVE_MS matches the 1s word-fade already shipped in #263.
+// LEAVE_MS matches the 1s word-fade already shipped in #263. Same
+// class-singleton shape as gameMode / messageMode.
+import { browser } from '$app/environment';
 
 const DIVE_URL = 'https://pyredivers.com/?dive';
 const LEAVE_MS = 1000;
 
 class DiveMode {
 	leaving = $state(false);
+
+	constructor() {
+		// bfcache: hitting Back after the send-off restores THIS page from
+		// memory with `leaving` frozen true — which would leave the whole
+		// homepage faded out and pointer-disabled. Reset on restore.
+		if (browser) {
+			window.addEventListener('pageshow', (e) => {
+				if (e.persisted) this.leaving = false;
+			});
+		}
+	}
 
 	start() {
 		if (this.leaving) return;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -13,6 +13,7 @@
   import Guide from '$lib/components/frame/Guide.svelte';
   import OutboundTracker from '$lib/components/OutboundTracker.svelte';
   import Anchor from '$lib/components/frame/Anchor.svelte';
+  import { diveMode } from '$lib/dive-mode.svelte';
 
   let { children }: { children: import('svelte').Snippet } = $props();
 
@@ -39,8 +40,20 @@
 </script>
 
 <OutboundTracker />
-<Guide />
+<!-- the guide coin leaves with everything else during the dive send-off;
+     wrapper (not Guide itself) so the fade composes with its own state -->
+<div class="guide-slot" class:diving-away={diveMode.leaving}>
+  <Guide />
+</div>
 <div class="bg-white">
   {@render children()}
 </div>
 <Anchor />
+
+<style>
+  .guide-slot.diving-away {
+    opacity: 0;
+    transition: opacity 1s ease;
+    pointer-events: none;
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
   import { messageMode } from '$lib/message-mode.svelte';
+  import { diveMode } from '$lib/dive-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
 
   // Structured site index for search + answer engines. Mirrors the
@@ -44,8 +45,12 @@
   <div class="h-[25dvh] w-full"></div>
   <div
     class="relative h-[50dvh] w-full transition-opacity duration-500 ease-out"
-    class:opacity-0={gameMode.active || messageMode.active || messageMode.revealing}
-    class:pointer-events-none={gameMode.active || messageMode.active || messageMode.revealing}
+    class:duration-1000={diveMode.leaving}
+    class:opacity-0={gameMode.active || messageMode.active || messageMode.revealing || diveMode.leaving}
+    class:pointer-events-none={gameMode.active ||
+      messageMode.active ||
+      messageMode.revealing ||
+      diveMode.leaving}
   >
     <Gallery />
   </div>


### PR DESCRIPTION
## What
Clicking the little stick guy in the tagline now fades the ENTIRE homepage — gallery, threesam wordmark, and guide coin — over the same 1s as the tagline words, game-screen style, leaving only the diver on the bare coin field before the hand-off to pyredivers.com?dive. Previously only the two words faded.

## How
`divingOut` promoted from a local BrandSignoff `$state` to a shared `diveMode` module (same class-singleton shape as `gameMode`/`messageMode`). The homepage gallery, wordmark, and a guide-slot wrapper each key their fade off `diveMode.leaving`. Reduced-motion and modified-clicks keep the plain-navigation path.

## /rev + /drive
- **Round 0** security: clean. **Round 1** codex: 1 correctness (bfcache Back could strand the page faded-out + pointer-disabled → `pageshow.persisted` reset) fixed; 1 elegance dismissed (class shape deliberately matches existing modes). **Round 2**: clean both lenses.
- **/drive** (hand-driven, local): click the diver → wordmark 1→0, guide 1→0, gallery 1→0, **diver holds at opacity 1**; screenshot confirms only-the-diver-on-coin. ✅
- **a11y**: machine-detectable A/AA clean (aria-label preserved, reduced-motion bypass, no new controls); judgment subset remains a human call.
- **build**: passes (pnpm), svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZAb3Vq5TYyhXRxZbKyeX