### PR TITLE
feat: ?test on the homepage auto-dives to pyre (analytics-clean)

### DIFF
--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -66,12 +66,11 @@
   // (game-screen style) — while the diver holds his spot on the bare
   // coin field, THEN we navigate — pyredivers.com opens on marigold with
   // only the stick figure, standing exactly where this one stands.
-  // Modified clicks (new tab, etc.) and reduced-motion users get the
-  // plain navigation.
+  // Modified clicks (new tab, etc.) keep the plain anchor navigation;
+  // reduced motion is handled inside diveMode.start (immediate hand-off).
   const divingOut = $derived(diveMode.leaving);
   const diveOut = (e: MouseEvent) => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
-    if (matchMedia('(prefers-reduced-motion: reduce)').matches) return;
     e.preventDefault();
     diveMode.start();
   };

--- a/src/lib/components/frame/BrandSignoff.svelte
+++ b/src/lib/components/frame/BrandSignoff.svelte
@@ -10,9 +10,10 @@
   // The parent must be positioned (relative) — the corners anchor to it.
   // `gameClickable` exposes the snake-game easter egg: clicking the "s"
   // toggles gameMode and triggers the letter-collapse → "snake" sequence.
+  import { page } from '$app/state';
   import { gameMode } from '$lib/game-mode.svelte';
   import { messageMode } from '$lib/message-mode.svelte';
-  import { diveMode } from '$lib/dive-mode.svelte';
+  import { diveMode, diveUrl } from '$lib/dive-mode.svelte';
 
   let {
     heading = false,
@@ -69,6 +70,9 @@
   // Modified clicks (new tab, etc.) keep the plain anchor navigation;
   // reduced motion is handled inside diveMode.start (immediate hand-off).
   const divingOut = $derived(diveMode.leaving);
+  // one href for every path — carries ?test so open-in-new-tab and the
+  // no-JS fallback reach pyre analytics-clean too, not just the JS dive
+  const diveHref = $derived(diveUrl(page.url.searchParams.get('test')));
   const diveOut = (e: MouseEvent) => {
     if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0) return;
     e.preventDefault();
@@ -182,7 +186,7 @@
 ><a
     class="tagline-link"
     class:diving-out={divingOut}
-    href="https://pyredivers.com/?dive"
+    href={diveHref}
     aria-label="certainly uncertain — dive into pyre divers"
     onclick={diveOut}
   ><span class="block md:inline">certainly</span><span class="diver"

--- a/src/lib/dive-mode.svelte.ts
+++ b/src/lib/dive-mode.svelte.ts
@@ -10,6 +10,14 @@ import { browser } from '$app/environment';
 const DIVE_URL = 'https://pyredivers.com/?dive';
 const LEAVE_MS = 1000;
 
+// The one hand-off URL, carrying ?test through to pyre so a test session
+// ejects analytics on both sides (pyre reads has('test') independent of
+// ?dive). Used by both start() and the tagline anchor's href, so every
+// path — auto, click, open-in-new-tab, no-JS — is consistent.
+export function diveUrl(test: string | null): string {
+	return test === null ? DIVE_URL : `${DIVE_URL}&test=${encodeURIComponent(test)}`;
+}
+
 class DiveMode {
 	leaving = $state(false);
 
@@ -27,13 +35,9 @@ class DiveMode {
 	start() {
 		if (this.leaving) return;
 		this.leaving = true;
-		// carry ?test through so the pyre side ejects analytics too — a
-		// test session dives clean end to end (pyre reads has('test')
-		// independent of ?dive). DIVE_URL already ends in `?dive`.
 		const test = browser ? new URLSearchParams(location.search).get('test') : null;
-		const url = test === null ? DIVE_URL : `${DIVE_URL}&test=${encodeURIComponent(test)}`;
 		const go = () => {
-			window.location.href = url;
+			window.location.href = diveUrl(test);
 		};
 		// reduced motion: skip the fade, hand off immediately. Single home
 		// for this decision so the click and auto-test paths both honor it.

--- a/src/lib/dive-mode.svelte.ts
+++ b/src/lib/dive-mode.svelte.ts
@@ -27,9 +27,21 @@ class DiveMode {
 	start() {
 		if (this.leaving) return;
 		this.leaving = true;
-		window.setTimeout(() => {
-			window.location.href = DIVE_URL;
-		}, LEAVE_MS);
+		// carry ?test through so the pyre side ejects analytics too — a
+		// test session dives clean end to end (pyre reads has('test')
+		// independent of ?dive). DIVE_URL already ends in `?dive`.
+		const test = browser ? new URLSearchParams(location.search).get('test') : null;
+		const url = test === null ? DIVE_URL : `${DIVE_URL}&test=${encodeURIComponent(test)}`;
+		const go = () => {
+			window.location.href = url;
+		};
+		// reduced motion: skip the fade, hand off immediately. Single home
+		// for this decision so the click and auto-test paths both honor it.
+		if (browser && matchMedia('(prefers-reduced-motion: reduce)').matches) {
+			go();
+			return;
+		}
+		window.setTimeout(go, LEAVE_MS);
 	}
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,11 +6,22 @@
   import InvadersGame from '$lib/components/invaders/InvadersGame.svelte';
   import MessageLetter from '$lib/components/message/MessageLetter.svelte';
   import SendAction from '$lib/components/message/SendAction.svelte';
+  import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
   import { messageMode } from '$lib/message-mode.svelte';
   import { diveMode } from '$lib/dive-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
+
+  // Testing shortcut: land on the homepage with ?test and run the whole
+  // send-off straight through to pyre — no click needed — so the full
+  // cross-property hand-off can be exercised in one step. ?test also
+  // ejects analytics (app.html), and diveMode carries it to pyre, so the
+  // test dive is analytics-clean end to end. ?test=0 (rejoin) never dives.
+  onMount(() => {
+    const test = new URLSearchParams(location.search).get('test');
+    if (test !== null && test !== '0') diveMode.start();
+  });
 
   // Structured site index for search + answer engines. Mirrors the
   // natural-language /llms.txt and the sitemap so the same SITE_PAGES


### PR DESCRIPTION
## What
Landing on `threesam.com/?test` now runs the whole send-off straight through to `pyredivers.com?dive` — no click — so the full cross-property hand-off is one step to test. `?test=0` (rejoin) never dives.

## Analytics-clean end to end
`diveMode` carries `?test` to pyre, which reads `has('test')` independent of `?dive`. Verified live against production pyre: garden ejects pre-paint → auto-dives → pyre origin `localStorage['umami.disabled'] === '1'` + intro runs (`?dive` consumed & stripped, `test` survives).

## /rev + /drive
- **Round 1** codex: fixed — the anchor `href` hardcoded `?dive`, so open-in-new-tab / no-JS reached pyre without the eject; extracted a shared `diveUrl()` used by both `start()` and a `$derived` href off `page.url`, so all four paths carry `test`. Reduced-motion consolidated into `start()` (both entry points honor it). Dismissed: the `?test=0` gate mirrors `app.html`'s `get('test')` eject semantics on purpose. **Round 2**: clean.
- **/drive**: (A) `/?test` → ejects garden, auto-dives with no click, lands on real pyre with `test` carried + pyre ejected + intro run ✅; (B) plain click still fades gallery/wordmark/guide with the diver held ✅.
- **a11y** machine-detectable A/AA clean; **build** passes, svelte-check 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZAb3Vq5TYyhXRxZbKyeX