### PR TITLE
fix: ?test just turns analytics off — no auto-dive

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,22 +6,11 @@
   import InvadersGame from '$lib/components/invaders/InvadersGame.svelte';
   import MessageLetter from '$lib/components/message/MessageLetter.svelte';
   import SendAction from '$lib/components/message/SendAction.svelte';
-  import { onMount } from 'svelte';
   import { fade } from 'svelte/transition';
   import { gameMode } from '$lib/game-mode.svelte';
   import { messageMode } from '$lib/message-mode.svelte';
   import { diveMode } from '$lib/dive-mode.svelte';
   import { SITE_PAGES, SITE_URL, homePageNode, itemListNode } from '$lib/seo';
-
-  // Testing shortcut: land on the homepage with ?test and run the whole
-  // send-off straight through to pyre — no click needed — so the full
-  // cross-property hand-off can be exercised in one step. ?test also
-  // ejects analytics (app.html), and diveMode carries it to pyre, so the
-  // test dive is analytics-clean end to end. ?test=0 (rejoin) never dives.
-  onMount(() => {
-    const test = new URLSearchParams(location.search).get('test');
-    if (test !== null && test !== '0') diveMode.start();
-  });
 
   // Structured site index for search + answer engines. Mirrors the
   // natural-language /llms.txt and the sitemap so the same SITE_PAGES


### PR DESCRIPTION
## What
Reverts the #266 overreach. `?test` on the homepage no longer auto-runs the dive — it's purely the analytics-off switch. Kept the useful half: the diver link still carries `?test` to pyre (`?dive&test=…`), so clicking through the dive during a self-test ejects BOTH origins. That's the 'add the param in both places' Sam actually wanted.

## Change
Removed the `onMount` auto-dive block + its now-unused `onMount` import from `src/routes/+page.svelte`. Nothing else touched — `diveMode` still imported for the gallery fade, `diveUrl` carry + shared href intact.

## /rev + /drive
- svelte-check 0 errors, build passes (the dangling-ref check for a mechanical block removal). Codex adversarial pass skipped — timed out twice on infra (6–7 min); the removal is self-contained and typecheck-covered.
- **/drive**: `/?test` → 3s in, no auto-dive, wordmark + gallery fully visible, `umami.disabled='1'`, diver href still `?dive&test=1`. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPZAb3Vq5TYyhXRxZbKyeX